### PR TITLE
Improve article shortcodes

### DIFF
--- a/content/edu/courses-events.md
+++ b/content/edu/courses-events.md
@@ -10,11 +10,8 @@ keywords: Forthcoming courses events tutorial data teaching software past
 
 **2021**
 
-**Oct 14** [ML4Microbiome Symposium on Grand Challenges of Data-Intensive Science in microbiome & metagenome data analysis and training](https://www.ml4microbiome.eu/the-programme-of-the-goblet-embnet-agm-2021-including-ml4microbiome-events-is-ready-and-available-here/)
+**July 2021** Summer school on microbiome data science related to gut-brain axis.
 
-**Nov 2-4** [Workshop on modeling microbial community time series](http://msysbiology.com/microbialtimeseries/). Leuven, Belgium 
-
-**Aug 23-26** [Baltic Summer School on Digital Methods](https://t.co/MJANYOeYmJ?amp=1) in humanities and social sciences. 
 
 
 ### Topics for MSc/PhD theses
@@ -47,6 +44,12 @@ Application topics are available in e.g. statistical ecology and (eco)systems bi
 
 
 **Microbiome data science**
+
+- [Workshop on modeling microbial community time series](http://msysbiology.com/microbialtimeseries/). November 2021 (virtual) 
+
+-  [ML4Microbiome Symposium on Grand Challenges of Data-Intensive Science in microbiome & metagenome data analysis and training](https://www.ml4microbiome.eu/the-programme-of-the-goblet-embnet-agm-2021-including-ml4microbiome-events-is-ready-and-available-here/). October 2021 (virtual lecture)
+
+- [Baltic Summer School on Digital Methods](https://t.co/MJANYOeYmJ?amp=1) in humanities and social sciences, August 2021 (virtual)
 
 - [ML4Microbiome Training School](https://www.ml4microbiome.eu/uppsala-2021), September 2021 (virtual)
 

--- a/content/publication_resources/bibtex/lahti.bib
+++ b/content/publication_resources/bibtex/lahti.bib
@@ -8,7 +8,7 @@
   pages =	 {2021.11.10.21266163},
   month =	 {},
   url =		 {},
-  status = {preprint},
+  pubstate = {preprint},
   note =	 {},
   doi = {10.1101/2021.11.10.21266163 },
   annote =	 {}  
@@ -216,7 +216,7 @@
 	note         = {Report on the openness of major scientific publishers commissioned by Finnish Ministry of Education and Culture},
 	institution  = {unknown},
 	authorship   = {corresponding},
-	status       = {openscience},
+	pubstate     = {openscience},
 	keywords     = {openscience},
 	url          = {https://github.com/openresearchlabs/openresearchlabs.github.io/blob/master/content/publication_resources/papers/2018-Bjork-ATT.pdf}
 }
@@ -793,7 +793,7 @@
 	pages        = {87--116},
 	doi          = {10.18352/lq.10112},
 	issn         = {2213-056X},
-	status       = {dh},
+	pubstate     = {dh},
 	authorship   = {first},
 	url          = {https://github.com/openresearchlabs/openresearchlabs.github.io/blob/master/content/publication_resources/papers/2015-Lahti-LIBERQuarterly.pdf},
 	keywords     = {dh}
@@ -828,7 +828,7 @@
 	note         = {Review of the international conference, including electronic material (video interviews, lectures and podcasts.},
 	authorship   = {first, corresponding},
 	keywords     = {openscience},
-	status       = {openscience},
+	pubstate     = {openscience},
 	url          = {https://github.com/openresearchlabs/openresearchlabs.github.io/blob/master/content/publication_resources/papers/2017-Lahti-PHOS.pdf},
 	keywords     = {dh}
 }
@@ -1073,7 +1073,7 @@
 	pages        = {55--66},
 	url          = {http://ceur-ws.org/Vol-2365/07-TwinTalks-DHN2019_paper_7.pdf},
 	editor       = {Steven Krauwer and Darja Fišer},
-	status       = {dh},
+	pubstate     = {dh},
 	keywords     = {dh},
 	url          = {https://github.com/openresearchlabs/openresearchlabs.github.io/blob/master/content/publication_resources/papers/2019-Makela-DHN.pdf}
 }
@@ -1131,7 +1131,7 @@
 	url          = {https://ojs.ugent.be/jeps/article/view/10483},
 	note         = {Special issue: Digital Approaches Towards Serial Publications},
 	url          = {https://github.com/openresearchlabs/openresearchlabs.github.io/blob/master/content/publication_resources/papers/2019-Marjanen-JEPS.pdf},
-	status       = {dh},
+	pubstate     = {dh},
 	keywords     = {dh}
 }
 
@@ -1592,7 +1592,7 @@
 	address      = {Copenhagen},
 	editor       = {Costanza Navarretta and Manex Agirrezabal and Bente Maegaard},
 	url          = {https://github.com/openresearchlabs/openresearchlabs.github.io/blob/master/content/publication_resources/papers/2019-Tolonen-DHN.pdf},
-	status       = {dh},
+	pubstate     = {dh},
 	keywords     = {dh}
 }
 

--- a/content/publication_resources/bibtex/lahti.bib
+++ b/content/publication_resources/bibtex/lahti.bib
@@ -7,6 +7,7 @@
   year =	 2021,
   volume =	 10,
   number =	 748,
+  keywords =	 {datascience},
   note =	 {(slides); version 1; not peer reviewed},
   doi =		 {10.7490/f1000research.1118712.1}
 }

--- a/content/publication_resources/bibtex/lahti.bib
+++ b/content/publication_resources/bibtex/lahti.bib
@@ -1018,16 +1018,20 @@
   title =	 {Digitaaliset ihmistieteet ja historiantutkimus},
   publisher =	 {Gaudeamus},
   authorship =	 {second},
-  year =	 {2018},  
+  year =	 2018,
   language =	 {Finnish},
-  note =	 {(in Finnish). In: Hannikainen, MO and Danielsbacka, M and Tepora, T (eds.). Menneisyyden rakentajat. Gaudeamus, Helsinki, 2018.},
-  %editor =	 {Hannikainen, MO and Danielsbacka, M and Tepora, T},
-  %booktitle = {Menneisyyden rakentajat},
-  journaltitle =	 {Menneisyyden rakentajat},
+  note =	 {(in Finnish). In: Hannikainen, MO and Danielsbacka,
+                  M and Tepora, T (eds.). Menneisyyden
+                  rakentajat. Gaudeamus, Helsinki, 2018.},
+  journaltitle = {Menneisyyden rakentajat},
   status =	 {dh},
-  journal = {Menneisyyden rakentajat},
+  journal =	 {Menneisyyden rakentajat},
   url =		 {https://www.gaudeamus.fi/menneisyyden-rakentajat/},
-  annote = {This is a book chapter but classified as article as could not find a way to include this to CSL automatically generated bibliography yet.}
+  annote =	 {This is a book chapter but classified as article as
+                  could not find a way to include this to CSL
+                  automatically generated bibliography yet. booktitle
+                  : Menneisyyden rakentajat, editor: Hannikainen, MO
+                  and Danielsbacka, M and Tepora, T}
 }
 
 @Misc{Lahti2006biopax,

--- a/content/publication_resources/bibtex/lahti.bib
+++ b/content/publication_resources/bibtex/lahti.bib
@@ -1,45 +1,16 @@
-@Article{Lahti2021bioc,
-  author =	 {Leo Lahti and Felix G.M. Ernst and Sudarshan
-                  A. Shetty and others},
-  title =	 {Microbiome data science in the {\it
-                  SummarizedExperiment} universe},
-  journal =	 {F1000Research},
-  year =	 2021,
-  volume =	 10,
-  number =	 748,
-  keywords =	 {datascience},
-  note =	 {(slides); version 1; not peer reviewed},
-  doi =		 {10.7490/f1000research.1118712.1}
+
+
+@article{Liu2021liver,
+	title        = {Early prediction of liver disease using conventional risk factors and gut microbiome-augmented gradient boosting},
+	author       = {Liu, Yang and Meric, Guillaume and Havulinna, Aki S. and Teo, Shu Mei and Ruuskanen, Matti and Sanders, Jon and Zhu, Qiyun and Tripathi, Anupriya and Verspoor, Karin and Cheng, Susan and Jain, Mo and Jousilahti, Pekka and Vazquez-Baeza, Yoshiki and Loomba, Rohit and Lahti, Leo and Niiranen, Teemu and Salomaa, Veikko and Knight, Rob and Inouye, Michael},
+	year         = 2020,
+	journal      = {medRxiv},
+	doi          = {10.1101/2020.06.24.20138933},
+	url          = {https://www.medrxiv.org/content/early/2020/06/25/2020.06.24.20138933},
+	eprint       = {https://www.medrxiv.org/content/early/2020/06/25/2020.06.24.20138933.full.pdf},
+	keywords       = {preprint}
 }
 
-@InProceedings{Tiihonen2021chr,
-  author =	 {Iiro Tiihonen and Mikko Tolonen and Leo Lahti},
-  title =	 {Probabilistic Analysis of Early Modern British Book
-                  Prices},
-  booktitle =	 {{Proc. CEUR Workshop Proceedings on Computational
-                  Humanities Research}},
-  year =	 2021,
-  pages =	 {39--48},
-  keywords =	 {dh},
-  month =	 {Nov},
-  url =
-                  {https://github.com/openresearchlabs/openresearchlabs.github.io/blob/master/content/publication_resources/papers/2021-Tiihonen-CHR.pdf},
-  note =	 {In M Ehrmann, F Karsdorp et al. (eds).}
-}
-
-@article{Tolonen2021rcl,
-  author =	 {Tolonen, M and M{\"a}kel{\"a}, E and Ijaz, A and
-                  Lahti, L},
-  title =	 {Corpus Linguistics and Eighteenth Century
-                  Collections Online (ECCO)},
-  journal =	 {Research in Corpus Linguistics},
-  year =	 2021,
-  volume =	 9,
-  number =	 1,
-  pages =	 {19--34},
-  doi =		 {10.32714/ricl.09.01.03},
-  keywords =	 {dh}
-}
 
 @Article{Qin2021,
   author =	 {Youwen Qin and Aki S. Havulinna and Yang Liu and
@@ -60,2119 +31,1747 @@
   doi =		 {10.1101/2020.09.12.20193045}
 }
 
-@Article{Arani2021,
-  author =	 {Babak M.S. Arani, Egbert van Nes, Leo Lahti, Stephen
-                  R. Carpenter, Marten Scheffer},
-  title =	 {Exit Time as a Measure of Ecological Resilience},
-  journal =	 {Science},
+
+
+
+@article{Zhu2021,
+	title        = {OGUs enable effective, phylogeny-aware analysis of even shallow metagenome community structures},
+	author       = {Zhu, Qiyun and Huang, Shi and Gonzalez, Antonio and McGrath, Imran and McDonald, Daniel and Haiminen, Niina and Armstrong, George and V{\'a}zquez-Baeza, Yoshiki and Yu, Julian and Kuczynski, Justin and Sepich-Poore, Gregory D and Swafford, Austin D and Das, Promi and Shaffer, Justin P and Lejzerowicz, Franck and Belda-Ferre, Pedro and Havulinna, Aki S and M{\'e}ric, Guillaume and Niiranen, Teemu and Lahti, Leo and Salomaa, Veikko and Kim, Ho-Cheol and Jain, Mohit and Inouye, Michael and Gilbert, Jack and Knight, Rob},
+	year         = 2021,
+	journal      = {bioRxiv},
+	doi          = {10.1101/2021.04.04.438427},
+	url          = {https://www.biorxiv.org/content/early/2021/04/06/2021.04.04.438427},
+	elocation-id = {2021.04.04.438427},
+	eprint       = {https://www.biorxiv.org/content/early/2021/04/06/2021.04.04.438427.full.pdf},
+	keywords     = {preprint}
+}
+
+
+
+@Article{Laitinen2021ews,
+  author =	 {Ville Laitinen and Vasilis Dakos and Leo Lahti},
+  title =	 {Probabilistic early warning signals},
+  journal =	 {Ecology & Evolution},
   year =	 2021,
-  volume =	 372,
-  number =	 6547,
-  pages =	 {eaay4895},
-  month =	 {June},
-  doi =		 {10.1126/science.aay4895}
+  volume =	 11,
+  number =	 20,
+  pages =	 {14101-14114},
+  month =	 {September},
+  keywords     = {bioscience},  
+  doi =		 {10.1002/ece3.8123}
 }
 
-@Article{Makela2021hs,
-  author =	 {Eetu Mäkelä and Leo Lahti and Johanna Lilja and
-                  Pekka Heikkinen},
-  title =	 {Laki estää tehokkaiden tutkimusmenetelmien käytön},
-  journal =	 {HS Mielipide},
-  year =	 2021,
-  month =	 {October},
-  url =		 {https://www.hs.fi/mielipide/art-2000008325656.html},
-  keywords =	 {opinion},
-  status =	 {general}
+
+
+@article{Aatsinki2018,
+	title        = {Gut Microbiota Composition in Mid-Pregnancy Is Associated with Gestational Weight Gain but Not Prepregnancy Body Mass Index},
+	author       = {Anna-Katariina Aatsinki and Henna-Maria Uusitupa and Eveliina Munukka and Henri Pesonen and Anniina Rintala and Sami Pietilä and Leo Lahti and Erkki Eerola and Linnea Karlsson and Hasse Karlsson},
+	year         = 2018,
+	month        = {May},
+	journal      = {Journal of Womens Health},
+	doi          = {10.1089/jwh.2017.6488},
+	note         = {Epub ahead of print.},
+	keywords     = {bioscience},
+	url          = {https://github.com/openresearchlabs/openresearchlabs.github.io/blob/master/content/publication_resources/papers/2018-Aatsinki.pdf}
 }
 
-@article {Zhu2021,
-  author =	 {Zhu, Qiyun and Huang, Shi and Gonzalez, Antonio and
-                  McGrath, Imran and McDonald, Daniel and Haiminen,
-                  Niina and Armstrong, George and V{\'a}zquez-Baeza,
-                  Yoshiki and Yu, Julian and Kuczynski, Justin and
-                  Sepich-Poore, Gregory D and Swafford, Austin D and
-                  Das, Promi and Shaffer, Justin P and Lejzerowicz,
-                  Franck and Belda-Ferre, Pedro and Havulinna, Aki S
-                  and M{\'e}ric, Guillaume and Niiranen, Teemu and
-                  Lahti, Leo and Salomaa, Veikko and Kim, Ho-Cheol and
-                  Jain, Mohit and Inouye, Michael and Gilbert, Jack
-                  and Knight, Rob},
-  title =	 {OGUs enable effective, phylogeny-aware analysis of
-                  even shallow metagenome community structures},
-  elocation-id = {2021.04.04.438427},
-  year =	 2021,
-  doi =		 {10.1101/2021.04.04.438427},
-  URL =
-                  {https://www.biorxiv.org/content/early/2021/04/06/2021.04.04.438427},
-  eprint =
-                  {https://www.biorxiv.org/content/early/2021/04/06/2021.04.04.438427.full.pdf},
-  journal =	 {bioRxiv},
-  status =	 {preprint}
+@article{Aatsinki2019,
+	title        = {Gut microbiota composition is associated with temperament traits in infants},
+	author       = {Anna Aatsinki and Leo Lahti and Henna Uusitupa and Eveliina Munukka and Anniina Keskitalo, Saara Nolvi and Siobhain O'Mahony and Sami Pietilä and Laura Elo and Erkki Eerola and Hasse Karlsson and Linnea Karlsson},
+	year         = 2019,
+	month        = {May},
+	journal      = {Brain Behavior and Immunity},
+	volume       = 80,
+	pages        = {849--858},
+	doi          = {10.1016/j.bbi.2019.05.035},
+	url          = {https://github.com/openresearchlabs/openresearchlabs.github.io/blob/master/content/publication_resources/papers/2019-Aatsinki.pdf},
+	keywords     = {bioscience}
 }
 
-@article {Liu2021liver,
-  author =	 {Liu, Yang and Meric, Guillaume and Havulinna, Aki
-                  S. and Teo, Shu Mei and Ruuskanen, Matti and
-                  Sanders, Jon and Zhu, Qiyun and Tripathi, Anupriya
-                  and Verspoor, Karin and Cheng, Susan and Jain, Mo
-                  and Jousilahti, Pekka and Vazquez-Baeza, Yoshiki and
-                  Loomba, Rohit and Lahti, Leo and Niiranen, Teemu and
-                  Salomaa, Veikko and Knight, Rob and Inouye, Michael},
-  title =	 {Early prediction of liver disease using conventional
-                  risk factors and gut microbiome-augmented gradient
-                  boosting},
-  year =	 2020,
-  doi =		 {10.1101/2020.06.24.20138933},
-  URL =
-                  {https://www.medrxiv.org/content/early/2020/06/25/2020.06.24.20138933},
-  eprint =
-                  {https://www.medrxiv.org/content/early/2020/06/25/2020.06.24.20138933.full.pdf},
-  journal =	 {medRxiv},
-  status =	 {preprint}
-}
-
-@inBook{Tolonen2021canon,
-  author =	 {Mikko Tolonen and Mark J. Hill and Ali Zeeshan Ijaz
-                  and Ville Vaara and Leo Lahti},
-  editor =	 {Baird, I.},
-  title =	 {Data Visualization in Enlightenment Literature and
-                  Culture},
-  chapter =	 {Examining the Early Modern Canon: {The English Short
-                  Title Catalogue} and Large-Scale Patterns of
-                  Cultural Production},
-  publisher =	 {Palgrave Macmillan, Cham.},
-  booktitle =	 {Data Visualization in Enlightenment Literature and
-                  Culture},
-  maintitle =	 {Data Visualization in Enlightenment Literature and
-                  Culture},
-  year =	 2021,
-  doi =		 {10.1007/978-3-030-54913-8_3},
-  month =	 {March},
-}
-
-@Article{Ruuskanen2021,
-  author =	 {Matti Ruuskanen and Guilhem Sommeria-Klein and Aki
-                  Havulinna and Teemu Niiranen and Leo Lahti},
-  title =	 {Modeling spatial patterns in host-associated
-                  microbial communities},
-  journal =	 {Environmental Microbiology},
-  year =	 2021,
-  volume =	 23,
-  number =	 5,
-  pages =	 {2374-2388},
-  month =	 {May},
-  doi =		 {10.1111/1462-2920.15462}
-}
-
-@Article{Hintikka2021,
-  author =	 {Hintikka, J and Lensu, S and Mäkinen, E and
-                  Karvinen, S and Honkanen, M and Linden, J and
-                  Garrels, T and Pekkala, S and Lahti, L},
-  title =	 {Xylo-Oligosaccharides in Prevention of Hepatic
-                  Steatosis and Adipose Tissue Inflammation:
-                  Associating Taxonomic and Metabolomic Patterns in
-                  Fecal Microbiomes with Biclustering},
-  journal =	 {International Journal of Environmental Research and
-                  Public Health},
-  year =	 2021,
-  volume =	 18,
-  number =	 8,
-  pages =	 4049,
-  month =	 {April},
-  doi =		 {10.3390/ijerph18084049},
-  status =	 {bioscience}
-}
-
-@Article{Salosensaari2021,
-  author =	 {Aaro Salosensaari* and Ville Laitinen* and Aki S
-                  Havulinna and Guillaume Meric and Susan Cheng and
-                  Markus Perola and Liisa Valsta and Georg Alfthan and
-                  Michael Inouye and Jeramie D Watrous and Tao Long
-                  and Rodolfo Salido and Karenina Sanders and
-                  Caitriona Brennan and Gregory C Humphrey and Jon G
-                  Sanders and Mohit Jain and Pekka Jousilahti and
-                  Veikko Salomaa and Rob Knight and Leo Lahti* and
-                  Teemu Niiranen*},
-  title =	 {Taxonomic signatures of cause-specific mortality
-                  risk in human gut microbiome},
-  journal =	 {Nature Communications},
-  year =	 2021,
-  volume =	 12,
-  pages =	 2671,
-  doi =		 {10.1038/s41467-021-22962-y},
-  status =	 {bioscience},
-  annote =	 {Preprint featured in HS Tiede Jan 30, 2020. Featured
-                  in Science Magazine Jan 22, 2020
-                  https://www.sciencemag.org/news/2020/01/microbes-your-gut-could-predict-whether-you-re-likely-die-next-15-years}
-}
-
-@InProceedings{Lahti2020chr,
-  author =	 {Leo Lahti and Eetu Mäkelä and Mikko Tolonen},
-  title =	 {Quantifying bias and uncertainty in historical data
-                  collections with probabilistic programming},
-  booktitle =	 {{Proc. CEUR Workshop Proceedings on Computational
-                  Humanities Research}},
-  pages =	 {80--89},
-  year =	 2020,
-  month =	 {Nov},
-  url =		 {http://ceur-ws.org/Vol-2723/short46.pdf}
-}
-
-@Article{Keskitalo2021,
-  author =	 {Keskitalo, A and Aatsinki, A-K and Kortesluoma, S
-                  and Pelto, J and Korhonen, L and Lahti, L and
-                  Lukkarinen, M and Munukka, E and Karlsson, H and
-                  Karlsson, L},
-  title =	 {Gut microbiota diversity but not composition is
-                  related to saliva cortisol stress response at the
-                  age of 2.5 months},
-  journal =	 {Stress},
-  year =	 2021,
-  volume =	 24,
-  number =	 5,
-  pages =	 {551-560},
-  month =	 {March},
-  doi =		 {10.1080/10253890.2021.1895110},
-  note =	 {In press.},
-  status =	 {bioscience}
-}
-
-@ARTICLE{MorenoIndias2021,
-  author =	 {Isabel Moreno-Indias and Leo Lahti and Miroslava
-                  Nedyalkova and Ilze Elbere and Gennady
-                  V. Roshchupkin and Muhamed Adilovic and Onder
-                  Aydemir and Burcu Bakir-Gungor and Enrique
-                  Carrillo-de Santa Pau and Domenica D'Elia and Magesh
-                  S. Desai and Laurent Falquet and Aycan Gundogdu and
-                  Karel Hron and Thomas Klammsteiner and Marta
-                  B. Lopes and Laura J. Marcos Zambrano and Cláudia
-                  Marques and Michael Mason and Patrick May and Lejla
-                  Pašić and Gianvito Pio and Sándor Pongor and Vasilis
-                  J. Promponas and Piotr Przymus and Julio
-                  Sáez-Rodríguez and Alexia Sampri and Rajesh Shigdel
-                  and Blaz Stres and Ramona Suharoschi and Jaak Truu
-                  and Ciprian-Octavian Truică and Baiba Vilne and
-                  Dimitrios P. Vlachakis and Ercüment Yılmaz and Georg
-                  Zeller and Aldert Zomer and David Gómez-Cabrero and
-                  Marcus Claesson},
-  title =	 {Statistical and machine learning techniques in human
-                  microbiome studies: contemporary challenges and
-                  solutions},
-  journal =	 {Frontiers in Microbiology},
-  volume =	 12,
-  pages =	 277,
-  month =	 {February},
-  year =	 2021,
-  doi =		 {10.3389/fmicb.2021.635781},
-  status =	 {bioscience}
-}
-
-@ARTICLE{MarcosZambrano2021,
-  author =	 {Marcos-Zambrano, Laura Judith and
-                  Karaduzovic-Hadziabdic, Kanita and Loncar Turukalo,
-                  Tatjana and Przymus, Piotr and Trajkovik, Vladimir
-                  and Aasmets, Oliver and Berland, Magali and Gruca,
-                  Aleksandra and Hasic, Jasminka and Hron, Karel and
-                  Klammsteiner, Thomas and Kolev, Mikhail and Lahti,
-                  Leo and Lopes, Marta B and Moreno, Victor and
-                  Naskinova, Irina and Org, Elin and Paciência, Inês
-                  and Papoutsoglou, Georgios and Shigdel, Rajesh and
-                  Stres, Blaz and Vilne, Baiba and Yousef, Malik and
-                  Zdravevski, Eftim and Tsamarindos, Ioannis and
-                  Carrillo de Santa Pau, Enrique and Claesson, Marcus
-                  J. and Moreno-Indias, Isabel and Truu, Jaak},
-  title =	 {Applications of Machine Learning in Human Microbiome
-                  Studies: A Review on Feature Selection, Biomarker
-                  Identification, Disease Prediction and Treatment},
-  journal =	 {Frontiers in Microbiology},
-  volume =	 12,
-  pages =	 313,
-  year =	 2021,
-  url =
-                  {https://www.frontiersin.org/article/10.3389/fmicb.2021.634511},
-  doi =		 {10.3389/fmicb.2021.634511},
-  issn =	 {1664-302X},
-  status =	 {bioscience}
-}
-
-@Article{Ruuskanen2021gutmicrobes,
-  author =	 {Matti O. Ruuskanen and Fredrik Åberg and Ville
-                  Männistö and Aki S. Havulinna and Guillaume Méric
-                  and Yang Liu and Rohit Loomba and Yoshiki
-                  Vázquez-Baeza and Anupriya Tripathi and Liisa
-                  M. Valsta and Michael Inouye and Pekka Jousilahti
-                  and Veikko Salomaa and Mohit Jain and Rob Knight and
-                  Leo Lahti and Teemu J. Niiranen},
-  title =	 {Links between gut microbiome composition and fatty
-                  liver disease in a large population sample},
-  journal =	 {Gut Microbes},
-  volume =	 13,
-  issue =	 1,
-  month =	 {March},
-  year =	 2021,
-  doi =		 {10.1080/19490976.2021.1888673},
-  status =	 {bioscience}
-}
-
-@Article{crossys2021,
-  author =	 {Marja A. Heiskanen and Sanna M. Honkala and Ronja
-                  A. Ojala and Riikka Lautamäki and Kalle Koskensalo
-                  and Martin Lietzén and Jaakko Hentilä and Virva
-                  Saunavaara and Jani Saunavaara and Mika Helmiö and
-                  Eliisa Löyttyniemi and Lauri Nummenmaa and Maria
-                  C. Collado and Tarja Malm and Leo Lahti and Kirsi
-                  H. Pietiläinen and Jaakko Kaprio and Juha O. Rinne
-                  and Jarna C. Hannukainen},
-  title =	 {Systemic cross-talk between brain, gut, and
-                  peripheral tissues in glucose homeostasis: effects
-                  of exercise training (CROSSYS): Exercise training
-                  intervention in monozygotic twins discordant for
-                  body weight},
-  journal =	 {BMC Sports Science, Medicine and Rehabilitation},
-  year =	 2021,
-  volume =	 13,
-  status =	 {bioscience},
-  pages =	 16,
-  doi =		 {10.1186/s13102-021-00241-z}
-}
-
-@Article{Sarhadi2021,
-  author =	 {Virinder Sarhadi and Binu Mathew and Arto Kokkola A
-                  and Tiina Karla and Milja Tikkanen and Hilpi
-                  Rautelin and Leo Lahti and Pauli Puolakkainen and
-                  Sakari Knuutila},
-  title =	 {Gut microbiota of patients with different subtypes
-                  of gastric cancer and gastrointestinal stromal
-                  tumors},
-  status =	 {bioscience},
-  doi =		 {10.1186/s13099-021-00403-x},
-  volume =	 13,
-  issue =	 11,
-  pages =	 {1-9},
-  journal =	 {Gut Pathogens},
-  year =	 2021
-}
-
-@Article{Palmu2021ijerph,
-  author =	 {Joonatan Palmu and Leo Lahti and Teemu Niiranen},
-  title =	 {Targeting gut microbiota to treat hypertension: a
-                  systematic review},
-  journal =	 {International Journal of Environmental Research and
-                  Public Health},
-  year =	 2021,
-  month =	 January,
-  volume =	 18,
-  number =	 3,
-  pages =	 1248,
-  doi =		 {10.3390/ijerph18031248},
-  status =	 {bioscience},
-  tag =		 {review}
-}
-
-@Article{Khalighi2021,
-  author =	 {Moein Khalighi and Leila Eftekhari and Soleiman
-                  Hosseinpour and Leo Lahti},
-  title =	 {Three-species Lotka-Volterra model with respect to
-                  Caputo and Caputo-Fabrizio fractional operators},
-  journal =	 {Symmetry},
-  volume =	 13,
-  issue =	 3,
-  pages =	 368,
-  month =	 {January},
-  doi =		 {10.3390/sym13030368},
-  status =	 {datascience},
-  year =	 2020
-}
-
-@TechReport{openedu2020,
-  author =	 {Expert Panel in Open Education (Open Science
-                  Coordination in Finland)},
-  title =	 {National policy and executive plan by the higher
-                  education and research community for 2021-2025 -
-                  Policy component 1: Open access to educational
-                  resources.},
-  institution =	 {unknown},
-  year =	 2020,
-  publisher =	 {Committee for Public Information (TJNK) and
-                  Federation of Finnish Learned Societies (TSV).},
-  series =	 {Responsible Research Series},
-  year =	 2020,
-  volume =	 16,
-  status =	 {openscience},
-  address =	 {Helsinki, Finland}
-}
-
-@Article{Koffert2020,
-  author =	 {Jukka Koffert and Leo Lahti and Lotta Nylund and
-                  Seppo Salminen and Jarna C Hannukainen and Paulina
-                  Salminen and Willem de Vos and Pirjo Nuutila},
-  title =	 {Partial restoration of normal intestinal microbiota
-                  in morbidly obese women six months after bariatric
-                  surgery},
-  journal =	 {PeerJ – Life & Environment},
-  year =	 2020,
-  volume =	 8,
-  pages =	 {e10442},
-  doi =		 {10.7717/peerj.10442},
-  note =	 {Shared first authorship.},
-  status =	 {bioscience}
-}
-
-@Article{Pekkala2020,
-  author =	 {Sanna Lensu and Raghunath Pariyani and Elina Mäkinen
-                  and Baoru Yang and Wisam Saleem and Eveliina Munukka
-                  and Maarit Lehti and Baoru Yang and Jere Linden and
-                  Marja Tiirola and Leo Lahti and Satu Pekkala},
-  title =	 {Prebiotic Xylo-oligosaccharides Targeting
-                  Faecalibacterium prausnitzii Prevent High Fat
-                  Diet-induced Hepatic Steatosis in Rats},
-  journal =	 {Nutrients},
-  year =	 2020,
-  volume =	 12,
-  number =	 11,
-  doi =		 {10.3390/nu12113225},
-  pages =	 3225,
-  month =	 {October},
-  status =	 {bioscience}
-}
-
-@Article{Nylund2020,
-  author =	 {Lotta Nylund and Salla Hakkola and Leo Lahti and
-                  Seppo Salminen and Marko Kalliomäki and Baoru Yang
-                  and Kaisa M. Linderborg},
-  title =	 {Diet, perceived intestinal well-being, fecal
-                  microbiota and short chain fatty acids in oat-using
-                  subjects with celiac disease or gluten sensitivity.},
-  journal =	 {Nutrients},
-  year =	 2020,
-  volume =	 12,
-  issue =	 9,
-  pages =	 2570,
-  status =	 {bioscience},
-  month =	 {August},
-  note =	 {Special issue.},
-  doi =		 {10.3390/nu12092570}
-}
-
-@Article{Palmu2020JAHA,
-  author =	 {Joonatan Palmu and others},
-  title =	 {Eicosanoid Inflammatory Mediators Are Robustly
-                  Associated with Blood Pressure in the General
-                  Population},
-  journal =	 {Journal of American Heart Association},
-  year =	 2020,
-  volume =	 9,
-  issue =	 15,
-  pages =	 {e016641},
-  status =	 {bioscience},
-  doi =		 {10.1161/JAHA.120.017598}
-}
-
-@Article{Lahti2020thinkopen,
-  author =	 {Leo Lahti},
-  title =	 {Avoimuus voi vahvistaa päätöksenteon tieteellistä
-                  pohjaa},
-  journal =	 {University of Helsinki, ThinkOpen blog},
-  year =	 2020,
-  month =	 {August},
-  url =
-                  {https://blogs.helsinki.fi/thinkopen/lahdekoodin-avoimuus-paatoksenteossa/},
-  status =	 {general}
-}
-
-@Article{Lahti2020hs2,
-  author =	 {Leo Lahti},
-  title =	 {Lähdekoodin sisältämien yksityiskohtien avoimuus on
-                  keskeistä päätöksenteon läpinäkyvyydelle.},
-  journal =	 {HS Mielipide},
-  year =	 2020,
-  month =	 {June},
-  url =		 {https://www.hs.fi/mielipide/art-2000006545770.html},
-  status =	 {general}
-}
-
-@Article{Lahti2020okf2,
-  author =	 {Leo Lahti},
-  title =	 {Päätös epidemialaskelmien salaamisesta vastoin
-                  valtioneuvoston avoimuuslinjausta},
-  journal =	 {Open Knowledge Finland Blog},
-  year =	 2020,
-  month =	 {June},
-  url =
-                  {https://www.okf.fi/fi/2020/06/15/thln-paatos-epidemialaskelmien-salaamisesta-vastoin-valtioneuvoston-avoimuuslinjausta/},
-  status =	 {general}
-}
-
-@Article{Lahti2020okf1,
-  author =	 {Leo Lahti and Tarmo Toikkanen},
-  title =	 {Tietopyyntö epidemialaskelmien lähdekoodeista},
-  journal =	 {Open Knowledge Finland Blog},
-  year =	 2020,
-  month =	 {May},
-  url =
-                  {https://www.okf.fi/fi/2020/05/13/tietopyynto-thln-epidemialaskelmien-lahdekoodeista},
-  status =	 {general}
-}
-
-@Article{Lahti2020hs1,
-  author =	 {Leo Lahti and Thomas Wallgren and Markku Kulmala},
-  title =	 {Laskentamallit eivät lähtökohtaisesti ole salassa
-                  pidettävää tietoa},
-  journal =	 {HS Mielipide},
-  year =	 2020,
-  month =	 {May},
-  url =		 {https://www.hs.fi/mielipide/art-2000006494641.html},
-  status =	 {general}
-}
-
-@Article{Vaura2020jch,
-  author =	 {Felix C. Vaura and Veikko V. Salomaa and Ilkka
-                  M. Kantola and Risto Kaaja and Leo Lahti and Teemu
-                  J. Niiranen},
-  title =	 {Unsupervised hierarchical clustering identifies a
-                  metabolically challenged subgroup of hypertensive
-                  individuals},
-  journal =	 {Journal of Clinical Hypertension},
-  year =	 2020,
-  volume =	 22,
-  number =	 9,
-  pages =	 {1546--1553},
-  month =	 {August},
-  doi =		 {10.1111/jch.13984},
-  status =	 {bioscience}
-}
-
-@Article{Palmu2020,
-  author =	 {Joonatan Palmu and Aaro Salosensaari and Aki
-                  S. Havulinna and Susan Cheng and Michael Inouye and
-                  Mohit Jain and Rodolfo A. Salido and Karenina
-                  Sanders and Caitriona Brennan and Gregory
-                  C. Humphrey and Jon G. Sanders and Erkki Vartiainen
-                  and Tiina Laatikainen and Pekka Jousilahti and
-                  Veikko Salomaa and Rob Knight and Leo Lahti and
-                  Teemu J. Niiranen},
-  title =	 {Association Between the Gut Microbiota and Blood
-                  Pressure in a Population Cohort of 6953 Individuals},
-  journal =	 {Journal of the American Heart Association},
-  year =	 2020,
-  status =	 {bioscience},
-  month =	 {July},
-  doi =		 {10.1161/JAHA.120.016641}
-}
 
 @article{Aatsinki2020,
-  title =	 {Maternal prenatal psychological distress and hair
-                  cortisol levels associate with infant fecal
-                  microbiota composition at 2.5 months of age},
-  journal =	 {Psychoneuroendocrinology},
-  volume =	 119,
-  pages =	 104754,
-  year =	 2020,
-  status =	 {bioscience},
-  doi =		 {10.1016/j.psyneuen.2020.104754},
-  author =	 {Anna-Katariina Aatsinki and Anniina Keskitalo and
-                  Ville Laitinen and Eveliina Munukka and Henna-Maria
-                  Uusitupa and Leo Lahti and Susanna Kortesluoma and
-                  Paula Mustonen and Ana João Rodrigues and Bárbara
-                  Coimbra and Pentti Huovinen and Hasse Karlsson and
-                  Linnea Karlsson}
+	title        = {Maternal prenatal psychological distress and hair cortisol levels associate with infant fecal microbiota composition at 2.5 months of age},
+	author       = {Anna-Katariina Aatsinki and Anniina Keskitalo and Ville Laitinen and Eveliina Munukka and Henna-Maria Uusitupa and Leo Lahti and Susanna Kortesluoma and Paula Mustonen and Ana João Rodrigues and Bárbara Coimbra and Pentti Huovinen and Hasse Karlsson and Linnea Karlsson},
+	year         = 2020,
+	journal      = {Psychoneuroendocrinology},
+	volume       = 119,
+	pages        = 104754,
+	doi          = {10.1016/j.psyneuen.2020.104754},
+	keywords     = {bioscience}
 }
 
-@Article{Sarhadi2020,
-  author =	 {Sarhadi, V and Lahti, L and Saberi, F and Youssef, O
-                  and Kokkola, A and Karla, T and Tikkanen, M and
-                  Rautelin, H and Puolakkainen, P and Salehi, R and
-                  Knuutila, S},
-  title =	 {Gut Microbiota and Host Gene Mutations in Colorectal
-                  Cancer Patients and Controls of Iranian and Finnish
-                  Origin},
-  journal =	 {Anticancer Research},
-  year =	 2020,
-  volume =	 40,
-  number =	 3,
-  pages =	 {1325-1334},
-  month =	 {March},
-  doi =		 {10.21873/anticanres.14074},
-  status =	 {bioscience},
-  pdf =		 {papers/2020-Sarhadi-Anticanc.pdf}
+@article{Aleksic14,
+	title        = {The Open Science Peer Review Oath},
+	author       = {Jelena Aleksic and Adrian Alexa and Teresa K Attwood and Neil Chue Hong and Martin Dahl{\"o} and Robert Davey and Holger Dinkel and Konrad U F{\"o}rstner and Ivo Grigorov and Jean-Karim Hériché and Leo Lahti and Dan MacLean and Michael L Markie and Jenny Molloy and Maria Victoria Schneider and Camille Scott and Richard Smith-Unna and Bruno Miguel Vieira},
+	year         = 2015,
+	month        = 1,
+	journal      = {F1000Research},
+	volume       = 3,
+	pages        = 271,
+	doi          = {10.12688/f1000research.5686.2},
+	category     = {perspective},
+	note         = {AllBio: Open Science & Reproducibility Best Practice Workshop},
+	keywords     = {openscience},
+	url          = {https://github.com/openresearchlabs/openresearchlabs.github.io/blob/master/content/publication_resources/papers/2014-Aleksic.pdf}
 }
 
-@InProceedings{Makela2020,
-  author =	 {Eetu, M and Lagus, K and Lahti, L and Säily, T and
-                  Tolonen, M and Hämäläinen, M and Kaislaniemi, S and
-                  Nevalainen T},
-  title =	 {Wrangling with Non-Standard Data},
-  booktitle =	 {Proc. Digital Humanities in the Nordic Countries},
-  year =	 2020,
-  month =	 {March},
-  series =	 {CEUR Workshop Proceedings},
-  pages =	 {81--96},
-  volume =	 2612,
-  editor =	 {Sanita Reinsone and Inguna Skadiņa and Anda Baklāne
-                  and Jānis Daugavietis},
-  pdf =		 {papers/2020-Makela-DHN.pdf},
-  status =	 {dh}
+
+@article{Alneberg14,
+	title        = {Binning metagenomic contigs by coverage and composition},
+	author       = {Johannes Alneberg and Brynjar Smári Bjarnason and Ino de Bruijn and Melanie Schirmer and Joshua Quick and Umer Z Ijaz and Leo Lahti and Nicholas J Loman and Anders F Andersson and Christopher Quince},
+	year         = 2014,
+	journal      = {Nature Methods},
+	volume       = 11,
+	number       = {1144--1146},
+	doi          = {10.1038/nmeth.3103},
+	note         = {CONCOCT algorithm},
+	keywords     = {bioscience},
+	url          = {https://github.com/openresearchlabs/openresearchlabs.github.io/blob/master/content/publication_resources/papers/2014-Alneberg-NatMeth.pdf}
 }
 
-@Article{Shetty2019,
-  author =	 {Sudarshan Shetty and Leo Lahti},
-  title =	 {Microbiome data science},
-  journal =	 {Journal of Biosciences},
-  year =	 2019,
-  volume =	 44,
-  pages =	 115,
+
+@article{Arani2018,
+	title        = {Stability estimation of autoregulated genes under Michaelis-Menten type kinetics},
+	author       = {Arani, Babak M. S. and Mahmoudi, Mahdi and Lahti, Leo and Gonz\'alez, Javier and Wit, Ernst C.},
+	year         = 2018,
+	month        = {Jun},
+	journal      = {Physical Review E},
+	publisher    = {American Physical Society},
+	volume       = 97,
+	number       = 6,
+	pages        = 062407,
+	doi          = {10.1103/PhysRevE.97.062407},
+	issn         = {2470-0045},
+	url          = {https://link.aps.org/doi/10.1103/PhysRevE.97.062407},
+	numpages     = 10,
+	keywords       = {datascience},
+	url          = {https://github.com/openresearchlabs/openresearchlabs.github.io/blob/master/content/publication_resources/papers/2018-Arani-PhysRevE.pdf}
+}
+
+
+
+
+@article{Arani2021,
+	title        = {Exit Time as a Measure of Ecological Resilience},
+	author       = {Babak M.S. Arani and Egbert van Nes and Leo Lahti and Stephen R. Carpenter and Marten Scheffer},
+	year         = 2021,
+	month        = {June},
+	journal      = {Science},
+	volume       = 372,
+	number       = 6547,
+	pages        = {eaay4895},
+	doi          = {10.1126/science.aay4895},
+	keywords     = {datascience}
+}
+
+
+
+
+
+
+@techreport{Bjork2018,
+	title        = {Opening academic publishing: development and application of systematic evaluation criteria},
+	author       = {Anna Björk and Juho-Matti Paavolainen and Teemu Ropponen and Mikael Laakso and Leo Lahti},
+	year         = 2018,
+	month        = {January},
+	publisher    = {Open Science and Research Initiative (ATT)},
+	url          = {http://urn.fi/URN:NBN:fi-fe201802123334},
+	category     = {report},
+	note         = {Report on the openness of major scientific publishers commissioned by Finnish Ministry of Education and Culture},
+	institution  = {unknown},
+	authorship   = {corresponding},
+	status       = {openscience},
+	keywords     = {openscience},
+	url          = {https://github.com/openresearchlabs/openresearchlabs.github.io/blob/master/content/publication_resources/papers/2018-Bjork-ATT.pdf}
+}
+
+@article{Borze11,
+	title        = {MicroRNA microarrays on archive bone marrow core biopsies of leukemias - method validation},
+	author       = {Ioana Borze and Mohamed Guled and Suad Musse and Anna Raunio and Erkki Elonen and Ulla Saarinen-Pihkala and Marja-Liisa Karjalainen-Lindsberg and Leo Lahti and Sakari Knuutila.},
+	year         = 2011,
+	month        = 2,
+	journal      = {Leukemia Research},
+	volume       = 35,
+	pages        = {188--195},
+	doi          = {10.1016/j.leukres.2010.08.005},
+	issue        = 2,
+	keywords     = {bioscience},	
+}
+
+
+
+@article{Buelow2017,
+	title        = {Comparative gut microbiota and resistome profiling of intensive care patients receiving selective digestive tract decontamination and healthy subjects},
+	author       = {Elena Buelow and Teresita {d.J.} Bello González and Susana Fuentes and Wouter A.A. {de Steenhuijsen Piters} and Leo Lahti and Jumamurat R. Bayjanov and Eline A.M. Majoor and Johanna C. Braat and Maaike S. van Mourik and Evelien A.N. Oostdijk and Rob J.L. Willems and Marc J.M. Bonten and Mark W.J. van Passel and Hauke Smidt and Willem van Schaik},
+	year         = 2017,
+	month        = {Aug},
+	journal      = {Microbiome},
+	volume       = 5,
+	number       = 1,
+	pages        = 88,
+	doi          = {10.1186/s40168-017-0309-z},
+	keywords     = {bioscience},
+	url          = {https://github.com/openresearchlabs/openresearchlabs.github.io/blob/master/content/publication_resources/papers/2017-Buelow-Microbiome.pdf}
+}
+
+
+
+
+
+@article{Elo05,
+	title        = {Integrating probe-level expression changes across generations of Affymetrix arrays},
+	author       = {Elo, Laura L. and Lahti, Leo and Skottman, Heli and Kyl{\"a}niemi, Minna and Lahesmaa, Riitta and Aittokallio, Tero},
+	year         = 2005,
+	month        = 12,
+	journal      = {Nucleic Acids Research},
+	volume       = 33,
+	number       = 22,
+	pages        = {e193},
+	doi          = {10.1093/nar/gni193},
+	authorship   = {second},
+	keywords     = {bioscience},
+	url          = {https://github.com/openresearchlabs/openresearchlabs.github.io/blob/master/content/publication_resources/papers/2005-Elo-NAR.pdf}
+}
+
+
+
+@inproceedings{Faisal2011,
+	title        = {Biomarker discovery via dependency analysis of multi-view functional genomics data},
+	author       = {Ali Faisal and Riku Louhimo and Leo Lahti and Sampsa Hautaniemi and Samuel Kaski},
+	year         = 2011,
+	booktitle    = {NIPS 2011 workshop From Statistical Genetics to Predictive Models in Personalized Medicine},
+	category     = {abstract},
+	keywords     = {bioscience},
+	url          = {https://github.com/openresearchlabs/openresearchlabs.github.io/blob/master/content/publication_resources/papers/2011-Faisal-NIPS.pdf}
+}
+
+
+@article{Faust15,
+	title        = {Metagenomics meets time series analysis: unraveling microbial community dynamics},
+	author       = {Karoline Faust and Leo Lahti and Didier Gonze and Willem M de Vos and Jeroen Raes},
+	year         = 2015,
+	month        = 6,
+	journal      = {Current Opinion in Microbiology},
+	volume       = 25,
+	pages        = {56--66},
+	doi          = {10.1016/j.mib.2015.04.004},
+	category     = {review},
+	keywords     = {bioscience},
+	authorship   = {shared first},
+	url          = {https://github.com/openresearchlabs/openresearchlabs.github.io/blob/master/content/publication_resources/papers/2015-Faust-CurrOpMicrob.pdf}
+}
+
+
+
+
+@article{Faust2017,
+	title        = {Multi-stability and the origin of microbial community types},
+	author       = {Didier Gonze and Leo Lahti and Jeroen Raes and Karoline Faust},
+	year         = 2017,
+	month        = {may},
+	journal      = {ISME Journal},
+	volume       = 11,
+	pages        = {2159--2166},
+	doi          = {10.1038/ismej.2017.60},
+	keywords     = {bioscience},
+	url          = {https://github.com/openresearchlabs/openresearchlabs.github.io/blob/master/content/publication_resources/papers/2017-Faust-ISME.pdf}
+}
+
+
+
+
+@article{Faust2018,
+	title        = {Signatures of ecological processes in microbial community time series},
+	author       = {Karoline Faust and Franziska Bauchinger and Beatrice Laroche and Sophie de Buyl and Leo Lahti and Alex D Washburne and Didier Gonze and Stefanie Widder},
+	year         = 2018,
+	month        = {June},
+	journal      = {Microbiome},
+	volume       = 6,
+	number       = 120,
+	doi          = {10.1186/s40168-018-0496-2},
+	keywords     = {bioscience},
+	url          = {https://github.com/openresearchlabs/openresearchlabs.github.io/blob/master/content/publication_resources/papers/2018-Faust-Microbiome.pdf}
+}
+
+
+@article{Gonze2018,
+	title        = {Microbial communities as dynamical systems},
+	author       = {Didier Gonze and Katharine Z Coyte and Leo Lahti and Karoline Faust},
+	year         = 2018,
+	month        = {July},
+	journal      = {Current Opinion in Microbiology},
+	volume       = 44,
+	pages        = {41--49},
+	doi          = {10.1016/j.mib.2018.07.004},
+	keywords     = {bioscience},
+	url          = {https://github.com/openresearchlabs/openresearchlabs.github.io/blob/master/content/publication_resources/papers/2018-Gonze.pdf}
+}
+
+
+@article{Guled09,
+	title        = {CDKN2A, NF2 and JUN Are Dysregulated Among Other Genes by miRNAs in Malignant Mesothelioma - a miRNA Microarray Analysis},
+	author       = {Mohamed Guled and Leo Lahti and Pamela M. Lindholm and Kaisa Salmenkivi and Izhar Bagwan and Andrew G. Nicholson and Sakari Knuutila},
+	year         = 2009,
+	month        = 7,
+	journal      = {Genes, Chromosomes and Cancer},
+	volume       = 48,
+	number       = 7,
+	pages        = {615--623},
+	doi          = {10.1002/gcc.20669},
+	url          = {https://github.com/openresearchlabs/openresearchlabs.github.io/blob/master/content/publication_resources/papers/2009-GCC-Guled-miRNA.pdf},
+	keywords = {bioscience}
+}
+
+
+
+
+
+@article{Harris17,
+	title        = {Linking statistical and ecological theory: Hubbell's unified neutral theory of biodiversity as a hierarchical Dirichlet process},
+	author       = {Keith Harris and Todd L Parsons and Umer Z Ijaz and Leo Lahti and Ian Holmes and Christopher Quince},
+	year         = 2017,
+	month        = {March},
+	journal      = {Proceedings of the IEEE},
+	volume       = 105,
+	number       = 3,
+	pages        = {516--529},
+	doi          = {10.1109/JPROC.2015.2428213},
+	keywords     = {bioscience},
+	url          = {https://github.com/openresearchlabs/openresearchlabs.github.io/blob/master/content/publication_resources/papers/2017-Harris-IEEE.pdf}
+}
+
+
+
+@inproceedings{Hill2018,
+	title        = {Spheres of “public” in eighteenth-century Britain},
+	author       = {Mark J Hill and Antti Kanner and Jani Marjanen and Ville Vaara and Eetu Mäkelä and Leo Lahti and Mikko Tolonen},
+	year         = 2018,
+	month        = 3,
+	booktitle    = {Proceedings of the Digital Humanities in the Nordics Conference},
+	address      = {Helsinki, Finland},
+	category     = {abstract},
+	keywords       = {dh}
+}
+
+
+
+
+
+@inproceedings{Hill2019dhn,
+	title        = {Reconstructing intellectual networks: from the {ESTC}'s bibliographic metadata to historical material},
+	author       = {Mark J Hill and Ville Vaara and Tanja S{\"a}ily and Leo Lahti and Mikko Tolonen},
+	year         = 2019,
+	month        = {March},
+	booktitle    = {Proc. Digital Humanities in the Nordic Countries},
+	address      = {Copenhagen},
+	series       = {CEUR Workshop Proceedings},
+	volume       = 2364,
+	pages        = {201--219},
+	note         = {Best paper award.},
+	editor       = {Costanza Navarretta and Manex Agirrezabal and Bente Maegaard},
+	url          = {https://github.com/openresearchlabs/openresearchlabs.github.io/blob/master/content/publication_resources/papers/2019-Hill-DHN.pdf},
+	keywords     = {dh}
+}
+
+
+
+@article{Hintikka2021,
+	title        = {Xylo-Oligosaccharides in Prevention of Hepatic Steatosis and Adipose Tissue Inflammation: Associating Taxonomic and Metabolomic Patterns in Fecal Microbiomes with Biclustering},
+	author       = {Hintikka, J and Lensu, S and Mäkinen, E and Karvinen, S and Honkanen, M and Linden, J and Garrels, T and Pekkala, S and Lahti, L},
+	year         = 2021,
+	month        = {April},
+	journal      = {International Journal of Environmental Research and Public Health},
+	volume       = 18,
+	number       = 8,
+	pages        = 4049,
+	doi          = {10.3390/ijerph18084049},
+	keywords     = {bioscience}
+}
+
+
+
+
+
+@inproceedings{Ijaz2019dh,
+	title        = {Analytical Edition Detection In Bibliographic Metadata},
+	author       = {Ali Ijaz and Hege Roivainen and Leo Lahti},
+	year         = 2019,
+	month        = {July},
+	booktitle    = {Proceedings of the Digital Humanities (DH2019)},
+	note         = {In press.},
+	keywords     = {dh}
+}
+
+
+@inproceedings{Ijaz2019rdhum,
+	title        = {Analytical determination of editions from bibliographic metadata},
+	author       = {Ali Ijaz and Mikko Tolonen and Leo Lahti},
+	year         = 2019,
+	month        = {August},
+	booktitle    = {Proceedings of the Research Data in the Humanities Conference},
+	address      = {Oulu},
+	url          = {https://github.com/openresearchlabs/openresearchlabs.github.io/blob/master/content/publication_resources/papers/2019-Ijaz-RDHum.pdf},
+	keywords = {dh}
+}
+
+@article{Jalanka-Tuovinen11,
+	title        = {Intestinal microbiota in healthy adults: Temporal analysis reveals individual and common core and relation to intestinal symptoms},
+	author       = {Jonna Jalanka-Tuovinen and Anne Salonen and Janne Nikkil{\"a} and Outi Immonen and Riina Kekkonen and Leo Lahti and Airi Palva and Willem M. de Vos},
+	year         = 2011,
+	month        = 7,
+	journal      = {PLoS One},
+	volume       = 6,
+	number       = 7,
+	pages        = {e23035},
+	url          = {10.1371/journal.pone.0023035},
+	keywords     = {bioscience},
+	url          = {https://github.com/openresearchlabs/openresearchlabs.github.io/blob/master/content/publication_resources/papers/2011-JalankaTuovinen-PLoS.pdf}
+}
+
+
+
+
+@article{Kaski05,
+	title        = {Associative clustering for exploring dependencies between functional genomics data sets},
+	author       = {Samuel Kaski and Janne Nikkil{\"a} and Janne Sinkkonen and Leo Lahti and Juha Knuuttila and Christophe Roos},
+	year         = 2005,
+	month        = {September},
+	journal      = {IEEE/ACM Transactions on Computational Biology and Bioinformatics},
+	volume       = 2,
+	number       = 3,
+	pages        = {203--216},
+	doi          = {10.1109/TCBB.2005.32},
+	note         = {Special Issue on Machine Learning for Bioinformatics -- Part 2},
+	keywords       = {datascience},
+	url          = {https://github.com/openresearchlabs/openresearchlabs.github.io/blob/master/content/publication_resources/papers/2005-TCBB–Kaski-AC.pdf}
+}
+
+@article{Keskitalo2021,
+	title        = {Gut microbiota diversity but not composition is related to saliva cortisol stress response at the age of 2.5 months},
+	author       = {Keskitalo, A and Aatsinki, A-K and Kortesluoma, S and Pelto, J and Korhonen, L and Lahti, L and Lukkarinen, M and Munukka, E and Karlsson, H and Karlsson, L},
+	year         = 2021,
+	month        = {March},
+	journal      = {Stress},
+	volume       = 24,
+	number       = 5,
+	pages        = {551--560},
+	doi          = {10.1080/10253890.2021.1895110},
+	note         = {In press.},
+	keywords       = {bioscience}
+}
+
+
+@article{Khalighi2021,
+	title        = {Three-species Lotka-Volterra model with respect to Caputo and Caputo-Fabrizio fractional operators},
+	author       = {Moein Khalighi and Leila Eftekhari and Soleiman Hosseinpour and Leo Lahti},
+	year         = 2020,
+	month        = {January},
+	journal      = {Symmetry},
+	volume       = 13,
+	pages        = 368,
+	doi          = {10.3390/sym13030368},
+	issue        = 3,
+	keywords       = {datascience}
+}
+
+
+
+@article{Koffert2020,
+	title        = {Partial restoration of normal intestinal microbiota in morbidly obese women six months after bariatric surgery},
+	author       = {Jukka Koffert and Leo Lahti and Lotta Nylund and Seppo Salminen and Jarna C Hannukainen and Paulina Salminen and Willem de Vos and Pirjo Nuutila},
+	year         = 2020,
+	journal      = {PeerJ – Life & Environment},
+	volume       = 8,
+	pages        = {e10442},
+	doi          = {10.7717/peerj.10442},
+	note         = {Shared first authorship.},
+	keywords     = {bioscience}
+}
+
+
+@mastersthesis{Lahti03,
+	title        = {Comparative functional genome analysis using associative clustering},
+	author       = {Lahti, Leo},
+	year         = 2003,
+	month        = 12,
+	url          = {https://github.com/antagomir/thesis/tree/master/msc03},
+	category     = {thesis},
+	note         = {(in Finnish)},
+	school       = {Helsinki University of Technology},
+	language     = {Finnish},
+	url          = {https://github.com/antagomir/thesis/blob/master/msc03/dtyo.pdf},
+	keywords = {thesis}
+}
+
+@misc{Lahti09bsc,
+	title        = {Concerning Blackburn's quasi-realism in securing moral discussion},
+	author       = {Leo Lahti},
+	year         = 2009,
+	month        = 7,
+	category     = {thesis},
+	keywords = {thesis},	
+	note         = {(In Finnish)},
+	howpublished = {B.Sc. thesis. University of Helsinki, Faculty of Political Sciences},
+	language     = {Finnish},
+	url          = {https://github.com/openresearchlabs/openresearchlabs.github.io/blob/master/content/publication_resources/theses/LeoLahti-BSc-2008.pdf}
+}
+
+@inproceedings{Lahti09mlsp,
+  title =	 {Dependency detection with similarity constraints},
+  author =	 {Leo Lahti and Samuel Myllykangas and Sakari Knuutila
+                  and Samuel Kaski},
+  year =	 2009,
+  booktitle =	 {Proc. MLSP'09 IEEE International Workshop on Machine
+                  Learning for Signal Processing XIX},
+  address =	 {Piscataway, NJ},
+  pages =	 {198--203},
+  url =		 {http://arxiv.org/abs/1101.5919},
+  note =	 {R/Bioconductor: pint},
+  editor =	 {Adali T, Chanussot J, Jutten C, and Larsen J},
+  howpublished = {software},
+  url =		 {https://github.com/openresearchlabs/openresearchlabs.github.io/blob/master/content/publication_resources/papers/2009-MLSP-Lahti-SimCCA.pdf},
+  authorship =	 {first, corresponding},
+  arxiv =	 {1101.5919},
+  keywords =	 {datascience}
+}
+
+@misc{Lahti09rpa,
+  title =	 {RPA: probe reliability and differential gene
+                  expression analysis},
+  author =	 {Leo Lahti},
+  year =	 2009,
   month =	 {October},
-  doi =		 {10.1007/s12038-019-9930-2},
-  note =	 {Preprint openly available at:
-                  https://openresearchlabs.github.io/publications/papers/2019-Shetty-MDS.pdf},
-  status =	 {bioscience},
-  keywords =	 {review}
+  doi =		 {10.18129/B9.BIOC.RPA},
+  url =
+                  {http://bioconductor.org/packages/release/bioc/html/RPA.html},
+  note =	 {R/Bioconductor: RPA},
+  howpublished = {software},
+  keywords =	 {bioscience}
 }
 
-@Article{Marjanen2019,
-  author =	 {Jani Marjanen and Ville Vaara and Antti Kanner and
-                  Hege Roivainen and Eetu Mäkelä and Leo Lahti and
-                  Mikko Tolonen},
-  title =	 {A National Public Sphere? Analyzing the Language,
-                  Location, and Form of Newspapers in Finland,
-                  1771–1917},
-  journal =	 {Journal of European Periodical Studies},
-  year =	 2019,
-  volume =	 4,
-  number =	 1,
-  month =	 {June},
-  doi =		 {10.21825/jeps.v4i1.10483},
-  url =		 {https://ojs.ugent.be/jeps/article/view/10483},
-  note =	 {Special issue: Digital Approaches Towards Serial
-                  Publications},
-  pdf =		 {papers/2019-Marjanen-JEPS.pdf},
-  status =	 {dh},
-  keywords =	 {dh}
+@article{Lahti10bioinf,
+	title        = {Global modeling of transcriptional responses in interaction networks},
+	author       = {Leo Lahti and Juha E.A. Knuuttila and Samuel Kaski},
+	year         = 2010,
+	month        = 11,
+	journal      = {Bioinformatics},
+	volume       = 26,
+	pages        = {2713--2720},
+	doi          = {10.1093/bioinformatics/btq500},
+	url          = {http://bioinformatics.oxfordjournals.org/content/early/2010/09/02/bioinformatics.btq500.abstract.html?ijkey=N1zzjtUBRng3wCM&keytype=ref},
+	note         = {R/Matlab implementations available at http://netpro.r-forge.r-project.org/},
+	issue        = 21,
+	keywords     = {bioscience},
+	authorship   = {first},
+	url          = {https://github.com/openresearchlabs/openresearchlabs.github.io/blob/master/content/publication_resources/papers/2010-Bioinformatics-Lahti-NetResponse.pdf},
+	annote       = {ArXiv: http://arxiv.org/abs/1202.0501; R/Matlab source code http://netpro.r-forge.r-project.org}
 }
 
-@InProceedings{Ijaz2019rdhum,
-  author =	 {Ali Ijaz and Mikko Tolonen and Leo Lahti},
-  title =	 {Analytical determination of editions from
-                  bibliographic metadata},
-  booktitle =	 {Proceedings of the Research Data in the Humanities
-                  Conference},
-  year =	 2019,
-  address =	 {Oulu},
-  month =	 {August},
-  pdf =		 {papers/2019-Ijaz-RDHum.pdf}
+@misc{Lahti10blog,
+  title =	 {opencomp blog},
+  author =	 {Leo Lahti},
+  url =		 {http://antagomir.wordpress.com/},
+  category =	 {blog},
+  keywords =	 {blog}
 }
 
-@InProceedings{Lahti2019rdhum,
-  author =	 {Leo Lahti and Ville Vaara and Jani Marjanen and
-                  Mikko Tolonen},
-  title =	 {Best practices in bibliographic data science},
-  booktitle =	 {Proceedings of the Research Data in the Humanities
-                  Conference},
-  year =	 2019,
-  address =	 {Oulu},
-  month =	 {August},
-  pdf =		 {papers/2019-Lahti-RDHUM.pdf},
-  status =	 {dh},
-  keywords =	 {dh}
+@misc{Lahti10dmt,
+  title =	 {Dependency modeling toolkit},
+  author =	 {Leo Lahti and Abhishek Tripathi and Olli-Pekka
+                  Huovilainen},
+  year =	 2010,
+  month =	 6,
+  publisher =	 {ICML workshop},
+  url =		 {http://dmt.r-forge.r-project.org/},
+  note =	 {CRAN: dmt},
+  howpublished = {software},
+  keywords =	 {datascience}
 }
 
-@Article{Aatsinki2019,
-  author =	 {Anna Aatsinki and Leo Lahti and Henna Uusitupa and
-                  Eveliina Munukka and Anniina Keskitalo, Saara Nolvi
-                  and Siobhain O'Mahony and Sami Pietilä and Laura Elo
-                  and Erkki Eerola and Hasse Karlsson and Linnea
-                  Karlsson},
-  title =	 {Gut microbiota composition is associated with
-                  temperament traits in infants},
-  pdf =		 {papers/2019-Aatsinki.pdf},
-  journal =	 {Brain Behavior and Immunity},
-  volume =	 80,
-  pages =	 {849--858},
-  year =	 2019,
-  month =	 {May},
-  status =	 {bioscience},
-  doi =		 {10.1016/j.bbi.2019.05.035}
+@misc{Lahti10netresponse,
+  title =	 {NetResponse (functional network analysis)},
+  author =	 {Leo Lahti and Antonio Gusmao and Olli-Pekka
+                  Huovilainen},
+  year =	 2010,
+  month =	 {October},
+  doi =		 {10.18129/B9.BIOC.NETRESPONSE},
+  url =
+                  {http://www.bioconductor.org/help/bioc-views/devel/bioc/html/netresponse.html},
+  note =	 {R/Bioconductor: netresponse},
+  keywords =	 {datascience},
+  howpublished = {software}
 }
 
-@Article{Timmis2019,
-  author =	 {K Timmis K and F Jebok F and M Rohde M and L Lahti L
-                  and G Molinari},
-  title =	 {Microbiome yarns: The Global Phenotype-Genotype
-                  Survey. Episode III: importance of microbiota
-                  diversification for microbiome function and biome
-                  health},
-  journal =	 {Microbial Biotechnology},
-  year =	 2019,
+@misc{Lahti10pint,
+  title =	 {Pairwise integration of functional genomics data},
+  author =	 {Olli-Pekka Huovilainen and Leo Lahti},
+  year =	 2010,
   month =	 {April},
-  doi =		 {10.1111/1751-7915.13406},
-  status =	 {misc},
-  keywords =	 {misc},
-  annote =	 {Comics piece for the popularization of microbiome
-                  research.}
-}
-
-@Article{stolaki2019,
-  author =	 {Stolaki, Maria and Minekus, Mans and Venema, Koen
-                  and Lahti, Leo and Smid, Eddy J. and Kleerebezem,
-                  Michiel and Zoetendal, Erwin G},
-  title =	 {Microbial communities in a dynamic {it in vitro}
-                  model for the human ileum resemble the human ileal
-                  microbiota},
-  journal =	 {FEMS Microbiology Ecology},
-  year =	 2019,
-  status =	 {bioscience},
-  vol =		 95,
-  number =	 8,
-  pages =	 {fiz096},
-  month =	 {August},
-  doi =		 {10.1093/femsec/fiz096},
-  pdf =		 {papers/2019-Stolaki-FEMS.pdf}
-}
-
-@InProceedings{Tolonen16dh,
-  author =	 {Mikko Tolonen and Niko Ilom{\"a}ki and Hege
-                  Roivainen and Leo Lahti},
-  title =	 {Printing in a Periphery: a Quantitative Study of
-                  Finnish Knowledge Production, 1640-1828},
-  booktitle =	 {Digital Humanities 2016: Conference Abstracts},
-  year =	 2016,
-  category =	 {abstract},
-  status =	 {dh},
-  publisher =	 {Jagiellonian University & Pedagogical University,
-                  Kraków},
-  address =	 {Krakow, Poland},
-  url =		 {http://dh2016.adho.org/abstracts/9},
-  pages =	 {383--385},
-  month =	 7,
-  keywords =	 {dh}
-}
-
-@InProceedings{Vaara2019dh,
-  author =	 {Ville Vaara and Ali Ijaz and Iiro Tiihonen and Simon
-                  Hengchen and Antti Kanner and Tanja S{\"a}ily and
-                  Leo Lahti},
-  title =	 {The Emerging Paradigm of Bibliographic Data Science},
-  booktitle =	 {Proceedings of the Digital Humanities (DH2019)},
-  year =	 2019,
-  month =	 {July},
-  status =	 {dh},
-  keywords =	 {dh},
-  note =	 {In press.}
-}
-
-@InProceedings{Ijaz2019dh,
-  author =	 {Ali Ijaz and Hege Roivainen and Leo Lahti},
-  title =	 {Analytical Edition Detection In Bibliographic
-                  Metadata},
-  booktitle =	 {Proceedings of the Digital Humanities (DH2019)},
-  year =	 2019,
-  month =	 {July},
-  status =	 {dh},
-  keywords =	 {dh},
-  note =	 {In press.}
-}
-
-@InProceedings{Hill2019dhn,
-  author =	 {Mark J Hill and Ville Vaara and Tanja S{\"a}ily and
-                  Leo Lahti and Mikko Tolonen},
-  title =	 {Reconstructing intellectual networks: from the
-                  {ESTC}'s bibliographic metadata to historical
-                  material},
-  pages =	 {201--219},
-  booktitle =	 {Proc. Digital Humanities in the Nordic Countries},
-  series =	 {CEUR Workshop Proceedings},
-  year =	 2019,
-  volume =	 2364,
-  month =	 {March},
-  address =	 {Copenhagen},
-  editor =	 {Costanza Navarretta and Manex Agirrezabal and Bente
-                  Maegaard},
-  url =		 {https://cst.dk/DHN2019Pro/papers/DHN2019_hill.pdf},
-  pdf =		 {papers/2019-Hill-DHN.pdf},
-  note =	 {Best paper award.},
-  status =	 {dh},
-  keywords =	 {dh}
-}
-
-@InProceedings{Makela2019dhn,
-  author =	 {Eetu M{\"a}kel{\"a} and Mikko Tolonen and Jani
-                  Marjanen and Antti Kanner and Ville Vaara and Leo
-                  Lahti},
-  title =	 {Interdisciplinary collaboration in studying
-                  newspaper materiality},
-  pages =	 {55-66},
-  booktitle =	 {Proc. Twin Talks workshop. Digital Humanities in the
-                  Nordic Countries},
-  series =	 {CEUR Workshop Proceedings},
-  year =	 2019,
-  month =	 {March},
-  address =	 {Copenhagen},
-  volume =	 2365,
-  editor =	 {Steven Krauwer and Darja Fišer},
-  status =	 {dh},
-  keywords =	 {dh},
-  pdf =		 {papers/2019-Makela-DHN.pdf},
   url =
-                  {http://ceur-ws.org/Vol-2365/07-TwinTalks-DHN2019_paper_7.pdf}
+                  {http://bioconductor.org/packages/devel/bioc/html/pint.html},
+  note =	 {R/BioConductor: pint},
+  keywords =	 {datascience},
+  howpublished = {software}
 }
 
-@InProceedings{Tolonen2019dhn,
-  author =	 {Mikko Tolonen and Jani Marjanen and Hege Roivainen
-                  and Leo Lahti},
-  title =	 {Scaling up bibliographic data science},
-  booktitle =	 {Proceedings of the Digital Humanities in the Nordics
-                  (DHN2019)},
-  year =	 2019,
-  month =	 {March},
-  address =	 {Copenhagen},
-  editor =	 {Costanza Navarretta and Manex Agirrezabal and Bente
-                  Maegaard},
-  pdf =		 {papers/2019-Tolonen-DHN.pdf},
-  status =	 {dh},
-  keywords =	 {dh}
+@phdthesis{Lahti10thesis,
+	title        = {Probabilistic analysis of the human transcriptome with side information},
+	author       = {Leo Lahti},
+	year         = 2010,
+	month        = 12,
+	address      = {Espoo},
+	series       = {TKK Dissertations in Information and Computer Science},
+	number       = {TKK-ICS-D19},
+	issn         = {1797-5069},
+	url          = {http://lib.tkk.fi/Diss/2010/isbn9789526033686/},
+	category     = {thesis},
+	note         = {LaTeX sources and the pdf version are openly available: https://github.com/antagomir/thesis/tree/master/phd10; Press release: https://github.com/antagomir/thesis/blob/master/phd10/Vaitostiedote-LeoLahti-20101207.pdf},
+	school       = {Aalto University School of Science and Technology, Faculty of Information and Natural Sciences, Department of Information and Computer Science},
+	language     = {Finnish},
+	keywords     = {thesis, probabilistic models, Bayesian analysis, data integration, gene expression, microarrays, computational science, data analysis, machine learning, computational biology, open source, open access, creative commons},
+	url          = {https://github.com/openresearchlabs/openresearchlabs.github.io/blob/master/content/publication_resources/papers/2010-Lahti-thesis.pdf},
+	abstract     = {Recent advances in high-throughput measurement technologies and efficient sharing of biomedical data through community databases have made it possible to investigate the complete collection of genetic material, the genome, which encodes the heritable genetic program of an organism. This has opened up new views to the study of living organisms with a profound impact on biological research. Functional genomics is a subdiscipline of molecular biology that investigates the functional organization of genetic information.  This thesis develops computational strategies to investigate a key functional layer of the genome, the transcriptome. The time- and context-specific transcriptional activity of the genes regulates the function of living cells through protein synthesis. Efficient computational techniques are needed in order to extract useful information from high-dimensional genomic observations that are associated with high levels of complex variation. Statistical learning and probabilistic models provide the theoretical framework for combining statistical evidence across multiple observations and the wealth of background information in genomic data repositories.  This thesis addresses three key challenges in transcriptome analysis. First, new preprocessing techniques that utilize side information in genomic sequence databases and microarray collections are developed to improve the accuracy of high-throughput microarray measurements.  Second, a novel exploratory approach is proposed in order to construct a global view of cell-biological network activation patterns and functional relatedness between tissues across normal human body. Information in genomic interaction databases is used to derive constraints that help to focus the modeling in those parts of the data that are supported by known or potential interactions between the genes, and to scale up the analysis. The third contribution is to develop novel approaches to model dependency between co-occurring measurement sources. The methods are used to study cancer mechanisms and transcriptome evolution; integrative analysis of the human transcriptome and other layers of genomic information allows the identification of functional mechanisms and interactions that could not be detected based on the individual measurement sources. Open source implementations of the key methodological contributions have been released to facilitat e their further adoption by the research community.}
 }
 
-@Article{Lahti2019bds,
-  author =	 {Leo Lahti and Jani Marjanen and Hege Roivainen and
-                  Mikko Tolonen},
-  title =	 {Bibliographic Data Science and the History of the
-                  Book (c. 1500–1800)},
-  journal =	 {Cataloging \& Classification Quarterly},
-  year =	 2019,
-  volume =	 57,
-  number =	 1,
-  pages =	 {5--23},
-  month =	 {January},
-  doi =		 {10.1080/01639374.2018.1543747},
-  pdf =		 {papers/2019-Lahti-CCQ.pdf},
-  publisher =	 {Routledge},
-  status =	 {dh},
-  note =	 {Special issue.}
+@misc{Lahti11-louhos,
+	title        = {Louhos blog},
+	author       = {Leo Lahti and Joona Lehtomäki and Juuso Parkkinen and others},
+	url          = {http://louhos.github.io/},
+	note         = {Open government data analytics blog (in Finnish)},
+	keywords       = {blog}
 }
 
-@Article{tolonen2019,
-  author =	 {Mikko Tolonen and Leo Lahti and Hege Roivainen and
-                  Jani Marjanen},
-  title =	 {A Quantitative Approach to Book-Printing in Sweden
-                  and Finland, 1640–1828},
-  journal =	 {Historical Methods: A Journal of Quantitative and
-                  Interdisciplinary History},
-  year =	 2019,
-  volume =	 52,
-  issue =	 1,
-  publisher =	 {Routledge},
-  pages =	 {57--78},
-  doi =		 {10.1080/01615440.2018.1526657},
-  status =	 {dh},
-  keywords =	 {dh},
-  pdf =		 {papers/2019-Tolonen.pdf}
-}
-
-@InProceedings{Lahti2018IDA,
-  author =	 {Lahti, Leo},
-  title =	 {Open Data Science},
-  booktitle =	 {Advances in Intelligent Data Analysis XVII. Lecture
-                  Notes in Computer Science 11191.},
-  year =	 2018,
-  volume =	 11191,
-  address =	 {India},
-  publisher =	 {Springer},
-  month =	 {October},
-  publisher =	 {Springer Nature},
-  keywords =	 {openscience},
-  category =	 {perspective},
-  status =	 {openscience},
-  authorship =	 {first},
-  pdf =
-                  {https://github.com/openresearchlabs/openresearchlabs.github.io/blob/devel/publications/papers/2018-Lahti-IDA.pdf},
-  note =	 {Conference proceedings.}
-}
-
-@InProceedings{Laitinen2018IDA,
-  author =	 {Laitinen, Ville and Lahti, Leo},
-  title =	 {A hierarchical Ornstein-Uhlenbeck model for
-                  stochastic time series analysis},
-  booktitle =	 {Advances in Intelligent Data Analysis XVII. Lecture
-                  Notes in Computer Science 11191.},
-  year =	 2018,
-  url =		 {https://github.com/velait/OUP},
-  address =	 {India},
-  month =	 {October},
-  publisher =	 {Springer},
-  status =	 {datascience},
-  authorship =	 {pi},
-  pdf =		 {papers/2018-Laitinen-IDA.pdf},
-  note =	 {Conference proceedings.}
-}
-
-@Article{gonze2018,
-  author =	 {Didier Gonze and Katharine Z Coyte and Leo Lahti and
-                  Karoline Faust},
-  title =	 {Microbial communities as dynamical systems},
-  journal =	 {Current Opinion in Microbiology},
-  keywords =	 {review},
-  status =	 {bioscience},
-  year =	 2018,
-  volume =	 44,
-  pages =	 {41-49},
-  month =	 {July},
-  doi =		 {10.1016/j.mib.2018.07.004},
-  pdf =		 {papers/2018-Gonze.pdf}
-}
-
-@Article{Youssef2018,
-  author =	 {Omar Youssef and Leo Lahti and Arto Kokkola and
-                  Tiina Karla and Milja Tikkanen and Homa Ehsan and
-                  Monika Carpelan‑Holmström and Selja Koskensalo and
-                  Tom Böhling and Hilpi Rautelin and Pauli
-                  Puolakkainen and Sakari Knuutila and Virinder
-                  Sarhadi},
-  title =	 {Stool Microbiota Composition Differs in Patients
-                  with Stomach, Colon, and Rectal Neoplasms},
-  journal =	 {Digestive Diseases and Sciences},
-  year =	 2018,
-  volume =	 63,
-  number =	 11,
-  pages =	 {2950--2958},
-  authorship =	 {shared first},
-  month =	 {July},
-  status =	 {bioscience},
-  pdf =		 {papers/2018-Youssef.pdf},
-  doi =		 {10.1007/s10620-018-5190-5}
-}
-
-@Article{openutu2018,
-  key =		 {report},
-  author =	 {University of Turku},
-  title =	 {Turun yliopiston avoimen tutkimuksen politiikka /
-                  Open Research Policy},
-  howpublished = {Report},
-  journal =	 {unknwown},
-  journaltitle = {unknown},
-  status =	 {openscience},
-  category =	 {report},
-  month =	 {May},
-  year =	 2018,
-  pdf =		 {papers/2018-avoimen-tutkimuksen-politiikka-fi.pdf},
-  url =
-                  {https://www.utu.fi/sites/default/files/public\%3A//media/file/ty-avoimen-tutkimuksen-politiikka-fi.pdf},
-  note =	 {(in Finnish)},
-  annote =	 {Member in the work group that developed the report.}
-}
-
-@Article{Faust2018,
-  author =	 {Karoline Faust and Franziska Bauchinger and Beatrice
-                  Laroche and Sophie de Buyl and Leo Lahti and Alex D
-                  Washburne and Didier Gonze and Stefanie Widder},
-  title =	 {Signatures of ecological processes in microbial
-                  community time series},
-  journal =	 {Microbiome},
-  keywords =	 {highlight},
-  status =	 {bioscience},
-  year =	 2018,
-  volume =	 6,
-  number =	 120,
-  month =	 {June},
-  pdf =		 {papers/2018-Faust-Microbiome.pdf},
-  doi =		 {10.1186/s40168-018-0496-2}
-}
-
-@Article{Aatsinki2018,
-  author =	 {Anna-Katariina Aatsinki and Henna-Maria Uusitupa and
-                  Eveliina Munukka and Henri Pesonen and Anniina
-                  Rintala and Sami Pietilä and Leo Lahti and Erkki
-                  Eerola and Linnea Karlsson and Hasse Karlsson},
-  title =	 {Gut Microbiota Composition in Mid-Pregnancy Is
-                  Associated with Gestational Weight Gain but Not
-                  Prepregnancy Body Mass Index},
-  journal =	 {Journal of Womens Health},
-  year =	 2018,
-  month =	 {May},
-  status =	 {bioscience},
-  doi =		 {10.1089/jwh.2017.6488},
-  pdf =		 {papers/2018-Aatsinki.pdf},
-  note =	 {Epub ahead of print.}
-}
-
-@Article{Arani2018,
-  author =	 {Arani, Babak M. S. and Mahmoudi, Mahdi and Lahti,
-                  Leo and Gonz\'alez, Javier and Wit, Ernst C.},
-  title =	 {Stability estimation of autoregulated genes under
-                  Michaelis-Menten type kinetics},
-  journal =	 {Physical Review E},
-  year =	 2018,
-  volume =	 97,
-  number =	 6,
-  pages =	 062407,
-  numpages =	 10,
-  issn =	 {2470-0045},
-  month =	 {Jun},
-  publisher =	 {American Physical Society},
-  status =	 {datascience},
-  pdf =		 {papers/2018-Arani-PhysRevE.pdf},
-  doi =		 {10.1103/PhysRevE.97.062407},
-  url =		 {https://link.aps.org/doi/10.1103/PhysRevE.97.062407}
-}
-
-@article{Tolonen2018gaudeamus,
-  author =	 {Mikko Tolonen and Leo Lahti},
-  title =	 {Digitaaliset ihmistieteet ja historiantutkimus},
-  publisher =	 {Gaudeamus},
-  authorship =	 {second},
-  year =	 2018,
-  language =	 {Finnish},
-  note =	 {(in Finnish). In: Hannikainen, MO and Danielsbacka,
-                  M and Tepora, T (eds.). Menneisyyden
-                  rakentajat. Gaudeamus, Helsinki, 2018.},
-  journaltitle = {Menneisyyden rakentajat},
-  status =	 {dh},
-  journal =	 {Menneisyyden rakentajat},
-  url =		 {https://www.gaudeamus.fi/menneisyyden-rakentajat/},
-  annote =	 {This is a book chapter but classified as article as
-                  could not find a way to include this to CSL
-                  automatically generated bibliography yet. booktitle
-                  : Menneisyyden rakentajat, editor: Hannikainen, MO
-                  and Danielsbacka, M and Tepora, T}
-}
-
-@Misc{Lahti2006biopax,
-  author =	 {Leo Lahti},
-  title =	 {A brief overview on the BioPAX and SBML standards},
-  howpublished = {arXiv},
-  authorship =	 {first},
-  status =	 {bioscience},
-  category =	 {thesis},
-  year =	 2007,
-  url =		 {https://arxiv.org/abs/1109.4919},
-  arxiv =	 {arXiv:1109.4919 [cs.DS]},
-  note =	 {Overview of machine-readable representations of
-                  biological processes.},
-  language =	 {Finnish},
-  note =	 {(in Finnish)}
-}
-
-@Misc{Lahti2001,
-  author =	 {Leo Lahti},
-  title =	 {Julian joukko iteraatioden valuma-altaan reunana},
-  category =	 {thesis},
-  status =	 {thesis},
-  year =	 2001,
-  url =
-                  {https://github.com/antagomir/thesis/tree/master/julia01},
-  language =	 {Finnish},
-  note =	 {Special assignment in Mathematics (in Finnish)}
-}
-
-@Misc{Lahti2002,
-  author =	 {Leo Lahti},
-  title =	 {Itsesimilaaristen joukkojen Hausdorffin dimension
-                  määrittäminen},
-  category =	 {thesis},
-  year =	 2002,
-  url =
-                  {https://github.com/antagomir/thesis/tree/master/hausdorff02},
-  language =	 {Finnish},
-  note =	 {Special assignment in Mathematics (in Finnish)}
-}
-
-@InProceedings{Hill2018,
-  author =	 {Mark J Hill and Antti Kanner and Jani Marjanen and
-                  Ville Vaara and Eetu Mäkelä and Leo Lahti and Mikko
-                  Tolonen},
-  title =	 {Spheres of “public” in eighteenth-century Britain},
-  booktitle =	 {Proceedings of the Digital Humanities in the Nordics
-                  Conference},
-  status =	 {dh},
-  category =	 {abstract},
-  year =	 2018,
-  address =	 {Helsinki, Finland},
-  month =	 3
-}
-
-@TechReport{Bjork2018,
-  author =	 {Anna Björk and Juho-Matti Paavolainen and Teemu
-                  Ropponen and Mikael Laakso and Leo Lahti},
-  title =	 {Opening academic publishing: development and
-                  application of systematic evaluation criteria},
-  institution =	 {unknown},
-  year =	 2018,
-  publisher =	 {Open Science and Research Initiative (ATT)},
-  month =	 {January},
-  note =	 {Report on the openness of major scientific
-                  publishers commissioned by Finnish Ministry of
-                  Education and Culture},
-  authorship =	 {corresponding},
-  category =	 {report},
-  status =	 {openscience},
-  keywords =	 {openscience},
-  url =		 {http://urn.fi/URN:NBN:fi-fe201802123334},
-  pdf =		 {papers/2018-Bjork-ATT.pdf}
-}
-
-@Article{Buelow2017,
-  author =	 {Elena Buelow and Teresita {d.J.} Bello González and
-                  Susana Fuentes and Wouter A.A. {de Steenhuijsen
-                  Piters} and Leo Lahti and Jumamurat R. Bayjanov and
-                  Eline A.M. Majoor and Johanna C. Braat and Maaike
-                  S. van Mourik and Evelien A.N. Oostdijk and Rob
-                  J.L. Willems and Marc J.M. Bonten and Mark W.J. van
-                  Passel and Hauke Smidt and Willem van Schaik},
-  title =	 {Comparative gut microbiota and resistome profiling
-                  of intensive care patients receiving selective
-                  digestive tract decontamination and healthy
-                  subjects},
-  journal =	 {Microbiome},
-  year =	 2017,
-  volume =	 5,
-  number =	 1,
-  status =	 {bioscience},
-  pages =	 88,
-  month =	 {Aug},
-  pdf =		 {papers/2017-Buelow-Microbiome.pdf},
-  doi =		 {10.1186/s40168-017-0309-z}
-}
-
-@Article{Lahti17phos,
-  author =	 {Leo Lahti and Filipe da Silva and Markus Petteri
-                  Laine and Viivi Lähteenoja and Mikko Tolonen},
-  title =	 {Alchemy & algorithms: perspectives on the philosophy
-                  and history of open science},
-  journal =	 {RIO Journal},
-  year =	 2017,
-  volume =	 3,
-  pages =	 {e13593},
-  month =	 {May},
-  authorship =	 {first, corresponding},
-  category =	 {perspective},
-  keywords =	 {highlight},
-  status =	 {openscience},
-  doi =		 {10.3897/rio.3.e13593},
-  pdf =		 {papers/2017-Lahti-PHOS.pdf},
-  keywords =	 {dh},
-  note =	 {Review of the international conference, including
-                  electronic material (video interviews, lectures and
-                  podcasts.}
-}
-
-@Article{Faust2017,
-  author =	 {Didier Gonze and Leo Lahti and Jeroen Raes and
-                  Karoline Faust},
-  title =	 {Multi-stability and the origin of microbial
-                  community types},
-  journal =	 {ISME Journal},
-  year =	 2017,
-  status =	 {bioscience},
-  keywords =	 {highlight},
-  volume =	 11,
-  pages =	 {2159--2166},
-  pdf =		 {papers/2017-Faust-ISME.pdf},
-  month =	 {may},
-  doi =		 {10.1038/ismej.2017.60}
-}
-
-@Article{Tolonen15EnnenNyt,
-  author =	 {Mikko Tolonen and Leo Lahti},
-  title =	 {Aatehistoria ja digitaalisten aineistojen
-                  mahdollisuudet},
-  journal =	 {Ennen \& Nyt 2},
-  authorship =	 {shared first},
-  year =	 2015,
-  volume =	 2,
-  category =	 {review},
-  language =	 {Finnish},
-  month =	 8,
-  pdf =		 {papers/2015-EnnenNyt-Tolonen.pdf},
-  status =	 {dh},
-  url =
-                  {http://www.ennenjanyt.net/2015/08/aatehistoria-ja-digitaalisten-aineistojen-mahdollisuudet}
-}
-
-@Article{Lahti15LIBER,
-  author =	 {Leo Lahti and Niko Ilom{\"a}ki and Mikko Tolonen},
-  title =	 {A quantitative study of history in the English
-                  short-title catalogue (ESTC) 1470-1800},
-  journal =	 {LIBER Quarterly},
-  year =	 2015,
-  status =	 {dh},
-  volume =	 25,
-  number =	 2,
-  pages =	 {87-116},
-  month =	 12,
-  authorship =	 {first},
-  pdf =		 {papers/2015-Lahti-LIBERQuarterly.pdf},
-  issn =	 {2213-056X},
-  keywords =	 {dh},
-  doi =		 {10.18352/lq.10112}
-}
-
-@Article{Ritari15,
-  author =	 {Jarmo Ritari and Jarkko Salojärvi and Leo Lahti and
-                  Willem M. de Vos},
-  title =	 {Improved taxonomic assignment of human intestinal
-                  16S rRNA sequences by a dedicated reference
-                  database},
-  journal =	 {BMC Genomics},
-  pdf =		 {papers/2015-Ritari-BMCGenomics.pdf},
-  year =	 2015,
-  volume =	 16,
-  status =	 {bioscience},
-  pages =	 1056,
-  month =	 12,
-  doi =		 {10.1186/s12864-015-2265-y}
-}
-
-@InProceedings{Laine15,
-  author =	 {Heidi Laine and Leo Lahti and Anne Lehto and Samuli
-                  Ollila and Markus Miettinen},
-  title =	 {Beyond Open Access - The Changing Culture of
-                  Producing and Disseminating Scientific Knowledge},
-  booktitle =	 {Proceedings of the 19th International Academic
-                  Mindtrek Conference in Tampere, Finland, September
-                  22-24},
-  year =	 2015,
-  address =	 {ACM New York, NY, USA},
-  organization = {AcademicMindTrek'15: Proceedings of the 19th
-                  International Academic Mindtrek Conference},
-  publisher =	 {ACM},
-  authorship =	 {second},
-  address =	 {New York, NY, USA},
-  status =	 {openscience},
-  location =	 {Tampere, Finland},
-  isbn =	 {978-1-4503-3948-3},
-  keywords =	 {openscience},
-  pdf =		 {papers/2015-Laine-Mindtrek.pdf},
-  url =		 {http://dl.acm.org/citation.cfm?id=2818187}
-}
-
-@Article{Su2015,
-  author =	 {Jing Su and Carl Ekman and Nikolay Oskolkov and Leo
-                  Lahti and Kristoffer Ström and Alvis Brazma and Leif
-                  Groop and Johan Rung and and Ola Hansson},
-  title =	 {A novel atlas of gene expression in human skeletal
-                  muscle reveals molecular changes associated with
-                  aging},
-  journal =	 {Skeletal Muscle},
-  status =	 {bioscience},
-  year =	 2015,
-  volume =	 5,
-  number =	 35,
-  doi =		 {10.1186/s13395-015-0059-1},
-  month =	 10,
-  pdf =		 {papers/2015-Su-SkeletalMuscle.pdf}
-}
-
-@Misc{Lahti13icml,
-  author =	 {Leo Lahti, Juuso Parkkinen, Joona Lehtomäki and
-                  Markus Kainu},
-  title =	 {rOpenGov: open source ecosystem for computational
-                  social sciences and digital humanities},
-  keywords =	 {dh, openscience},
-  howpublished = {software},
-  category =	 {abstract},
-  status =	 {datascience},
-  month =	 12,
-  year =	 2013,
-  url =		 {http://ropengov.github.io},
-  note =	 {ICML/MLOSS workshop (Int'l Conf. on Machine Learning
-                  - Open Source Software workshop).}
-}
-
-@Article{Siavash15,
-  author =	 {Siavash Atashgahi and Rozelin Aydin and Mauricio
-                  R. Dimitrov and Detmer Sipkema and Kelly Hamonts and
-                  Leo Lahti and Farai Maphosa and Thomas Kruse and
-                  Edoardo Saccenti and Dirk Springael, Winnie Dejonghe
-                  and Hauke Smidt},
-  title =	 {Impact of a wastewater treatment plant on microbial
-                  community composition and function in a hyporheic
-                  zone of a eutrophic river},
-  journal =	 {Scientific Reports},
-  status =	 {bioscience},
-  year =	 2015,
-  volume =	 5,
-  number =	 17284,
-  month =	 11,
-  doi =		 {10.1038/srep17284},
-  pdf =		 {papers/2015-Atagashi.pdf}
-}
-
-@Article{Faust15,
-  author =	 {Karoline Faust and Leo Lahti and Didier Gonze and
-                  Willem M de Vos and Jeroen Raes},
-  title =	 {Metagenomics meets time series analysis: unraveling
-                  microbial community dynamics},
-  journal =	 {Current Opinion in Microbiology},
-  year =	 2015,
-  volume =	 25,
-  category =	 {review},
-  status =	 {bioscience},
-  keywords =	 {highlight},
-  pages =	 {56--66},
-  month =	 6,
-  authorship =	 {shared first},
-  doi =		 {10.1016/j.mib.2015.04.004},
-  pdf =		 {papers/2015-Faust-CurrOpMicrob.pdf}
-}
-
-@Article{OKeefe15,
-  author =	 {SJD O'Keefe and JV Li and L Lahti and J Ou and F
-                  Carbonero and K Mohammed and JM Posma and J Kinross
-                  and E Wahl and E Ruder and K Vipperla and V Naidoo
-                  and L Mtshali and S Tims and PGB Puylaert, J DeLany
-                  and A Krasinskas and AC Benefiel and HO Kaseb and K
-                  Newton and JK Nicholson and WM de Vos and HR Gaskins
-                  and EG Zoetendal},
-  title =	 {Fat, Fiber and Cancer Risk in African, Americans and
-                  Rural Africans},
-  journal =	 {Nature Communications},
-  year =	 2015,
-  volume =	 6,
-  pages =	 6342,
-  keywords =	 {gut},
-  status =	 {bioscience},
-  keywords =	 {highlight},
-  month =	 {Apr},
-  doi =		 {10.1038/ncomms7342},
-  note =	 {Top science article in Guardian on the release day.},
-  pdf =		 {papers/2015-OKeefe-NComms.pdf},
-  annote =	 {Guardian:
-                  http://www.theguardian.com/science/2015/apr/28/bowel-cancer-risk-may-be-reduced-by-rural-african-diet-study-finds}
-}
-
-@Article{Aleksic14,
-  author =	 {Jelena Aleksic and Adrian Alexa and Teresa K Attwood
-                  and Neil Chue Hong and Martin Dahl{\"o} and Robert
-                  Davey and Holger Dinkel and Konrad U F{\"o}rstner
-                  and Ivo Grigorov and Jean-Karim Hériché and Leo
-                  Lahti and Dan MacLean and Michael L Markie and Jenny
-                  Molloy and Maria Victoria Schneider and Camille
-                  Scott and Richard Smith-Unna and Bruno Miguel
-                  Vieira},
-  keywords =	 {openscience},
-  status =	 {openscience},
-  category =	 {perspective},
-  title =	 {The Open Science Peer Review Oath},
-  journal =	 {F1000Research},
-  year =	 2015,
-  volume =	 3,
-  month =	 1,
-  pages =	 271,
-  note =	 {AllBio: Open Science & Reproducibility Best Practice
-                  Workshop},
-  pdf =		 {papers/2014-Aleksic.pdf},
-  doi =		 {10.12688/f1000research.5686.2}
-}
-
-@Article{Niini12,
-  author =	 {Tarja Niini and Ilari Scheinin and Leo Lahti and
-                  Suvi Savola and Fredrik Mertens and Jaakko Hollmén
-                  and Tom Böhling and Aarne Kivioja and Karolin H Nord
-                  and Sakari Knuutila},
-  title =	 {Homozygous Deletions of Cadherin Genes in
-                  Chondrosarcoma – an Array CGH Study},
-  journal =	 {Cancer Genetics},
-  year =	 2012,
-  volume =	 205,
-  number =	 11,
-  pages =	 {588-93},
-  status =	 {bioscience},
-  month =	 11,
-  doi =		 {10.1016/j.cancergen.2012.09.007},
-  pmid =	 23146407
-}
-
-@Article{Lahti12cmi,
-  author =	 {Anne Salonen and Jarkko Saloj{\"a}rvi and Leo Lahti
-                  and and Willem M. de Vos},
-  title =	 {The adult intestinal core microbiota is determined
-                  by analysis depth and health status},
-  journal =	 {Clinical Microbiology and Infection},
-  year =	 2012,
-  volume =	 18,
-  number =	 {Suppl. 4},
-  status =	 {bioscience},
-  pages =	 {16–20},
-  pdf =		 {papers/2012-Salonen-CMI.pdf},
-  doi =		 {10.1111/j.1469-0691.2012.03855.x},
-}
-
-@Article{Mosakhani12,
-  author =	 {Neda Mosakhani and Leo Lahti and Ioana Borze and
-                  Marja-Liisa Karjalainen-Lindsberg and Jari Sundstrom
-                  and Raija Ristamaki and Pia Osterlund and Sakari
-                  Knuutila and and Virinder Kaur Sarhadi},
-  title =	 {MicroRNA profiling predicts survival in anti-EGFR
-                  treated chemorefractory metastatic colorectal cancer
-                  patients with wild-type KRAS and BRAF},
-  journal =	 {Cancer Genetics},
-  year =	 2012,
-  volume =	 205,
-  number =	 11,
-  pages =	 {545-51},
-  status =	 {bioscience},
-  pdf =		 {papers/2012-Mosakhani-CG.pdf},
-  authorship =	 {second},
-  month =	 11,
-  doi =		 {10.1016/j.cancergen.2012.08.003}
-}
-
-@Article{Lahti2012intcomp,
-  author =	 {Leo Lahti and Martin Sch{\"a}fer and Hans-Ulrich
-                  Klein and Silvio Bicciato and Martin Dugas},
-  title =	 {Cancer gene prioritization by integrative analysis
-                  of mRNA expression and DNA copy number data: a
-                  comparative review},
-  journal =	 {Briefings in Bioinformatics},
-  year =	 2013,
-  volume =	 14,
-  number =	 1,
-  month =	 6,
-  status =	 {bioscience},
-  authorship =	 {first, corresponding},
-  pdf =		 {papers/2013-Lahti-BriefBioinf.pdf},
-  category =	 {review},
-  pages =	 {27--35},
-  doi =		 {10.1093/bib/bbs005}
-}
-
-@Article{Lahti13provasI,
-  author =	 {Leo Lahti and Anne Salonen and Riina A. Kekkonen and
-                  Jarkko Salojärvi and Jonna Jalanka-Tuovinen and Airi
-                  Palva and Matej Orešič and Willem M. de Vos},
-  title =	 {Associations between the human intestinal
-                  microbiota, Lactobacillus rhamnosus GG and serum
-                  lipids indicated by integrated analysis of
-                  high-throughput profiling data},
-  journal =	 {PeerJ},
-  year =	 2013,
-  volume =	 1,
-  pages =	 {e32},
-  status =	 {bioscience},
-  authorship =	 {corresponding, shared first},
-  pdf =		 {papers/2013-Lahti-PeerJ.pdf},
-  doi =		 {10.7717/peerj.32},
-  note =	 {Highly accessed, featured in PeerJ journal blog and
-                  Top-10 Microbiology collection.},
-  pmid =	 23638368
-}
-
-@Article{Sarhadi13,
-  author =	 {Virinder Kaur Sarhadi and Leo Lahti and Ilari
-                  Scheinin and Anne Tyyb{\"a}kinoja and Suvi Savola
-                  and Anu Usvasalo and Riikka R{\"a}ty and Erkki
-                  Elonen and Pekka Ellonen and Ulla M Saarinen-Pihkala
-                  and Sakari Knuutila},
-  status =	 {bioscience},
-  title =	 {Targeted Resequencing of 9p in Acute Lymphoblastic
-                  Leukemia Yields Concordant Results with Array CGH
-                  and Reveals Novel Genomic Alterations},
-  journal =	 {Genomics},
-  pdf =		 {papers/2013-Sarhadi-Genomics.pdf},
-  year =	 2013,
-  volume =	 102,
-  month =	 9,
-  authorship =	 {shared first},
-  number =	 3,
-  pages =	 {182--188},
-  doi =		 {10.1016/j.ygeno.2013.01.001}
-}
-
-@Article{Mosakhani12LL,
-  author =	 {N Mosakhani and VK Sarhadi and A Usvasalo and ML
-                  Karjalainen-Lindsberg and L Lahti and K Tuononen and
-                  UM Saarinen-Pihkala and S Knuutila},
-  title =	 {MicroRNA profiling in pediatric acute lymphoblastic
-                  leukemia: novel prognostic tools},
-  journal =	 {Leukemia \& Lymphoma},
-  year =	 2012,
-  pdf =		 {papers/2012-Mosakhani-LL.pdf},
-  volume =	 53,
-  number =	 12,
-  pages =	 {2517-2520},
-  status =	 {bioscience},
-  month =	 {Dec},
-  doi =		 {10.3109/10428194.2012.685731}
-}
-
-@Article{Harris17,
-  author =	 {Keith Harris and Todd L Parsons and Umer Z Ijaz and
-                  Leo Lahti and Ian Holmes and Christopher Quince},
-  title =	 {Linking statistical and ecological theory: Hubbell's
-                  unified neutral theory of biodiversity as a
-                  hierarchical Dirichlet process},
-  journal =	 {Proceedings of the IEEE},
-  status =	 {bioscience},
-  keywords =	 {highlight},
-  year =	 2017,
-  volume =	 105,
-  number =	 3,
-  pages =	 {516--529},
-  pdf =		 {papers/2017-Harris-IEEE.pdf},
-  month =	 {March},
-  doi =		 {10.1109/JPROC.2015.2428213}
-}
-
-@Article{Alneberg14,
-  author =	 {Johannes Alneberg and Brynjar Smári Bjarnason and
-                  Ino de Bruijn and Melanie Schirmer and Joshua Quick
-                  and Umer Z Ijaz and Leo Lahti and Nicholas J Loman
-                  and Anders F Andersson and Christopher Quince},
-  title =	 {Binning metagenomic contigs by coverage and
-                  composition},
-  journal =	 {Nature Methods},
-  year =	 2014,
-  status =	 {bioscience},
-  keywords =	 {highlight},
-  volume =	 11,
-  number =	 {1144--1146},
-  pdf =		 {papers/2014-Alneberg-NatMeth.pdf},
-  note =	 {CONCOCT algorithm},
-  doi =		 {10.1038/nmeth.3103}
-}
-
-@Article{lahti14natcomm,
-  author =	 {Leo Lahti and Jarkko Saloj{\"a}rvi and Anne Salonen
-                  and Marten Scheffer and Willem M. de Vos},
-  title =	 {Tipping elements in the human intestinal ecosystem},
-  journal =	 {Nature Communications},
-  year =	 2014,
-  volume =	 5,
-  pages =	 4344,
-  pdf =		 {papers/2014-Lahti-NatComm.pdf},
-  month =	 7,
-  authorship =	 {first},
-  status =	 {bioscience},
-  keywords =	 {highlight},
-  doi =		 {10.1038/ncomms5344}
-}
-
-@Article{salonen14,
-  author =	 {Anne Salonen and Leo Lahti and Jarkko Saloj{\"a}rvi
-                  and Grietje Holtrop and Katri Korpela and Sylvia
-                  Duncan and Priya Date and Alexandra Johnstone and
-                  Gerald Lobley and Petra Louis and Harry Flint and
-                  Willem M. de Vos},
-  title =	 {Impact of diet and individual variation on
-                  intestinal microbiota composition and fermentation
-                  products in obese men},
-  journal =	 {ISME Journal},
-  year =	 2014,
-  status =	 {bioscience},
-  volume =	 8,
-  pdf =		 {papers/2014-Salonen-ISME.pdf},
-  authorship =	 {second},
-  pages =	 {2218--2230},
-  doi =		 {10.1038/ismej.2014.63}
-}
-
-@Article{bender13,
-  author =	 {Leo Lahti},
-  title =	 {Intestinal microbiota, individuality and health. In:
-                  Computational Methods Aiding Early-Stage Drug Design
-                  (Dagstuhl Seminar 13212)},
-  pages =	 {78--94},
-  journal =	 {Dagstuhl Reports},
-  ISSN =	 {2192-5283},
-  year =	 2013,
-  volume =	 3,
-  number =	 5,
-  category =	 {abstract},
-  status =	 {bioscience},
-  editor =	 {Andreas Bender and Hinrich G{\"o}hlmann and Sepp
-                  Hochreiter and Ziv Shkedy},
-  publisher =	 {Schloss Dagstuhl--Leibniz-Zentrum fuer Informatik},
-  address =	 {Dagstuhl, Germany},
-  URL =		 {http://drops.dagstuhl.de/opus/volltexte/2013/4179},
-  URN =		 {urn:nbn:de:0030-drops-41791},
-  doi =		 {10.4230/DagRep.3.5.78},
-  annote =	 {Keywords: Bioinformatics, Chemoinformatics, Machine
-                  learning, Statistics, Interdisciplinary
-                  applications. Short abstract for the Dagstuhl
-                  seminar.}
-}
-
-@article{Lahti11rpa,
-  author =	 {Leo Lahti and Laura L. Elo and Tero Aittokallio and
-                  Samuel Kaski},
-  title =	 {Probabilistic Analysis of Probe Reliability in
-                  Differential Gene Expression Studies with Short
-                  Oligonucleotide Arrays},
-  journal =	 {IEEE/ACM Transactions on Computational Biology and
-                  Bioinformatics},
-  year =	 2011,
-  volume =	 8,
-  number =	 1,
-  pages =	 {217--225},
-  month =	 {Jan.-Mar.},
-  status =	 {bioscience},
-  authorship =	 {first, corresponding},
-  doi =		 {10.1109/TCBB.2009.38},
-  pdf =		 {papers/2011-Lahti-TCBB.pdf},
-  publisher =	 {IEEE Computer Society},
-  address =	 {Los Alamitos, CA, USA},
-  annote =	 {R/Bioconductor: RPA}
-}
-
-@Misc{Lahti11-louhos,
-  author =	 {Leo Lahti and Joona Lehtomäki and Juuso Parkkinen
-                  and others},
-  title =	 {Louhos blog},
-  status =	 {blog},
-  url =		 {http://louhos.github.io/},
-  note =	 {Open government data analytics blog (in Finnish)}
-}
-
-@Misc{Lahti13-ropengov,
-  author =	 {Leo Lahti and Joona Lehtomäki and Markus Kainu and
-                  Juuso Parkkinen and others},
-  title =	 {rOpenGov blog},
-  status =	 {blog},
-  url =		 {http://ropengov.github.io/},
-  note =	 {Open government data analytics blog}
-}
-
-@Misc{Lahti11intcomp,
-  author =	 {Leo Lahti and Martin Schäfer and Hans-Ulrich Klein
-                  and Silvio Bicciato and Martin Dugas},
-  title =	 {intcomp: a benchmarking pipeline for integrative
-                  cancer gene detection algorithms},
-  howpublished = {software},
-  status =	 {bioscience},
-  month =	 2,
-  year =	 2011,
-  url =		 {http://intcomp.r-forge.r-project.org/},
-  note =	 {R-forge}
-}
-
-@Article{Jalanka-Tuovinen11,
-  author =	 {Jonna Jalanka-Tuovinen and Anne Salonen and Janne
-                  Nikkil{\"a} and Outi Immonen and Riina Kekkonen and
-                  Leo Lahti and Airi Palva and Willem M. de Vos},
-  title =	 {Intestinal microbiota in healthy adults: Temporal
-                  analysis reveals individual and common core and
-                  relation to intestinal symptoms},
-  journal =	 {PLoS One},
-  year =	 2011,
-  volume =	 6,
-  status =	 {bioscience},
-  number =	 7,
-  month =	 7,
-  pages =	 {e23035},
-  url =		 {10.1371/journal.pone.0023035},
-  pdf =		 {papers/2011-JalankaTuovinen-PLoS.pdf},
-}
-
-@article{Louhimo14,
-  author =	 {Riku Louhimo and Viljami Aittom{\"a}ki and Ali
-                  Faisal and Marko Laakso and Ping Chen and Kristian
-                  Ovaska and Erkka Valo and Leo Lahti and Vladimir
-                  Rogojin and Samuel Kaski and Sampsa Hautaniemi.},
-  journal =	 {Systems Biomedicine (special issue)},
-  volume =	 1,
-  issue =	 2,
-  pages =	 {130--136},
-  status =	 {bioscience},
-  title =	 {Systematic Use of Computational Methods Allows
-                  Stratifying Treatment Responders in Glioblastoma
-                  Multiforme},
-  note =	 {Critical Assessment of Massive Data Analysis (CAMDA)
-                  workshop},
-  year =	 2014,
-  month =	 4,
-  pdf =		 {papers/2014-Louhimo.pdf},
-  doi =		 {10.4161/sysb.28904}
+@misc{Lahti11intcomp,
+	title        = {intcomp: a benchmarking pipeline for integrative cancer gene detection algorithms},
+	author       = {Leo Lahti and Martin Schäfer and Hans-Ulrich Klein and Silvio Bicciato and Martin Dugas},
+	year         = 2011,
+	month        = 2,
+	url          = {http://intcomp.r-forge.r-project.org/},
+	note         = {R-forge},
+	howpublished = {software},
+	keywords     = {bioscience}
 }
 
 @misc{Lahti11ismb,
-  author =	 {Leo Lahti and Samuel Kaski},
-  title =	 {Probabilistic dependency models for data integration
-                  in functional genomics},
-  category =	 {abstract},
-  authorship =	 {first, corresponding},
-  status =	 {bioscience},
-  pdf =		 {papers/2011-MLSB-Lahti.pdf},
-  month =	 {July},
-  year =	 2011,
-  note =	 {Machine Learning for Systems Biology workshop, ISMB,
-                  Vienna, Austria}
+	title        = {Probabilistic dependency models for data integration in functional genomics},
+	author       = {Leo Lahti and Samuel Kaski},
+	year         = 2011,
+	month        = {July},
+	category     = {abstract},
+	note         = {Machine Learning for Systems Biology workshop, ISMB, Vienna, Austria},
+	authorship   = {first, corresponding},
+	keywords     = {bioscience},
+	url          = {https://github.com/openresearchlabs/openresearchlabs.github.io/blob/master/content/publication_resources/papers/2011-MLSB-Lahti.pdf}
 }
 
-@Article{Nymark11,
-  author =	 {Penny Nymark and Mohamed Guled and Ioana Borze and
-                  Ali Faisal and Leo Lahti and Kaisa Salmenkivi and
-                  Eeva Kettunen and Sisko Anttila and Sakari Knuutila},
-  title =	 {Integrative Analysis of microRNA, mRNA and aCGH Data
-                  Reveals Asbestos- and Histology-Related Changes in
-                  Lung Cancer},
-  journal =	 {Genes, Chromosomes and Cancer},
-  pdf =		 {papers/2011-Nymark-GCC.pdf},
-  year =	 2011,
-  volume =	 50,
-  number =	 8,
-  pages =	 {585--597},
-  month =	 8,
-  status =	 {bioscience},
-  doi =		 {10.1002/gcc.20880}
+@article{Lahti11rpa,
+	title        = {Probabilistic Analysis of Probe Reliability in Differential Gene Expression Studies with Short Oligonucleotide Arrays},
+	author       = {Leo Lahti and Laura L. Elo and Tero Aittokallio and Samuel Kaski},
+	year         = 2011,
+	month        = {Jan.-Mar.},
+	journal      = {IEEE/ACM Transactions on Computational Biology and Bioinformatics},
+	publisher    = {IEEE Computer Society},
+	address      = {Los Alamitos, CA, USA},
+	volume       = 8,
+	number       = 1,
+	pages        = {217--225},
+	doi          = {10.1109/TCBB.2009.38},
+	keywords     = {bioscience},
+	authorship   = {first, corresponding},
+	url          = {https://github.com/openresearchlabs/openresearchlabs.github.io/blob/master/content/publication_resources/papers/2011-Lahti-TCBB.pdf},
+	annote       = {R/Bioconductor: RPA}
 }
 
-@Article{Niini11mfh,
-  author =	 {Tarja Niini and Leo Lahti and Francesca Michelacci
-                  and Shinsuke Ninomiya and Claudia Maria Hattinger
-                  and Mohamed Guled and Tom B{\"o}hling and Piero
-                  Picci and Massimo Serra and Sakari Knuutila},
-  title =	 {Array Comparative Genomic Hybridization Reveals
-                  Frequent Alterations of G1/S Checkpoint Genes in
-                  Undifferentiated Pleomorphic Sarcoma of Bone},
-  journal =	 {Genes, Chromosomes and Cancer},
-  year =	 2011,
-  authorship =	 {second},
-  pdf =		 {papers/2011-Niini-GCC.pdf},
-  volume =	 50,
-  number =	 5,
-  month =	 5,
-  pages =	 {291--306},
-  status =	 {bioscience},
-  doi =		 {10.1002/gcc.20851}
+@article{Lahti12cmi,
+	title        = {The adult intestinal core microbiota is determined by analysis depth and health status},
+	author       = {Anne Salonen and Jarkko Saloj{\"a}rvi and Leo Lahti and and Willem M. de Vos},
+	year         = 2012,
+	journal      = {Clinical Microbiology and Infection},
+	volume       = 18,
+	number       = {Suppl. 4},
+	pages        = {16–20},
+	doi          = {10.1111/j.1469-0691.2012.03855.x},
+	keywords     = {bioscience},
+	url          = {https://github.com/openresearchlabs/openresearchlabs.github.io/blob/master/content/publication_resources/papers/2012-Salonen-CMI.pdf}
 }
 
-@article{Elo05,
-  author =	 {Elo, Laura L. and Lahti, Leo and Skottman, Heli and
-                  Kyl{\"a}niemi, Minna and Lahesmaa, Riitta and
-                  Aittokallio, Tero},
-  title =	 {Integrating probe-level expression changes across
-                  generations of Affymetrix arrays},
-  journal =	 {Nucleic Acids Research},
-  volume =	 33,
-  number =	 22,
-  pages =	 {e193},
-  month =	 12,
-  authorship =	 {second},
-  status =	 {bioscience},
-  doi =		 {10.1093/nar/gni193},
-  pdf =		 {papers/2005-Elo-NAR.pdf},
-  year =	 2005
+@misc{Lahti13-ropengov,
+	title        = {rOpenGov blog},
+	author       = {Leo Lahti and Joona Lehtomäki and Markus Kainu and Juuso Parkkinen and others},
+	url          = {http://ropengov.github.io/},
+	note         = {Open government data analytics blog},
+	keywords       = {blog}
 }
 
-@Article{Kaski05,
-  author =	 {Samuel Kaski and Janne Nikkil{\"a} and Janne
-                  Sinkkonen and Leo Lahti and Juha Knuuttila and
-                  Christophe Roos},
-  title =	 {Associative clustering for exploring dependencies
-                  between functional genomics data sets},
-  journal =	 {IEEE/ACM Transactions on Computational Biology and
-                  Bioinformatics},
-  year =	 2005,
-  volume =	 2,
-  number =	 3,
-  pages =	 {203--216},
-  month =	 {September},
-  status =	 {datascience},
-  note =	 {Special Issue on Machine Learning for Bioinformatics
-                  -- Part 2},
-  doi =		 {10.1109/TCBB.2005.32},
-  pdf =		 {papers/2005-TCBB–Kaski-AC.pdf}
+@misc{Lahti13icml,
+	title        = {rOpenGov: open source ecosystem for computational social sciences and digital humanities},
+	author       = {Leo Lahti, Juuso Parkkinen, Joona Lehtomäki and Markus Kainu},
+	year         = 2013,
+	month        = 12,
+	url          = {http://ropengov.github.io},
+	category     = {abstract},
+	note         = {ICML/MLOSS workshop (Int'l Conf. on Machine Learning - Open Source Software workshop).},
+	keywords     = {dh},
+	howpublished = {software},
+	keywords       = {datascience}
 }
 
-@MastersThesis{Lahti03,
-  author =	 {Lahti, Leo},
-  title =	 {Comparative functional genome analysis using
-                  associative clustering},
-  school =	 {Helsinki University of Technology},
-  year =	 2003,
-  month =	 12,
-  language =	 {Finnish},
-  url =
-                  {https://github.com/antagomir/thesis/tree/master/msc03},
-  pdf =
-                  {https://github.com/antagomir/thesis/blob/master/msc03/dtyo.pdf},
-  category =	 {thesis},
-  note =	 {(in Finnish)}
+@article{Lahti13nar,
+	title        = {A fully scalable online pre-processing algorithm for short oligonucleotide microarray atlases},
+	author       = {Leo Lahti and Aurora Torrente and Laura L Elo and Alvis Brazma and Johan Rung},
+	year         = 2013,
+	journal      = {Nucleic Acids Research},
+	volume       = 41,
+	number       = 10,
+	pages        = {e110},
+	doi          = {10.1093/nar/gkt229},
+	note         = {Implementation available through Bioconductor RPA package.},
+	url          = {https://github.com/openresearchlabs/openresearchlabs.github.io/blob/master/content/publication_resources/papers/2013-Lahti-NAR.pdf},
+	authorship   = {first, corresponding},
+	keywords = {bioscience}
 }
 
-@Misc{Lahti09bsc,
-  author =	 {Leo Lahti},
-  title =	 {Concerning Blackburn's quasi-realism in securing
-                  moral discussion},
-  howpublished = {B.Sc. thesis. University of Helsinki, Faculty of
-                  Political Sciences},
-  month =	 7,
-  year =	 2009,
-  language =	 {Finnish},
-  category =	 {thesis},
-  pdf =		 {theses/LeoLahti-BSc-2008.pdf},
-  note =	 {(In Finnish)}
+@article{Lahti13provasI,
+	title        = {Associations between the human intestinal microbiota, Lactobacillus rhamnosus GG and serum lipids indicated by integrated analysis of high-throughput profiling data},
+	author       = {Leo Lahti and Anne Salonen and Riina A. Kekkonen and Jarkko Salojärvi and Jonna Jalanka-Tuovinen and Airi Palva and Matej Orešič and Willem M. de Vos},
+	year         = 2013,
+	journal      = {PeerJ},
+	volume       = 1,
+	pages        = {e32},
+	doi          = {10.7717/peerj.32},
+	note         = {Highly accessed, featured in PeerJ journal blog and Top-10 Microbiology collection.},
+	keywords     = {bioscience},
+	authorship   = {corresponding, shared first},
+	url          = {https://github.com/openresearchlabs/openresearchlabs.github.io/blob/master/content/publication_resources/papers/2013-Lahti-PeerJ.pdf},
+	pmid         = 23638368
 }
 
-@Article{Nymark07,
-  author =	 {Penny Nymark and Pamela M. Lindholm and Mikko
-                  V. Korpela and Leo Lahti and Salla Ruosaari and
-                  Samuel Kaski and Jaakko Hollmen and Sisko Anttila
-                  and Vuokko L. Kinnula and Sakari Knuutila},
-  title =	 {Gene Expression Profiles in Asbestos-exposed
-                  Epithelial and Mesothelial Lung Cell Lines},
-  journal =	 {BMC Genomics},
-  year =	 2007,
-  month =	 3,
-  volume =	 8,
-  number =	 62,
-  status =	 {bioscience},
-  doi =		 {10.1186/1471-2164-8-62},
-  annote =	 {CCA on two asbestos-exposed cell lines.}
-}
-
-@TechReport{Sinkkonen05tr,
-  author =	 {Janne Sinkkonen and Samuel Kaski and Janne
-                  Nikkil{\"a} and Leo Lahti},
-  title =	 {Associative Clustering (AC): Technical Details},
-  institution =	 {Helsinki University of Technology},
-  year =	 2005,
-  number =	 {A84},
-  address =	 {Espoo, Finland},
-  month =	 {April},
-  status =	 {datascience},
-  pdf =		 {papers/2005-TechRep-Sinkkonen-ACtechdetails.pdf},
-  note =	 {Publications in Computer and Information Science}
-}
-
-@InCollection{Sinkkonen04ecml,
-  author =	 {Janne Sinkkonen and Janne Nikkil\"{a} and Leo Lahti
-                  and Samuel Kaski},
-  title =	 {Associative Clustering},
-  booktitle =	 {Proceedings of the ECML'04, 15th European Conference
-                  on Machine Learning},
-  editor =	 {Boulicaut and Esposito and Giannotti and Pedreschi},
-  pages =	 {396--406},
-  publisher =	 {Springer},
-  address =	 {Berlin},
-  category =	 {abstract},
-  status =	 {datascience},
-  year =	 2004,
-  url =
-                  {http://www.cis.hut.fi/projects/mi/abstracts/ecml04.html},
-  pdf =		 {papers/2004-ECML-Sinkkonen-AC.pdf}
-}
-
-@TechReport{Sinkkonen03tr,
-  author =	 {Janne Sinkkonen and Janne Nikkil\"{a} and Leo Lahti
-                  and Samuel Kaski},
-  title =	 {Associative Clustering by Maximizing a {B}ayes
-                  Factor},
-  institution =	 {Helsinki University of Technology and Laboratory of
-                  Computer and Information Science},
-  year =	 2003,
-  month =	 6,
-  number =	 {A68},
-  pdf =		 {papers/2003-TechRep-Sinkkonen-ACBayesFactor.pdf},
-  address =	 {Espoo, Finland}
+@article{Lahti15LIBER,
+	title        = {A quantitative study of history in the English short-title catalogue (ESTC) 1470-1800},
+	author       = {Leo Lahti and Niko Ilom{\"a}ki and Mikko Tolonen},
+	year         = 2015,
+	month        = 12,
+	journal      = {LIBER Quarterly},
+	volume       = 25,
+	number       = 2,
+	pages        = {87--116},
+	doi          = {10.18352/lq.10112},
+	issn         = {2213-056X},
+	status       = {dh},
+	authorship   = {first},
+	url          = {https://github.com/openresearchlabs/openresearchlabs.github.io/blob/master/content/publication_resources/papers/2015-Lahti-LIBERQuarterly.pdf},
+	keywords     = {dh}
 }
 
 @article{Lahti17eurostat,
-  author =	 {Leo Lahti and Janne Huovari and Markus Kainu and
-                  Przemysław Biecek},
-  title =	 {Retrieval and Analysis of Eurostat Open Data with
-                  the eurostat Package},
-  year =	 2017,
-  journal =	 {The R Journal},
+	title        = {Retrieval and Analysis of Eurostat Open Data with the eurostat Package},
+	author       = {Leo Lahti and Janne Huovari and Markus Kainu and Przemysław Biecek},
+	year         = 2017,
+	journal      = {The R Journal},
+	volume       = 9,
+	number       = 1,
+	pages        = {385--392},
+	url          = {https://journal.r-project.org/archive/2017/RJ-2017-019/index.html},
+	keywords     = {dh},
+	software     = {yes},
+	url          = {https://github.com/openresearchlabs/openresearchlabs.github.io/blob/master/content/publication_resources/papers/2017-Lahti-RJournal.pdf},
+	authorship   = {first, corresponding},
+	annote       = {R package homepage URL: http://ropengov.github.io/eurostat/}
+}
+
+@article{Lahti17phos,
+	title        = {Alchemy & algorithms: perspectives on the philosophy and history of open science},
+	author       = {Leo Lahti and Filipe da Silva and Markus Petteri Laine and Viivi Lähteenoja and Mikko Tolonen},
+	year         = 2017,
+	month        = {May},
+	journal      = {RIO Journal},
+	volume       = 3,
+	pages        = {e13593},
+	doi          = {10.3897/rio.3.e13593},
+	category     = {perspective},
+	note         = {Review of the international conference, including electronic material (video interviews, lectures and podcasts.},
+	authorship   = {first, corresponding},
+	keywords     = {openscience},
+	status       = {openscience},
+	url          = {https://github.com/openresearchlabs/openresearchlabs.github.io/blob/master/content/publication_resources/papers/2017-Lahti-PHOS.pdf},
+	keywords     = {dh}
+}
+
+@misc{Lahti2001,
+	title        = {Julian joukko iteraatioden valuma-altaan reunana},
+	author       = {Leo Lahti},
+	year         = 2001,
+	url          = {https://github.com/antagomir/thesis/tree/master/julia01},
+	category     = {thesis},
+	note         = {Special assignment in Mathematics (in Finnish)},
+	keywords       = {thesis},
+	language     = {Finnish}
+}
+
+@misc{Lahti2002,
+	title        = {Itsesimilaaristen joukkojen Hausdorffin dimension määrittäminen},
+	author       = {Leo Lahti},
+	year         = 2002,
+	url          = {https://github.com/antagomir/thesis/tree/master/hausdorff02},
+	category     = {thesis},
+	keywords       = {thesis},	
+	note         = {Special assignment in Mathematics (in Finnish)},
+	language     = {Finnish}
+}
+
+@misc{Lahti2006biopax,
+	title        = {A brief overview on the BioPAX and SBML standards},
+	author       = {Leo Lahti},
+	year         = 2007,
+	url          = {https://arxiv.org/abs/1109.4919},
+	category     = {thesis},
+	note         = {Overview of machine-readable representations of biological processes.},
+	note         = {(in Finnish)},
+	howpublished = {arXiv},
+	authorship   = {first},
+	keywords     = {bioscience},
+	arxiv        = {arXiv:1109.4919 [cs.DS]},
+	language     = {Finnish}
+}
+
+@article{Lahti2012intcomp,
+	title        = {Cancer gene prioritization by integrative analysis of mRNA expression and DNA copy number data: a comparative review},
+	author       = {Leo Lahti and Martin Sch{\"a}fer and Hans-Ulrich Klein and Silvio Bicciato and Martin Dugas},
+	year         = 2013,
+	month        = 6,
+	journal      = {Briefings in Bioinformatics},
+	volume       = 14,
+	number       = 1,
+	pages        = {27--35},
+	doi          = {10.1093/bib/bbs005},
+	category     = {review},
+	keywords     = {bioscience},
+	authorship   = {first, corresponding},
+	url          = {https://github.com/openresearchlabs/openresearchlabs.github.io/blob/master/content/publication_resources/papers/2013-Lahti-BriefBioinf.pdf}
+}
+
+@inproceedings{Lahti2018IDA,
+	title        = {Open Data Science},
+	author       = {Lahti, Leo},
+	year         = 2018,
+	month        = {October},
+	booktitle    = {Advances in Intelligent Data Analysis XVII. Lecture Notes in Computer Science 11191.},
+	publisher    = {Springer},
+	publisher    = {Springer Nature},
+	address      = {India},
+	volume       = 11191,
+	category     = {perspective},
+	note         = {Conference proceedings.},
+	keywords     = {openscience},
+	authorship   = {first},
+	url          = {https://github.com/openresearchlabs/openresearchlabs.github.io/blob/devel/publications/https://github.com/openresearchlabs/openresearchlabs.github.io/blob/master/content/publication_resources/papers/2018-Lahti-IDA.pdf}
+}
+
+@article{Lahti2019bds,
+	title        = {Bibliographic Data Science and the History of the Book (c. 1500–1800)},
+	author       = {Leo Lahti and Jani Marjanen and Hege Roivainen and Mikko Tolonen},
+	year         = 2019,
+	month        = {January},
+	journal      = {Cataloging \& Classification Quarterly},
+	publisher    = {Routledge},
+	volume       = 57,
+	number       = 1,
+	pages        = {5--23},
+	doi          = {10.1080/01639374.2018.1543747},
+	note         = {Special issue.},
+	url          = {https://github.com/openresearchlabs/openresearchlabs.github.io/blob/master/content/publication_resources/papers/2019-Lahti-CCQ.pdf},
+	keywords       = {dh}
+}
+
+@inproceedings{Lahti2019rdhum,
+	title        = {Best practices in bibliographic data science},
+	author       = {Leo Lahti and Ville Vaara and Jani Marjanen and Mikko Tolonen},
+	year         = 2019,
+	month        = {August},
+	booktitle    = {Proceedings of the Research Data in the Humanities Conference},
+	address      = {Oulu},
+	url          = {https://github.com/openresearchlabs/openresearchlabs.github.io/blob/master/content/publication_resources/papers/2019-Lahti-RDHUM.pdf},
+	keywords     = {dh}
+}
+
+@inproceedings{Lahti2020chr,
+	title        = {Quantifying bias and uncertainty in historical data collections with probabilistic programming},
+	author       = {Leo Lahti and Eetu Mäkelä and Mikko Tolonen},
+	year         = 2020,
+	month        = {Nov},
+	booktitle    = {{Proc. CEUR Workshop Proceedings on Computational Humanities Research}},
+	pages        = {80--89},
+	keywords     = {dh},	
+	url          = {http://ceur-ws.org/Vol-2723/short46.pdf}
+}
+
+
+
+@article{Lahti2020hs1,
+	title        = {Laskentamallit eivät lähtökohtaisesti ole salassa pidettävää tietoa},
+	author       = {Leo Lahti and Thomas Wallgren and Markku Kulmala},
+	year         = 2020,
+	month        = {May},
+	journal      = {HS Mielipide},
+	url          = {https://www.hs.fi/mielipide/art-2000006494641.html},
+	keywords       = {opinion}			
+}
+@article{Lahti2020hs2,
+	title        = {Lähdekoodin sisältämien yksityiskohtien avoimuus on keskeistä päätöksenteon läpinäkyvyydelle.},
+	author       = {Leo Lahti},
+	year         = 2020,
+	month        = {June},
+	journal      = {HS Mielipide},
+	url          = {https://www.hs.fi/mielipide/art-2000006545770.html},
+	keywords       = {opinion}
+}
+
+
+
+@article{Lahti2020okf1,
+	title        = {Tietopyyntö epidemialaskelmien lähdekoodeista},
+	author       = {Leo Lahti and Tarmo Toikkanen},
+	year         = 2020,
+	month        = {May},
+	journal      = {Open Knowledge Finland Blog},
+	url          = {https://www.okf.fi/fi/2020/05/13/tietopyynto-thln-epidemialaskelmien-lahdekoodeista},
+	keywords       = {opinion}		
+
+}
+
+@article{Lahti2020okf2,
+	title        = {Päätös epidemialaskelmien salaamisesta vastoin valtioneuvoston avoimuuslinjausta},
+	author       = {Leo Lahti},
+	year         = 2020,
+	month        = {June},
+	journal      = {Open Knowledge Finland Blog},
+	url          = {https://www.okf.fi/fi/2020/06/15/thln-paatos-epidemialaskelmien-salaamisesta-vastoin-valtioneuvoston-avoimuuslinjausta/},
+	keywords       = {opinion}	
+}
+
+
+
+@article{Lahti2020thinkopen,
+  title =	 {Avoimuus voi vahvistaa päätöksenteon tieteellistä
+                  pohjaa},
+  author =	 {Leo Lahti},
+  year =	 2020,
+  month =	 {August},
+  journal =	 {University of Helsinki, ThinkOpen blog},
+  keywords =	 {opinion},
   url =
-                  {https://journal.r-project.org/archive/2017/RJ-2017-019/index.html},
-  pages =	 {385--392},
+                  {https://blogs.helsinki.fi/thinkopen/lahdekoodin-avoimuus-paatoksenteossa/}
+}
+
+
+@article{Lahti2021bioc,
+	title        = {Microbiome data science in the {\it SummarizedExperiment} universe},
+	author       = {Leo Lahti and Felix G.M. Ernst and Sudarshan A. Shetty and others},
+	year         = 2021,
+	journal      = {F1000Research},
+	volume       = 10,
+	number       = 748,
+	doi          = {10.7490/f1000research.1118712.1},
+	note         = {(slides); version 1; not peer reviewed},
+	keywords = {bioscience}
+}
+
+
+@inproceedings{Laine15,
+	title        = {Beyond Open Access - The Changing Culture of Producing and Disseminating Scientific Knowledge},
+	author       = {Heidi Laine and Leo Lahti and Anne Lehto and Samuli Ollila and Markus Miettinen},
+	year         = 2015,
+	booktitle    = {Proceedings of the 19th International Academic Mindtrek Conference in Tampere, Finland, September 22-24},
+	location     = {Tampere, Finland},
+	publisher    = {ACM},
+	address      = {ACM New York, NY, USA},
+	address      = {New York, NY, USA},
+	isbn         = {978-1-4503-3948-3},
+	url          = {http://dl.acm.org/citation.cfm?id=2818187},
+	organization = {AcademicMindTrek'15: Proceedings of the 19th International Academic Mindtrek Conference},
+	authorship   = {second},
+	keywords     = {openscience},
+	url          = {https://github.com/openresearchlabs/openresearchlabs.github.io/blob/master/content/publication_resources/papers/2015-Laine-Mindtrek.pdf}
+}
+
+@inproceedings{Laitinen2018IDA,
+	title        = {A hierarchical Ornstein-Uhlenbeck model for stochastic time series analysis},
+	author       = {Laitinen, Ville and Lahti, Leo},
+	year         = 2018,
+	month        = {October},
+	booktitle    = {Advances in Intelligent Data Analysis XVII. Lecture Notes in Computer Science 11191.},
+	publisher    = {Springer},
+	address      = {India},
+	url          = {https://github.com/velait/OUP},
+	note         = {Conference proceedings.},
+	keywords       = {datascience},
+	authorship   = {pi},
+	url          = {https://github.com/openresearchlabs/openresearchlabs.github.io/blob/master/content/publication_resources/papers/2018-Laitinen-IDA.pdf}
+}
+
+
+@article{Louhimo14,
+	title        = {Systematic Use of Computational Methods Allows Stratifying Treatment Responders in Glioblastoma Multiforme},
+	author       = {Riku Louhimo and Viljami Aittom{\"a}ki and Ali Faisal and Marko Laakso and Ping Chen and Kristian Ovaska and Erkka Valo and Leo Lahti and Vladimir Rogojin and Samuel Kaski and Sampsa Hautaniemi.},
+	year         = 2014,
+	month        = 4,
+	journal      = {Systems Biomedicine (special issue)},
+	volume       = 1,
+	pages        = {130--136},
+	doi          = {10.4161/sysb.28904},
+	note         = {Critical Assessment of Massive Data Analysis (CAMDA) workshop},
+	issue        = 2,
+	keywords     = {bioscience},
+	url          = {https://github.com/openresearchlabs/openresearchlabs.github.io/blob/master/content/publication_resources/papers/2014-Louhimo.pdf}
+}
+
+@inproceedings{Makela2019dhn,
+	title        = {Interdisciplinary collaboration in studying newspaper materiality},
+	author       = {Eetu M{\"a}kel{\"a} and Mikko Tolonen and Jani Marjanen and Antti Kanner and Ville Vaara and Leo Lahti},
+	year         = 2019,
+	month        = {March},
+	booktitle    = {Proc. Twin Talks workshop. Digital Humanities in the Nordic Countries},
+	address      = {Copenhagen},
+	series       = {CEUR Workshop Proceedings},
+	volume       = 2365,
+	pages        = {55--66},
+	url          = {http://ceur-ws.org/Vol-2365/07-TwinTalks-DHN2019_paper_7.pdf},
+	editor       = {Steven Krauwer and Darja Fišer},
+	status       = {dh},
+	keywords     = {dh},
+	url          = {https://github.com/openresearchlabs/openresearchlabs.github.io/blob/master/content/publication_resources/papers/2019-Makela-DHN.pdf}
+}
+
+@inproceedings{Makela2020,
+	title        = {Wrangling with Non-Standard Data},
+	author       = {Eetu, M and Lagus, K and Lahti, L and Säily, T and Tolonen, M and Hämäläinen, M and Kaislaniemi, S and Nevalainen, T},
+	year         = 2020,
+	month        = {March},
+	booktitle    = {Proc. Digital Humanities in the Nordic Countries},
+	series       = {CEUR Workshop Proceedings},
+	volume       = 2612,
+	pages        = {81--96},
+	editor       = {Sanita Reinsone and Inguna Skadiņa and Anda Baklāne and Jānis Daugavietis},
+	url          = {https://github.com/openresearchlabs/openresearchlabs.github.io/blob/master/content/publication_resources/papers/2020-Makela-DHN.pdf},
+	keywords       = {dh}
+}
+
+@misc{Makela2021hs,
+  author =	 {Eetu Mäkelä and Leo Lahti and Johanna Lilja and
+                  Pekka Heikkinen},
+  title =	 {Laki estää tehokkaiden tutkimusmenetelmien käytön},
+  howpublished = {HS Mielipide},
+  month =	 {October},
+  year =	 2021,
+  url =
+                  {https://www.hs.fi/mielipide/art-2000008325656.html?share=6421b425ce95dfc19d87511d90f6d3c4},
+  keywords =	 {opinion}
+}
+
+@article{MarcosZambrano2021,
+	title        = {Applications of Machine Learning in Human Microbiome Studies: A Review on Feature Selection, Biomarker Identification, Disease Prediction and Treatment},
+	author       = {Marcos-Zambrano, Laura Judith and Karaduzovic-Hadziabdic, Kanita and Loncar Turukalo, Tatjana and Przymus, Piotr and Trajkovik, Vladimir and Aasmets, Oliver and Berland, Magali and Gruca, Aleksandra and Hasic, Jasminka and Hron, Karel and Klammsteiner, Thomas and Kolev, Mikhail and Lahti, Leo and Lopes, Marta B and Moreno, Victor and Naskinova, Irina and Org, Elin and Paciência, Inês and Papoutsoglou, Georgios and Shigdel, Rajesh and Stres, Blaz and Vilne, Baiba and Yousef, Malik and Zdravevski, Eftim and Tsamarindos, Ioannis and Carrillo de Santa Pau, Enrique and Claesson, Marcus J. and Moreno-Indias, Isabel and Truu, Jaak},
+	year         = 2021,
+	journal      = {Frontiers in Microbiology},
+	volume       = 12,
+	pages        = 313,
+	doi          = {10.3389/fmicb.2021.634511},
+	issn         = {1664-302X},
+	url          = {https://www.frontiersin.org/article/10.3389/fmicb.2021.634511},
+	keywords     = {bioscience}
+}
+
+
+
+@article{Marjanen2019,
+	title        = {A National Public Sphere? Analyzing the Language, Location, and Form of Newspapers in Finland, 1771–1917},
+	author       = {Jani Marjanen and Ville Vaara and Antti Kanner and Hege Roivainen and Eetu Mäkelä and Leo Lahti and Mikko Tolonen},
+	year         = 2019,
+	month        = {June},
+	journal      = {Journal of European Periodical Studies},
+	volume       = 4,
+	number       = 1,
+	doi          = {10.21825/jeps.v4i1.10483},
+	url          = {https://ojs.ugent.be/jeps/article/view/10483},
+	note         = {Special issue: Digital Approaches Towards Serial Publications},
+	url          = {https://github.com/openresearchlabs/openresearchlabs.github.io/blob/master/content/publication_resources/papers/2019-Marjanen-JEPS.pdf},
+	status       = {dh},
+	keywords     = {dh}
+}
+
+@article{MorenoIndias2021,
+	title        = {Statistical and machine learning techniques in human microbiome studies: contemporary challenges and solutions},
+	author       = {Isabel Moreno-Indias and Leo Lahti and Miroslava Nedyalkova and Ilze Elbere and Gennady V. Roshchupkin and Muhamed Adilovic and Onder Aydemir and Burcu Bakir-Gungor and Enrique Carrillo-de Santa Pau and Domenica D'Elia and Magesh S. Desai and Laurent Falquet and Aycan Gundogdu and Karel Hron and Thomas Klammsteiner and Marta B. Lopes and Laura J. Marcos Zambrano and Cláudia Marques and Michael Mason and Patrick May and Lejla Pašić and Gianvito Pio and Sándor Pongor and Vasilis J. Promponas and Piotr Przymus and Julio Sáez-Rodríguez and Alexia Sampri and Rajesh Shigdel and Blaz Stres and Ramona Suharoschi and Jaak Truu and Ciprian-Octavian Truică and Baiba Vilne and Dimitrios P. Vlachakis and Ercüment Yılmaz and Georg Zeller and Aldert Zomer and David Gómez-Cabrero and Marcus Claesson},
+	year         = 2021,
+	month        = {February},
+	journal      = {Frontiers in Microbiology},
+	volume       = 12,
+	pages        = 277,
+	doi          = {10.3389/fmicb.2021.635781},
+	keywords     = {bioscience}
+}
+
+
+@article{Mosakhani10,
+	title        = {Unique microRNA profile in Dupuytren's contracture supports deregulation of beta-catenin pathway},
+	author       = {Neda Mosakhani and Mohamed Guled and Leo Lahti and Ioana Borze and Minna Forsman and Jorma Ryh{\"a}nen and Sakari Knuutila},
+	year         = 2010,
+	month        = 11,
+	journal      = {Modern Pathology},
+	volume       = 23,
+	pages        = {1544--1522},
+	doi          = {10.1038/modpathol.2010.146},
+	note         = {International Dupuytren Award for best research paper in 2011},
+	url          = {https://github.com/openresearchlabs/openresearchlabs.github.io/blob/master/content/publication_resources/papers/2010-ModernPathology-Mosakhani-Dupuytre.pdf},
+		keywords     = {bioscience}
+}
+
+@article{Mosakhani12,
+	title        = {MicroRNA profiling predicts survival in anti-EGFR treated chemorefractory metastatic colorectal cancer patients with wild-type KRAS and BRAF},
+	author       = {Neda Mosakhani and Leo Lahti and Ioana Borze and Marja-Liisa Karjalainen-Lindsberg and Jari Sundstrom and Raija Ristamaki and Pia Osterlund and Sakari Knuutila and and Virinder Kaur Sarhadi},
+	year         = 2012,
+	month        = 11,
+	journal      = {Cancer Genetics},
+	volume       = 205,
+	number       = 11,
+	pages        = {545--51},
+	doi          = {10.1016/j.cancergen.2012.08.003},
+	keywords     = {bioscience},
+	url          = {https://github.com/openresearchlabs/openresearchlabs.github.io/blob/master/content/publication_resources/papers/2012-Mosakhani-CG.pdf},
+	authorship   = {second}
+}
+@article{Mosakhani12LL,
+	title        = {MicroRNA profiling in pediatric acute lymphoblastic leukemia: novel prognostic tools},
+	author       = {N Mosakhani and VK Sarhadi and A Usvasalo and ML Karjalainen-Lindsberg and L Lahti and K Tuononen and UM Saarinen-Pihkala and S Knuutila},
+	year         = 2012,
+	month        = {Dec},
+	journal      = {Leukemia \& Lymphoma},
+	volume       = 53,
+	number       = 12,
+	pages        = {2517--2520},
+	doi          = {10.3109/10428194.2012.685731},
+	url          = {https://github.com/openresearchlabs/openresearchlabs.github.io/blob/master/content/publication_resources/papers/2012-Mosakhani-LL.pdf},
+	keywords     = {bioscience}
+}
+
+@article{Niini11mfh,
+	title        = {Array Comparative Genomic Hybridization Reveals Frequent Alterations of G1/S Checkpoint Genes in Undifferentiated Pleomorphic Sarcoma of Bone},
+	author       = {Tarja Niini and Leo Lahti and Francesca Michelacci and Shinsuke Ninomiya and Claudia Maria Hattinger and Mohamed Guled and Tom B{\"o}hling and Piero Picci and Massimo Serra and Sakari Knuutila},
+	year         = 2011,
+	month        = 5,
+	journal      = {Genes, Chromosomes and Cancer},
+	volume       = 50,
+	number       = 5,
+	pages        = {291--306},
+	doi          = {10.1002/gcc.20851},
+	authorship   = {second},
+	url          = {https://github.com/openresearchlabs/openresearchlabs.github.io/blob/master/content/publication_resources/papers/2011-Niini-GCC.pdf},
+	keywords     = {bioscience}
+}
+
+@article{Niini12,
+	title        = {Homozygous Deletions of Cadherin Genes in Chondrosarcoma – an Array CGH Study},
+	author       = {Tarja Niini and Ilari Scheinin and Leo Lahti and Suvi Savola and Fredrik Mertens and Jaakko Hollmén and Tom Böhling and Aarne Kivioja and Karolin H Nord and Sakari Knuutila},
+	year         = 2012,
+	month        = 11,
+	journal      = {Cancer Genetics},
+	volume       = 205,
+	number       = 11,
+	pages        = {588--93},
+	doi          = {10.1016/j.cancergen.2012.09.007},
+	keywords     = {bioscience},
+	pmid         = 23146407
+}
+
+@article{Nylund2020,
+	title        = {Diet, perceived intestinal well-being, fecal microbiota and short chain fatty acids in oat-using subjects with celiac disease or gluten sensitivity.},
+	author       = {Lotta Nylund and Salla Hakkola and Leo Lahti and Seppo Salminen and Marko Kalliomäki and Baoru Yang and Kaisa M. Linderborg},
+	year         = 2020,
+	month        = {August},
+	journal      = {Nutrients},
+	volume       = 12,
+	pages        = 2570,
+	doi          = {10.3390/nu12092570},
+	note         = {Special issue.},
+	issue        = 9,
+	keywords     = {bioscience}
+}
+
+
+@article{Nymark07,
+	title        = {Gene Expression Profiles in Asbestos-exposed Epithelial and Mesothelial Lung Cell Lines},
+	author       = {Penny Nymark and Pamela M. Lindholm and Mikko V. Korpela and Leo Lahti and Salla Ruosaari and Samuel Kaski and Jaakko Hollmen and Sisko Anttila and Vuokko L. Kinnula and Sakari Knuutila},
+	year         = 2007,
+	month        = 3,
+	journal      = {BMC Genomics},
+	volume       = 8,
+	number       = 62,
+	doi          = {10.1186/1471-2164-8-62},
+	keywords     = {bioscience},
+	annote       = {CCA on two asbestos-exposed cell lines.}
+}
+
+@article{Nymark11,
+	title        = {Integrative Analysis of microRNA, mRNA and aCGH Data Reveals Asbestos- and Histology-Related Changes in Lung Cancer},
+	author       = {Penny Nymark and Mohamed Guled and Ioana Borze and Ali Faisal and Leo Lahti and Kaisa Salmenkivi and Eeva Kettunen and Sisko Anttila and Sakari Knuutila},
+	year         = 2011,
+	month        = 8,
+	journal      = {Genes, Chromosomes and Cancer},
+	volume       = 50,
+	number       = 8,
+	pages        = {585--597},
+	doi          = {10.1002/gcc.20880},
+	url          = {https://github.com/openresearchlabs/openresearchlabs.github.io/blob/master/content/publication_resources/papers/2011-Nymark-GCC.pdf},
+	keywords     = {bioscience}
+}
+
+@article{OKeefe15,
+	title        = {Fat, Fiber and Cancer Risk in African, Americans and Rural Africans},
+	author       = {SJD O'Keefe and JV Li and L Lahti and J Ou and F Carbonero and K Mohammed and JM Posma and J Kinross and E Wahl and E Ruder and K Vipperla and V Naidoo and L Mtshali and S Tims and PGB Puylaert, J DeLany and A Krasinskas and AC Benefiel and HO Kaseb and K Newton and JK Nicholson and WM de Vos and HR Gaskins and EG Zoetendal},
+	year         = 2015,
+	month        = {Apr},
+	journal      = {Nature Communications},
+	volume       = 6,
+	pages        = 6342,
+	doi          = {10.1038/ncomms7342},
+	note         = {Top science article in Guardian on the release day.},
+	keywords     = {gut},
+	keywords     = {bioscience},
+	url          = {https://github.com/openresearchlabs/openresearchlabs.github.io/blob/master/content/publication_resources/papers/2015-OKeefe-NComms.pdf},
+	annote       = {Guardian: http://www.theguardian.com/science/2015/apr/28/bowel-cancer-risk-may-be-reduced-by-rural-african-diet-study-finds}
+}
+
+@article{Palmu2020,
+	title        = {Association Between the Gut Microbiota and Blood Pressure in a Population Cohort of 6953 Individuals},
+	author       = {Joonatan Palmu and Aaro Salosensaari and Aki S. Havulinna and Susan Cheng and Michael Inouye and Mohit Jain and Rodolfo A. Salido and Karenina Sanders and Caitriona Brennan and Gregory C. Humphrey and Jon G. Sanders and Erkki Vartiainen and Tiina Laatikainen and Pekka Jousilahti and Veikko Salomaa and Rob Knight and Leo Lahti and Teemu J. Niiranen},
+	year         = 2020,
+	month        = {July},
+	journal      = {Journal of the American Heart Association},
+	doi          = {10.1161/JAHA.120.016641},
+	keywords     = {bioscience}
+
+
+
+
+
+}
+@article{Palmu2020JAHA,
+	title        = {Eicosanoid Inflammatory Mediators Are Robustly Associated with Blood Pressure in the General Population},
+	author       = {Joonatan Palmu and others},
+	year         = 2020,
+	journal      = {Journal of American Heart Association},
+	volume       = 9,
+	pages        = {e016641},
+	doi          = {10.1161/JAHA.120.017598},
+	issue        = 15,
+	keywords     = {bioscience}
+}
+
+@article{Palmu2021ijerph,
+	title        = {Targeting gut microbiota to treat hypertension: a systematic review},
+	author       = {Joonatan Palmu and Leo Lahti and Teemu Niiranen},
+	year         = 2021,
+	month        = January,
+	journal      = {International Journal of Environmental Research and Public Health},
+	volume       = 18,
+	number       = 3,
+	pages        = 1248,
+	doi          = {10.3390/ijerph18031248},
+	keywords     = {bioscience},
+	tag          = {review}
+}
+
+
+@article{Pekkala2020,
+	title        = {Prebiotic Xylo-oligosaccharides Targeting Faecalibacterium prausnitzii Prevent High Fat Diet-induced Hepatic Steatosis in Rats},
+	author       = {Sanna Lensu and Raghunath Pariyani and Elina Mäkinen and Baoru Yang and Wisam Saleem and Eveliina Munukka and Maarit Lehti and Baoru Yang and Jere Linden and Marja Tiirola and Leo Lahti and Satu Pekkala},
+	year         = 2020,
+	month        = {October},
+	journal      = {Nutrients},
+	volume       = 12,
+	number       = 11,
+	pages        = 3225,
+	doi          = {10.3390/nu12113225},
+	keywords     = {bioscience}
+}
+
+@article{Ritari15,
+	title        = {Improved taxonomic assignment of human intestinal 16S rRNA sequences by a dedicated reference database},
+	author       = {Jarmo Ritari and Jarkko Salojärvi and Leo Lahti and Willem M. de Vos},
+	year         = 2015,
+	month        = 12,
+	journal      = {BMC Genomics},
+	volume       = 16,
+	pages        = 1056,
+	doi          = {10.1186/s12864-015-2265-y},
+	url          = {https://github.com/openresearchlabs/openresearchlabs.github.io/blob/master/content/publication_resources/papers/2015-Ritari-BMCGenomics.pdf},
+	keywords     = {bioscience}
+}
+
+@article{Ruuskanen2021,
+	title        = {Modeling spatial patterns in host-associated microbial communities},
+	author       = {Matti Ruuskanen and Guilhem Sommeria-Klein and Aki Havulinna and Teemu Niiranen and Leo Lahti},
+	year         = 2021,
+	month        = {May},
+	journal      = {Environmental Microbiology},
+	volume       = 23,
+	number       = 5,
+	pages        = {2374--2388},
+	keywords     = {bioscience},
+	doi          = {10.1111/1462-2920.15462}
+}
+
+
+
+@article{Ruuskanen2021gutmicrobes,
+	title        = {Links between gut microbiome composition and fatty liver disease in a large population sample},
+	author       = {Matti O. Ruuskanen and Fredrik Åberg and Ville Männistö and Aki S. Havulinna and Guillaume Méric and Yang Liu and Rohit Loomba and Yoshiki Vázquez-Baeza and Anupriya Tripathi and Liisa M. Valsta and Michael Inouye and Pekka Jousilahti and Veikko Salomaa and Mohit Jain and Rob Knight and Leo Lahti and Teemu J. Niiranen},
+	year         = 2021,
+	month        = {March},
+	journal      = {Gut Microbes},
+	volume       = 13,
+	doi          = {10.1080/19490976.2021.1888673},
+	issue        = 1,
+	keywords     = {bioscience}
+}
+
+
+@article{Salosensaari2021,
+	title        = {Taxonomic signatures of cause-specific mortality risk in human gut microbiome},
+	author       = {Aaro Salosensaari* and Ville Laitinen* and Aki S Havulinna and Guillaume Meric and Susan Cheng and Markus Perola and Liisa Valsta and Georg Alfthan and Michael Inouye and Jeramie D Watrous and Tao Long and Rodolfo Salido and Karenina Sanders and Caitriona Brennan and Gregory C Humphrey and Jon G Sanders and Mohit Jain and Pekka Jousilahti and Veikko Salomaa and Rob Knight and Leo Lahti* and Teemu Niiranen*},
+	year         = 2021,
+	journal      = {Nature Communications},
+	volume       = 12,
+	pages        = 2671,
+	doi          = {10.1038/s41467-021-22962-y},
+	keywords     = {bioscience},
+	annote       = {Preprint featured in HS Tiede Jan 30, 2020. Featured in Science Magazine Jan 22, 2020 https://www.sciencemag.org/news/2020/01/microbes-your-gut-could-predict-whether-you-re-likely-die-next-15-years}
+}
+
+
+
+@article{Sarhadi13,
+	title        = {Targeted Resequencing of 9p in Acute Lymphoblastic Leukemia Yields Concordant Results with Array CGH and Reveals Novel Genomic Alterations},
+	author       = {Virinder Kaur Sarhadi and Leo Lahti and Ilari Scheinin and Anne Tyyb{\"a}kinoja and Suvi Savola and Anu Usvasalo and Riikka R{\"a}ty and Erkki Elonen and Pekka Ellonen and Ulla M Saarinen-Pihkala and Sakari Knuutila},
+	year         = 2013,
+	month        = 9,
+	journal      = {Genomics},
+	volume       = 102,
+	number       = 3,
+	pages        = {182--188},
+	doi          = {10.1016/j.ygeno.2013.01.001},
+	keywords     = {bioscience},
+	url          = {https://github.com/openresearchlabs/openresearchlabs.github.io/blob/master/content/publication_resources/papers/2013-Sarhadi-Genomics.pdf},
+	authorship   = {shared first}
+}
+
+
+@article{Sarhadi2020,
+	title        = {Gut Microbiota and Host Gene Mutations in Colorectal Cancer Patients and Controls of Iranian and Finnish Origin},
+	author       = {Sarhadi, V and Lahti, L and Saberi, F and Youssef, O and Kokkola, A and Karla, T and Tikkanen, M and Rautelin, H and Puolakkainen, P and Salehi, R and Knuutila, S},
+	year         = 2020,
+	month        = {March},
+	journal      = {Anticancer Research},
+	volume       = 40,
+	number       = 3,
+	pages        = {1325--1334},
+	doi          = {10.21873/anticanres.14074},
+	keywords     = {bioscience},
+	url          = {https://github.com/openresearchlabs/openresearchlabs.github.io/blob/master/content/publication_resources/papers/2020-Sarhadi-Anticanc.pdf}
+}
+
+@article{Sarhadi2021,
+	title        = {Gut microbiota of patients with different subtypes of gastric cancer and gastrointestinal stromal tumors},
+	author       = {Virinder Sarhadi and Binu Mathew and Arto Kokkola A and Tiina Karla and Milja Tikkanen and Hilpi Rautelin and Leo Lahti and Pauli Puolakkainen and Sakari Knuutila},
+	year         = 2021,
+	journal      = {Gut Pathogens},
+	volume       = 13,
+	pages        = {1--9},
+	doi          = {10.1186/s13099-021-00403-x},
+	keywords     = {bioscience},
+	issue        = 11
+}
+
+
+@article{Shetty2017,
+	title        = {Intestinal microbiome landscaping: Insight in community assemblage and implications for microbial modulation strategies},
+	author       = {Shetty, SA and Hugenholtz, F and Lahti, L and Smidt, H and de Vos, WM and Danchin, A},
+	year         = 2017,
+	month        = {March},
+	journal      = {FEMS Microbiology Reviews},
+	volume       = 41,
+	pages        = {182--199},
+	note        = {fuw045},
+	doi          = {10.1093/femsre/fuw045},
+	issue        = 2,
+	keywords     = {bioscience},
+	note     = {review},
+	url          = {https://github.com/openresearchlabs/openresearchlabs.github.io/blob/master/content/publication_resources/papers/2017-Shetty-FEMS.pdf}
+}
+
+@article{Shetty2019,
+  title =	 {Microbiome data science},
+  author =	 {Sudarshan Shetty and Leo Lahti},
+  year =	 2019,
+  month =	 {October},
+  journal =	 {Journal of Biosciences},
+  volume =	 44,
+  pages =	 115,
+  doi =		 {10.1007/s12038-019-9930-2},
+  url =
+                  {https://github.com/openresearchlabs/openresearchlabs.github.io/blob/master/content/publication_resources/papers/2019-Shetty-MDS.pdf},
+  keywords =	 {bioscience},
+  category =	 {review}
+}
+
+@article{Siavash15,
+	title        = {Impact of a wastewater treatment plant on microbial community composition and function in a hyporheic zone of a eutrophic river},
+	author       = {Siavash Atashgahi and Rozelin Aydin and Mauricio R. Dimitrov and Detmer Sipkema and Kelly Hamonts and Leo Lahti and Farai Maphosa and Thomas Kruse and Edoardo Saccenti and Dirk Springael, Winnie Dejonghe and Hauke Smidt},
+	year         = 2015,
+	month        = 11,
+	journal      = {Scientific Reports},
+	volume       = 5,
+	number       = 17284,
+	doi          = {10.1038/srep17284},
+	keywords     = {bioscience},
+	url          = {https://github.com/openresearchlabs/openresearchlabs.github.io/blob/master/content/publication_resources/papers/2015-Atagashi.pdf}
+}
+
+@techreport{Sinkkonen03tr,
+	title        = {Associative Clustering by Maximizing a {B}ayes Factor},
+	author       = {Janne Sinkkonen and Janne Nikkil\"{a} and Leo Lahti and Samuel Kaski},
+	year         = 2003,
+	month        = 6,
+	address      = {Espoo, Finland},
+	number       = {A68},
+	institution  = {Helsinki University of Technology and Laboratory of Computer and Information Science},
+	keywords     = {bioscience},	
+	url          = {https://github.com/openresearchlabs/openresearchlabs.github.io/blob/master/content/publication_resources/papers/2003-TechRep-Sinkkonen-ACBayesFactor.pdf}
+}
+
+@incollection{Sinkkonen04ecml,
+	title        = {Associative Clustering},
+	author       = {Janne Sinkkonen and Janne Nikkil\"{a} and Leo Lahti and Samuel Kaski},
+	year         = 2004,
+	booktitle    = {Proceedings of the ECML'04, 15th European Conference on Machine Learning},
+	publisher    = {Springer},
+	address      = {Berlin},
+	pages        = {396--406},
+	url          = {http://www.cis.hut.fi/projects/mi/abstracts/ecml04.html},
+	category     = {abstract},
+	editor       = {Boulicaut and Esposito and Giannotti and Pedreschi},
+	keywords       = {datascience},
+	url          = {https://github.com/openresearchlabs/openresearchlabs.github.io/blob/master/content/publication_resources/papers/2004-ECML-Sinkkonen-AC.pdf}
+}
+
+@techreport{Sinkkonen05tr,
+	title        = {Associative Clustering (AC): Technical Details},
+	author       = {Janne Sinkkonen and Samuel Kaski and Janne Nikkil{\"a} and Leo Lahti},
+	year         = 2005,
+	month        = {April},
+	address      = {Espoo, Finland},
+	number       = {A84},
+	note         = {Publications in Computer and Information Science},
+	institution  = {Helsinki University of Technology},
+	keywords       = {datascience},
+	url          = {https://github.com/openresearchlabs/openresearchlabs.github.io/blob/master/content/publication_resources/papers/2005-TechRep-Sinkkonen-ACtechdetails.pdf}
+}
+
+@article{Su2015,
+	title        = {A novel atlas of gene expression in human skeletal muscle reveals molecular changes associated with aging},
+	author       = {Jing Su and Carl Ekman and Nikolay Oskolkov and Leo Lahti and Kristoffer Ström and Alvis Brazma and Leif Groop and Johan Rung and and Ola Hansson},
+	year         = 2015,
+	month        = 10,
+	journal      = {Skeletal Muscle},
+	volume       = 5,
+	number       = 35,
+	doi          = {10.1186/s13395-015-0059-1},
+	keywords     = {bioscience},
+	url          = {https://github.com/openresearchlabs/openresearchlabs.github.io/blob/master/content/publication_resources/papers/2015-Su-SkeletalMuscle.pdf}
+}
+
+@article{Timmis2019,
+	title        = {Microbiome yarns: The Global Phenotype-Genotype Survey. Episode III: importance of microbiota diversification for microbiome function and biome health},
+	author       = {Timmis, K and Jebok, F and Rohde, M and Lahti, L and Molinari, G},
+	year         = 2019,
+	month        = {April},
+	journal      = {Microbial Biotechnology},
+	doi          = {10.1111/1751-7915.13406},
+	keywords     = {misc},
+	annote       = {Comics piece for the popularization of microbiome research.}
+}
+
+@article{Tolonen15EnnenNyt,
+  title =	 {Aatehistoria ja digitaalisten aineistojen
+                  mahdollisuudet},
+  author =	 {Mikko Tolonen and Leo Lahti},
+  year =	 2015,
+  month =	 8,
+  journal =	 {Ennen \& Nyt 2},
+  volume =	 2,
   keywords =	 {dh},
-  software =	 {yes},
-  volume =	 9,
-  number =	 1,
-  status =	 {dh},
-  pdf =		 {papers/2017-Lahti-RJournal.pdf},
-  authorship =	 {first, corresponding},
-  annote =	 {R package homepage URL:
-                  http://ropengov.github.io/eurostat/}
-}
-
-@Article{Shetty2017,
-  author =	 {Shetty, SA and Hugenholtz, F and Lahti, L and Smidt,
-                  H and de Vos, WM and Danchin, A},
-  title =	 {Intestinal microbiome landscaping: Insight in
-                  community assemblage and implications for microbial
-                  modulation strategies},
-  journal =	 {FEMS Microbiology Reviews},
-  volume =	 41,
-  issue =	 2,
-  month =	 {March},
-  status =	 {bioscience},
-  keywords =	 {review},
-  pages =	 {182--199},
-  year =	 2017,
-  pdf =		 {papers/2017-Shetty-FEMS.pdf},
-  pages =	 {fuw045},
-  doi =		 {10.1093/femsre/fuw045}
-}
-
-@Article{sarhadi14,
-  author =	 {Virinder Sarhadi and Leo Lahti and Ilari Scheinin
-                  and Pekka Ellonen and Eeva Kettunen and Massimo
-                  Serra and Katia Scotlandi and Pierro Picci and
-                  Sakari Knuutila},
-  title =	 {Copy Number Alterations and Neoplasia Specific
-                  Mutations in MELK, PDCD1LG2, TLN1, and PAX5 at 9p in
-                  Different Neoplasias},
-  journal =	 {Genes, Chromosomes and Cancer},
-  year =	 2014,
-  volume =	 53,
-  number =	 7,
-  pages =	 {579--588},
-  month =	 7,
-  authorship =	 {second},
-  doi =		 {10.1002/gcc.22168}
-}
-
-@Article{Lahti13nar,
-  author =	 {Leo Lahti and Aurora Torrente and Laura L Elo and
-                  Alvis Brazma and Johan Rung},
-  title =	 {A fully scalable online pre-processing algorithm for
-                  short oligonucleotide microarray atlases},
-  journal =	 {Nucleic Acids Research},
-  volume =	 41,
-  number =	 10,
-  year =	 2013,
-  pages =	 {e110},
-  pdf =		 {papers/2013-Lahti-NAR.pdf},
-  authorship =	 {first, corresponding},
-  doi =		 {10.1093/nar/gkt229},
-  note =	 {Implementation available through Bioconductor RPA
-                  package.}
-}
-
-@InProceedings{Faisal2011,
-  author =	 {Ali Faisal and Riku Louhimo and Leo Lahti and Sampsa
-                  Hautaniemi and Samuel Kaski},
-  title =	 {Biomarker discovery via dependency analysis of
-                  multi-view functional genomics data},
-  booktitle =	 {NIPS 2011 workshop From Statistical Genetics to
-                  Predictive Models in Personalized Medicine},
-  category =	 {abstract},
-  status =	 {bioscience},
-  pdf =		 {papers/2011-Faisal-NIPS.pdf},
-  year =	 2011
-}
-
-@PhdThesis{Lahti10thesis,
-  author =	 {Leo Lahti},
-  title =	 {Probabilistic analysis of the human transcriptome
-                  with side information},
-  school =	 {Aalto University School of Science and Technology,
-                  Faculty of Information and Natural Sciences,
-                  Department of Information and Computer Science},
-  year =	 2010,
-  address =	 {Espoo},
-  month =	 12,
-  series =	 {TKK Dissertations in Information and Computer
-                  Science},
-  category =	 {thesis},
+  authorship =	 {shared first},
   language =	 {Finnish},
-  number =	 {TKK-ICS-D19},
-  note =	 {LaTeX sources and the pdf version are openly
-                  available:
-                  https://github.com/antagomir/thesis/tree/master/phd10;
-                  Press release:
-                  https://github.com/antagomir/thesis/blob/master/phd10/Vaitostiedote-LeoLahti-20101207.pdf},
-  keywords =	 {probabilistic models, Bayesian analysis, data
-                  integration, gene expression, microarrays,
-                  computational science, data analysis, machine
-                  learning, computational biology, open source, open
-                  access, creative commons},
-  url =		 {http://lib.tkk.fi/Diss/2010/isbn9789526033686/},
-  pdf =		 {papers/2010-Lahti-thesis.pdf},
-  issn =	 {1797-5069},
-  abstract =	 {Recent advances in high-throughput measurement
-                  technologies and efficient sharing of biomedical
-                  data through community databases have made it
-                  possible to investigate the complete collection of
-                  genetic material, the genome, which encodes the
-                  heritable genetic program of an organism. This has
-                  opened up new views to the study of living organisms
-                  with a profound impact on biological research.
-                  Functional genomics is a subdiscipline of molecular
-                  biology that investigates the functional
-                  organization of genetic information.  This thesis
-                  develops computational strategies to investigate a
-                  key functional layer of the genome, the
-                  transcriptome. The time- and context-specific
-                  transcriptional activity of the genes regulates the
-                  function of living cells through protein
-                  synthesis. Efficient computational techniques are
-                  needed in order to extract useful information from
-                  high-dimensional genomic observations that are
-                  associated with high levels of complex
-                  variation. Statistical learning and probabilistic
-                  models provide the theoretical framework for
-                  combining statistical evidence across multiple
-                  observations and the wealth of background
-                  information in genomic data repositories.  This
-                  thesis addresses three key challenges in
-                  transcriptome analysis. First, new preprocessing
-                  techniques that utilize side information in genomic
-                  sequence databases and microarray collections are
-                  developed to improve the accuracy of high-throughput
-                  microarray measurements.  Second, a novel
-                  exploratory approach is proposed in order to
-                  construct a global view of cell-biological network
-                  activation patterns and functional relatedness
-                  between tissues across normal human
-                  body. Information in genomic interaction databases
-                  is used to derive constraints that help to focus the
-                  modeling in those parts of the data that are
-                  supported by known or potential interactions between
-                  the genes, and to scale up the analysis. The third
-                  contribution is to develop novel approaches to model
-                  dependency between co-occurring measurement
-                  sources. The methods are used to study cancer
-                  mechanisms and transcriptome evolution; integrative
-                  analysis of the human transcriptome and other layers
-                  of genomic information allows the identification of
-                  functional mechanisms and interactions that could
-                  not be detected based on the individual measurement
-                  sources. Open source implementations of the key
-                  methodological contributions have been released to
-                  facilitat e their further adoption by the research
-                  community.}
+  url =		 {https://github.com/openresearchlabs/openresearchlabs.github.io/blob/master/content/publication_resources/papers/2015-EnnenNyt-Tolonen.pdf},
+  keywords =	 {dh}
 }
 
-@Article{Lahti10bioinf,
-  author =	 {Leo Lahti and Juha E.A. Knuuttila and Samuel Kaski},
-  title =	 {Global modeling of transcriptional responses in
-                  interaction networks},
-  journal =	 {Bioinformatics},
-  year =	 2010,
-  doi =		 {10.1093/bioinformatics/btq500},
-  pages =	 {2713--2720},
-  volume =	 26,
-  issue =	 21,
-  status =	 {bioscience},
-  authorship =	 {first},
-  month =	 11,
-  note =	 {R/Matlab implementations available at
-                  http://netpro.r-forge.r-project.org/},
+@inproceedings{Tolonen16dh,
+	title        = {Printing in a Periphery: a Quantitative Study of Finnish Knowledge Production, 1640-1828},
+	author       = {Mikko Tolonen and Niko Ilom{\"a}ki and Hege Roivainen and Leo Lahti},
+	year         = 2016,
+	month        = 7,
+	booktitle    = {Digital Humanities 2016: Conference Abstracts},
+	publisher    = {Jagiellonian University & Pedagogical University, Kraków},
+	address      = {Krakow, Poland},
+	pages        = {383--385},
+	url          = {http://dh2016.adho.org/abstracts/9},
+	category     = {abstract},
+	keywords     = {dh}
+}
+
+@article{Tolonen2018gaudeamus,
+	title        = {Digitaaliset ihmistieteet ja historiantutkimus},
+	author       = {Mikko Tolonen and Leo Lahti},
+	year         = 2018,
+	journal      = {Menneisyyden rakentajat},
+	booktitle    = {Menneisyyden rakentajat},
+	publisher    = {Gaudeamus},
+	url          = {https://www.gaudeamus.fi/menneisyyden-rakentajat/},
+	note         = {(in Finnish). In: Hannikainen, MO and Danielsbacka, M and Tepora, T (eds.). Menneisyyden rakentajat. Gaudeamus, Helsinki, 2018.},
+	authorship   = {second},
+	language     = {Finnish},
+	editor       = {Hannikainen, MO and Danielsbacka, M and Tepora, T},
+	journaltitle = {Menneisyyden rakentajat},
+	keywords       = {dh},
+	annote       = {This is a book chapter but classified as article as could not find a way to include this to CSL automatically generated bibliography yet.}
+}
+
+@inproceedings{Tolonen2019dhn,
+	title        = {Scaling up bibliographic data science},
+	author       = {Mikko Tolonen and Jani Marjanen and Hege Roivainen and Leo Lahti},
+	year         = 2019,
+	month        = {March},
+	booktitle    = {Proceedings of the Digital Humanities in the Nordics (DHN2019)},
+	address      = {Copenhagen},
+	editor       = {Costanza Navarretta and Manex Agirrezabal and Bente Maegaard},
+	url          = {https://github.com/openresearchlabs/openresearchlabs.github.io/blob/master/content/publication_resources/papers/2019-Tolonen-DHN.pdf},
+	status       = {dh},
+	keywords     = {dh}
+}
+
+
+@incollection{Tolonen2021canon,
+	title        = {Examining the Early Modern Canon: The English Short Title Catalogue and Large-Scale Patterns of Cultural Production.},
+	author       = {Mikko Tolonen and Mark J. Hill and Ali Zeeshan Ijaz and Ville Vaara and Leo Lahti},
+	year         = 2021,
+	month        = {March},
+	booktitle    = {Data Visualization in Enlightenment Literature and Culture},
+	publisher    = {Palgrave Macmillan, Cham.},
+	doi          = {10.1007/978-3-030-54913-8_3},
+	note         = {Book chapter in: Data Visualization in Enlightenment Literature and Culture},
+	editor       = {Baird, I.},
+	chapter      = 3,
+	keywords={dh}
+}
+
+@InProceedings{Tiihonen2021chr,
+  author =	 {Iiro Tiihonen and Mikko Tolonen and Leo Lahti},
+  title =	 {Probabilistic Analysis of Early Modern British Book
+                  Prices},
+  booktitle =	 {{Proc. CEUR Workshop Proceedings on Computational
+                  Humanities Research}},
+  year =	 2021,
+  pages =	 {39--48},
+  keywords =	 {dh},
+  month =	 {Nov},
   url =
-                  {http://bioinformatics.oxfordjournals.org/content/early/2010/09/02/bioinformatics.btq500.abstract.html?ijkey=N1zzjtUBRng3wCM&keytype=ref},
-  pdf =		 {papers/2010-Bioinformatics-Lahti-NetResponse.pdf},
-  annote =	 {ArXiv: http://arxiv.org/abs/1202.0501; R/Matlab
-                  source code http://netpro.r-forge.r-project.org}
+                  {https://github.com/openresearchlabs/openresearchlabs.github.io/blob/master/content/publication_resources/papers/2021-Tiihonen-CHR.pdf},
+  note =	 {In M Ehrmann, F Karsdorp et al. (eds).}
 }
 
-@Article{Mosakhani10,
-  author =	 {Neda Mosakhani and Mohamed Guled and Leo Lahti and
-                  Ioana Borze and Minna Forsman and Jorma Ryh{\"a}nen
-                  and Sakari Knuutila},
-  title =	 {Unique microRNA profile in Dupuytren's contracture
-                  supports deregulation of beta-catenin pathway},
-  journal =	 {Modern Pathology},
-  year =	 2010,
-  volume =	 23,
-  pages =	 {1544--1522},
-  month =	 11,
-  doi =		 {10.1038/modpathol.2010.146},
-  pdf =		 {papers/2010-ModernPathology-Mosakhani-Dupuytre.pdf},
-  note =	 {International Dupuytren Award for best research
-                  paper in 2011}
+
+@article{Tolonen2021rcl,
+	title        = {Corpus Linguistics and Eighteenth Century Collections Online (ECCO)},
+	author       = {Tolonen, M and M{\"a}kel{\"a}, E and Ijaz, A and Lahti, L},
+	year         = 2021,
+	journal      = {Research in Corpus Linguistics},
+	volume       = 9,
+	number       = 1,
+	pages        = {19--34},
+	doi          = {10.32714/ricl.09.01.03},
+	keywords     = {dh}
 }
 
-@Article{Borze11,
-  author =	 {Ioana Borze and Mohamed Guled and Suad Musse and
-                  Anna Raunio and Erkki Elonen and Ulla
-                  Saarinen-Pihkala and Marja-Liisa
-                  Karjalainen-Lindsberg and Leo Lahti and Sakari
-                  Knuutila.},
-  title =	 {MicroRNA microarrays on archive bone marrow core
-                  biopsies of leukemias - method validation},
-  journal =	 {Leukemia Research},
-  year =	 2011,
-  volume =	 35,
-  month =	 2,
-  issue =	 2,
-  pages =	 {188--195},
-  doi =		 {10.1016/j.leukres.2010.08.005}
+@inproceedings{Vaara2019dh,
+	title        = {The Emerging Paradigm of Bibliographic Data Science},
+	author       = {Ville Vaara and Ali Ijaz and Iiro Tiihonen and Simon Hengchen and Antti Kanner and Tanja S{\"a}ily and Leo Lahti},
+	year         = 2019,
+	month        = {July},
+	booktitle    = {Proceedings of the Digital Humanities (DH2019)},
+	note         = {In press.},
+	keywords     = {dh}
 }
 
-@Misc{Lahti10pint,
-  author =	 {Olli-Pekka Huovilainen and Leo Lahti},
-  title =	 {Pairwise integration of functional genomics data},
-  howpublished = {software},
-  month =	 {April},
-  year =	 2010,
-  url =
-                  {http://bioconductor.org/packages/devel/bioc/html/pint.html},
-  note =	 {R/BioConductor: pint}
+@article{Vaura2020jch,
+	title        = {Unsupervised hierarchical clustering identifies a metabolically challenged subgroup of hypertensive individuals},
+	author       = {Felix C. Vaura and Veikko V. Salomaa and Ilkka M. Kantola and Risto Kaaja and Leo Lahti and Teemu J. Niiranen},
+	year         = 2020,
+	month        = {August},
+	journal      = {Journal of Clinical Hypertension},
+	volume       = 22,
+	number       = 9,
+	pages        = {1546--1553},
+	doi          = {10.1111/jch.13984},
+	keywords     = {bioscience}
 }
 
-@Misc{Lahti10dmt,
-  author =	 {Leo Lahti and Abhishek Tripathi and Olli-Pekka
-                  Huovilainen},
-  title =	 {Dependency modeling toolkit},
-  howpublished = {software},
-  publisher =	 {ICML workshop},
-  month =	 6,
-  year =	 2010,
-  url =		 {http://dmt.r-forge.r-project.org/},
-  note =	 {CRAN: dmt}
+@article{Youssef2018,
+	title        = {Stool Microbiota Composition Differs in Patients with Stomach, Colon, and Rectal Neoplasms},
+	author       = {Omar Youssef and Leo Lahti and Arto Kokkola and Tiina Karla and Milja Tikkanen and Homa Ehsan and Monika Carpelan‑Holmström and Selja Koskensalo and Tom Böhling and Hilpi Rautelin and Pauli Puolakkainen and Sakari Knuutila and Virinder Sarhadi},
+	year         = 2018,
+	month        = {July},
+	journal      = {Digestive Diseases and Sciences},
+	volume       = 63,
+	number       = 11,
+	pages        = {2950--2958},
+	doi          = {10.1007/s10620-018-5190-5},
+	authorship   = {shared first},
+	keywords     = {bioscience},
+	url          = {https://github.com/openresearchlabs/openresearchlabs.github.io/blob/master/content/publication_resources/papers/2018-Youssef.pdf}
 }
 
-@Misc{Lahti10netresponse,
-  author =	 {Leo Lahti and Antonio Gusmao and Olli-Pekka
-                  Huovilainen},
-  title =	 {NetResponse (functional network analysis)},
-  howpublished = {software},
-  month =	 {October},
-  year =	 2010,
-  url =
-                  {http://www.bioconductor.org/help/bioc-views/devel/bioc/html/netresponse.html},
-  doi =		 {10.18129/B9.BIOC.NETRESPONSE},
-  note =	 {R/Bioconductor: netresponse}
+
+
+@article{bender13,
+	title        = {Intestinal microbiota, individuality and health. In: Computational Methods Aiding Early-Stage Drug Design (Dagstuhl Seminar 13212)},
+	author       = {Leo Lahti},
+	year         = 2013,
+	journal      = {Dagstuhl Reports},
+	publisher    = {Schloss Dagstuhl--Leibniz-Zentrum fuer Informatik},
+	address      = {Dagstuhl, Germany},
+	volume       = 3,
+	number       = 5,
+	pages        = {78--94},
+	doi          = {10.4230/DagRep.3.5.78},
+	issn         = {2192-5283},
+	url          = {http://drops.dagstuhl.de/opus/volltexte/2013/4179},
+	category     = {abstract},
+	keywords     = {bioscience},
+	editor       = {Andreas Bender and Hinrich G{\"o}hlmann and Sepp Hochreiter and Ziv Shkedy},
+	urn          = {urn:nbn:de:0030-drops-41791},
+	annote       = {Keywords: Bioinformatics, Chemoinformatics, Machine learning, Statistics, Interdisciplinary applications. Short abstract for the Dagstuhl seminar.}
 }
 
-@Misc{Lahti09rpa,
-  author =	 {Leo Lahti},
-  title =	 {RPA: probe reliability and differential gene
-                  expression analysis},
-  howpublished = {software},
-  month =	 {October},
-  year =	 2009,
-  url =
-                  {http://bioconductor.org/packages/release/bioc/html/RPA.html},
-  doi =		 {10.18129/B9.BIOC.RPA},
-  note =	 {R/Bioconductor: RPA}
+@article{crossys2021,
+	title        = {Systemic cross-talk between brain, gut, and peripheral tissues in glucose homeostasis: effects of exercise training (CROSSYS): Exercise training intervention in monozygotic twins discordant for body weight},
+	author       = {Marja A. Heiskanen and Sanna M. Honkala and Ronja A. Ojala and Riikka Lautamäki and Kalle Koskensalo and Martin Lietzén and Jaakko Hentilä and Virva Saunavaara and Jani Saunavaara and Mika Helmiö and Eliisa Löyttyniemi and Lauri Nummenmaa and Maria C. Collado and Tarja Malm and Leo Lahti and Kirsi H. Pietiläinen and Jaakko Kaprio and Juha O. Rinne and Jarna C. Hannukainen},
+	year         = 2021,
+	journal      = {BMC Sports Science, Medicine and Rehabilitation},
+	volume       = 13,
+	pages        = 16,
+	doi          = {10.1186/s13102-021-00241-z},
+	keywords     = {bioscience}
 }
 
-@Article{Guled09,
-  author =	 {Mohamed Guled and Leo Lahti and Pamela M. Lindholm
-                  and Kaisa Salmenkivi and Izhar Bagwan and Andrew
-                  G. Nicholson and Sakari Knuutila},
-  title =	 {CDKN2A, NF2 and JUN Are Dysregulated Among Other
-                  Genes by miRNAs in Malignant Mesothelioma - a miRNA
-                  Microarray Analysis},
-  journal =	 {Genes, Chromosomes and Cancer},
-  year =	 2009,
-  volume =	 48,
-  number =	 7,
-  month =	 7,
-  pdf =		 {papers/2009-GCC-Guled-miRNA.pdf},
-  authorship =	 {second},
-  pages =	 {615--623},
-  doi =		 {10.1002/gcc.20669}
+
+@article{lahti14natcomm,
+	title        = {Tipping elements in the human intestinal ecosystem},
+	author       = {Leo Lahti and Jarkko Saloj{\"a}rvi and Anne Salonen and Marten Scheffer and Willem M. de Vos},
+	year         = 2014,
+	month        = 7,
+	journal      = {Nature Communications},
+	volume       = 5,
+	pages        = 4344,
+	doi          = {10.1038/ncomms5344},
+	url          = {https://github.com/openresearchlabs/openresearchlabs.github.io/blob/master/content/publication_resources/papers/2014-Lahti-NatComm.pdf},
+	authorship   = {first},
+	keywords     = {bioscience}
 }
 
-@InProceedings{Lahti09mlsp,
-  author =	 {Leo Lahti and Samuel Myllykangas and Sakari Knuutila
-                  and Samuel Kaski},
-  title =	 {Dependency detection with similarity constraints},
-  editor =	 {Adali T, Chanussot J, Jutten C, and Larsen J},
-  booktitle =	 {Proc. MLSP'09 IEEE International Workshop on Machine
-                  Learning for Signal Processing XIX},
-  year =	 2009,
-  howpublished = {software},
-  pages =	 {198--203},
-  address =	 {Piscataway, NJ},
-  pdf =		 {papers/2009-MLSP-Lahti-SimCCA.pdf},
-  note =	 {R/Bioconductor: pint},
-  authorship =	 {first, corresponding},
-  url =		 {http://arxiv.org/abs/1101.5919},
-  arxiv =	 {1101.5919}
+@techreport{openedu2020,
+	title        = {National policy and executive plan by the higher education and research community for 2021-2025 - Policy component 1: Open access to educational resources.},
+	author  = {Expert Panel in Open Education (Open Science Coordination in Finland)},
+	year         = 2020,
+	publisher    = {Committee for Public Information (TJNK) and Federation of Finnish Learned Societies (TSV).},
+	address      = {Helsinki, Finland},
+	journal      = {Responsible Research Series},
+	volume       = 16,
+	keywords       = {openscience}
 }
+
+
+
+@techreport{openutu2018,
+	title        = {Turun yliopiston avoimen tutkimuksen politiikka / Open Research Policy},
+	year         = 2018,
+	month        = {May},
+	author = {{OpenUTU work group}},
+	journal      = {unknwown},
+	category     = {report},
+	note         = {(in Finnish)},
+	key          = {report},
+	institution  = {University of Turku},
+	howpublished = {Report},
+	journaltitle = {unknown},
+	keywords       = {openscience},
+	url          = {https://github.com/openresearchlabs/openresearchlabs.github.io/blob/master/content/publication_resources/papers/2018-avoimen-tutkimuksen-politiikka-fi.pdf},
+	annote       = {Member in the work group that developed the report.}
+}
+
+
+@article{salonen14,
+	title        = {Impact of diet and individual variation on intestinal microbiota composition and fermentation products in obese men},
+	author       = {Anne Salonen and Leo Lahti and Jarkko Saloj{\"a}rvi and Grietje Holtrop and Katri Korpela and Sylvia Duncan and Priya Date and Alexandra Johnstone and Gerald Lobley and Petra Louis and Harry Flint and Willem M. de Vos},
+	year         = 2014,
+	journal      = {ISME Journal},
+	volume       = 8,
+	pages        = {2218--2230},
+	doi          = {10.1038/ismej.2014.63},
+	keywords     = {bioscience},
+	url          = {https://github.com/openresearchlabs/openresearchlabs.github.io/blob/master/content/publication_resources/papers/2014-Salonen-ISME.pdf},
+	authorship   = {second}
+}
+
+@article{sarhadi14,
+	title        = {Copy Number Alterations and Neoplasia Specific Mutations in MELK, PDCD1LG2, TLN1, and PAX5 at 9p in Different Neoplasias},
+	author       = {Virinder Sarhadi and Leo Lahti and Ilari Scheinin and Pekka Ellonen and Eeva Kettunen and Massimo Serra and Katia Scotlandi and Pierro Picci and Sakari Knuutila},
+	year         = 2014,
+	month        = 7,
+	journal      = {Genes, Chromosomes and Cancer},
+	volume       = 53,
+	number       = 7,
+	pages        = {579--588},
+	doi          = {10.1002/gcc.22168},
+	keywords     = {bioscience},	
+	authorship   = {second}
+}
+
+@article{stolaki2019,
+	title        = {Microbial communities in a dynamic {it in vitro} model for the human ileum resemble the human ileal microbiota},
+	author       = {Stolaki, Maria and Minekus, Mans and Venema, Koen and Lahti, Leo and Smid, Eddy J. and Kleerebezem, Michiel and Zoetendal, Erwin G},
+	year         = 2019,
+	month        = {August},
+	journal      = {FEMS Microbiology Ecology},
+	number       = 8,
+	pages        = {fiz096},
+	doi          = {10.1093/femsec/fiz096},
+	keywords     = {bioscience},
+	vol          = 95,
+	url          = {https://github.com/openresearchlabs/openresearchlabs.github.io/blob/master/content/publication_resources/papers/2019-Stolaki-FEMS.pdf}
+}
+
+@article{tolonen2019,
+	title        = {A Quantitative Approach to Book-Printing in Sweden and Finland, 1640–1828},
+	author       = {Mikko Tolonen and Leo Lahti and Hege Roivainen and Jani Marjanen},
+	year         = 2019,
+	journal      = {Historical Methods: A Journal of Quantitative and Interdisciplinary History},
+	publisher    = {Routledge},
+	volume       = 52,
+	pages        = {57--78},
+	doi          = {10.1080/01615440.2018.1526657},
+	issue        = 1,
+	keywords     = {dh},
+	url          = {https://github.com/openresearchlabs/openresearchlabs.github.io/blob/master/content/publication_resources/papers/2019-Tolonen.pdf}
+}
+

--- a/content/publication_resources/bibtex/lahti.bib
+++ b/content/publication_resources/bibtex/lahti.bib
@@ -1,3 +1,16 @@
+@Article{Lahti2021hs,
+  author =	 {Eetu Mäkelä and Leo Lahti and Johanna Lilja and
+                  Pekka Heikkinen},
+  title =	 {Laki estää tehokkaiden tutkimusmenetelmien käytön},
+  journal =	 {HS Mielipide},
+  year =	 2021,
+  month =	 {October},
+  url =		 {https://www.hs.fi/mielipide/art-2000008325656.html},
+  keywords =	 {opinion},
+  status =	 {general}
+}
+
+
 @Article{Qin2021,
   author =	 {Youwen Qin and Aki S. Havulinna and Yang Liu and Pekka Jousilahti and Scott C. Ritchie and Alex Tokolyi and Jon G. Sanders and Liisa Valsta and Marta Brożyńska and Qiyun Zhu and Anupriya Tripathi and Yoshiki Vazquez-Baeza and Rohit Loomba and Susan Cheng and Mohit Jain and Teemu Niiranen and Leo Lahti and Rob Knight and Veikko Salomaa and Michael Inouye and Guillaume Méric},
   title =	 {Combined effects of host genetics and diet on human gut microbiota and incident disease in a single population cohort},

--- a/content/publication_resources/bibtex/lahti.bib
+++ b/content/publication_resources/bibtex/lahti.bib
@@ -31,7 +31,8 @@
 	journal      = {medRxiv (preprint)},
 	pages        = {2020.09.12.20193045},
 	doi          = {10.1101/2020.09.12.20193045},
-	keywords     = {preprint}
+	pubstate     = {preprint},
+	keywords     = {bioscience}
 }
 @article{Zhu2021,
 	title        = {OGUs enable effective, phylogeny-aware analysis of even shallow metagenome community structures},
@@ -42,7 +43,8 @@
 	url          = {https://www.biorxiv.org/content/early/2021/04/06/2021.04.04.438427},
 	elocation-id = {2021.04.04.438427},
 	eprint       = {https://www.biorxiv.org/content/early/2021/04/06/2021.04.04.438427.full.pdf},
-	keywords     = {preprint}
+	pubstate     = {preprint},
+	keywords     = {bioscience}
 }
 @article{Laitinen2021ews,
 	title        = {Probabilistic early warning signals},
@@ -247,7 +249,8 @@
 	doi          = {10.1101/2020.06.24.20138933},
 	url          = {https://www.medrxiv.org/content/early/2020/06/25/2020.06.24.20138933},
 	eprint       = {https://www.medrxiv.org/content/early/2020/06/25/2020.06.24.20138933.full.pdf},
-	keywords     = {preprint}
+	pubstate     = {preprint},
+	keywords     = {bioscience}
 }
 @article{Aatsinki2020,
 	title        = {Maternal prenatal psychological distress and hair cortisol levels associate with infant fecal microbiota composition at 2.5 months of age},
@@ -972,7 +975,6 @@
 	journal      = {Ennen \& Nyt 2},
 	volume       = 2,
 	url          = {https://github.com/openresearchlabs/openresearchlabs.github.io/blob/master/content/publication_resources/papers/2015-EnnenNyt-Tolonen.pdf},
-	keywords     = {dh},
 	authorship   = {shared first},
 	language     = {Finnish},
 	keywords     = {dh}

--- a/content/publication_resources/bibtex/lahti.bib
+++ b/content/publication_resources/bibtex/lahti.bib
@@ -11,6 +11,7 @@
 	url          = {},
 	note         = {},
 	pubstate     = {preprint},
+	keywords     = {bioscience},
 	annote       = {}
 }
 @article{Mokkala2021,

--- a/content/publication_resources/bibtex/lahti.bib
+++ b/content/publication_resources/bibtex/lahti.bib
@@ -1,3 +1,19 @@
+@Article{Qin2021,
+  author =	 {Youwen Qin and Aki S. Havulinna and Yang Liu and Pekka Jousilahti and Scott C. Ritchie and Alex Tokolyi and Jon G. Sanders and Liisa Valsta and Marta Brożyńska and Qiyun Zhu and Anupriya Tripathi and Yoshiki Vazquez-Baeza and Rohit Loomba and Susan Cheng and Mohit Jain and Teemu Niiranen and Leo Lahti and Rob Knight and Veikko Salomaa and Michael Inouye and Guillaume Méric},
+  title =	 {Combined effects of host genetics and diet on human gut microbiota and incident disease in a single population cohort},
+  journal =	 {medRxiv (preprint)},
+  year =	 {2021},
+  volume =	 {},
+  number =	 {},
+  pages =	 {2020.09.12.20193045},
+  month =	 {},
+  url =		 {},
+  note =	 {},
+  keywords = {preprint},
+  doi = {10.1101/2020.09.12.20193045}
+}
+
+
 @article{Tolonen2021rcl,
   author =	 {Tolonen, M and M{\"a}kel{\"a}, E and Ijaz, A and
                   Lahti, L},

--- a/content/publication_resources/bibtex/lahti.bib
+++ b/content/publication_resources/bibtex/lahti.bib
@@ -1,3 +1,35 @@
+@TechReport{Sinkkonen05tr,
+  author =	 {Janne Sinkkonen and Samuel Kaski and Janne
+                  Nikkil{\"a} and Leo Lahti},
+  title =	 {Associative Clustering (AC): Technical Details},
+  institution =	 {Helsinki University of Technology},
+  year =	 2005,
+  number =	 {A84},
+  address =	 {Espoo, Finland},
+  month =	 {April},
+  keywords =	 {datascience},
+  pdf =		 {papers/2005-TechRep-Sinkkonen-ACtechdetails.pdf},
+  note =	 {Publications in Computer and Information Science}
+}
+
+@InProceedings{Tiihonen2021chr,
+  author =	 {Iiro Tiihonen and Mikko Tolonen and Leo Lahti},
+  title =	 {Probabilistic Analysis of Early Modern British Book
+                  Prices},
+  booktitle =	 {{Proc. CEUR Workshop Proceedings on Computational
+                  Humanities Research}},
+  year =	 2021,
+  pages =	 {39--48},
+  keywords = {dh},  
+  month =	 {Nov},
+  url =		 {https://github.com/openresearchlabs/openresearchlabs.github.io/blob/master/content/publication_resources/papers/2021-Tiihonen-CHR.pdf},
+  note =	 {In M Ehrmann, F Karsdorp et al. (eds).}
+}
+
+
+
+
+
 @Article{Lahti2021hs,
   author =	 {Eetu Mäkelä and Leo Lahti and Johanna Lilja and
                   Pekka Heikkinen},
@@ -198,8 +230,13 @@
                   Humanities Research}},
   pages =	 {80--89},
   year =	 2020,
+  number =	 2723,
   month =	 {Nov},
-  url =		 {http://ceur-ws.org/Vol-2723/short46.pdf}
+  keywords =	 {dh},
+  url =
+                  {https://github.com/openresearchlabs/openresearchlabs.github.io/blob/master/content/publication_resources/papers/2020-Lahti-CHR.pdf},
+  note =	 {In F Karsdorp, B McGillivray, A Nerghes & M Wevers
+                  (eds).}
 }
 
 @Article{Keskitalo2021,
@@ -218,7 +255,7 @@
   month =	 {March},
   doi =		 {10.1080/10253890.2021.1895110},
   note =	 {In press.},
-  status =	 {bioscience}
+  keywords =	 {bioscience}
 }
 
 @Article{MorenoIndias2021,
@@ -578,7 +615,7 @@
   month =	 {March},
   doi =		 {10.21873/anticanres.14074},
   keywords =	 {bioscience},
-  pdf =		 {papers/2020-Sarhadi-Anticanc.pdf}
+  pdf =		 {https://github.com/openresearchlabs/openresearchlabs.github.io/blob/master/content/publication_resources/papers/2020-Sarhadi-Anticanc.pdf}
 }
 
 @InProceedings{Makela2020,
@@ -594,7 +631,7 @@
   volume =	 2612,
   editor =	 {Sanita Reinsone and Inguna Skadiņa and Anda Baklāne
                   and Jānis Daugavietis},
-  pdf =		 {papers/2020-Makela-DHN.pdf},
+  pdf =		 {https://github.com/openresearchlabs/openresearchlabs.github.io/blob/master/content/publication_resources/papers/2020-Makela-DHN.pdf},
   status =	 {dh}
 }
 
@@ -629,7 +666,7 @@
   url =		 {https://ojs.ugent.be/jeps/article/view/10483},
   note =	 {Special issue: Digital Approaches Towards Serial
                   Publications},
-  pdf =		 {papers/2019-Marjanen-JEPS.pdf},
+  pdf =		 {https://github.com/openresearchlabs/openresearchlabs.github.io/blob/master/content/publication_resources/papers/2019-Marjanen-JEPS.pdf},
   status =	 {dh},
   keywords =	 {dh}
 }
@@ -643,7 +680,7 @@
   year =	 2019,
   address =	 {Oulu},
   month =	 {August},
-  pdf =		 {papers/2019-Ijaz-RDHum.pdf}
+  pdf =		 {https://github.com/openresearchlabs/openresearchlabs.github.io/blob/master/content/publication_resources/papers/2019-Ijaz-RDHum.pdf}
 }
 
 @InProceedings{Lahti2019rdhum,
@@ -655,7 +692,7 @@
   year =	 2019,
   address =	 {Oulu},
   month =	 {August},
-  pdf =		 {papers/2019-Lahti-RDHUM.pdf},
+  pdf =		 {https://github.com/openresearchlabs/openresearchlabs.github.io/blob/master/content/publication_resources/papers/2019-Lahti-RDHUM.pdf},
   status =	 {dh},
   keywords =	 {dh}
 }
@@ -668,7 +705,7 @@
                   Karlsson},
   title =	 {Gut microbiota composition is associated with
                   temperament traits in infants},
-  pdf =		 {papers/2019-Aatsinki.pdf},
+  pdf =		 {https://github.com/openresearchlabs/openresearchlabs.github.io/blob/master/content/publication_resources/papers/2019-Aatsinki.pdf},
   journal =	 {Brain Behavior and Immunity},
   volume =	 80,
   pages =	 {849--858},
@@ -710,7 +747,7 @@
   pages =	 {fiz096},
   month =	 {August},
   doi =		 {10.1093/femsec/fiz096},
-  pdf =		 {papers/2019-Stolaki-FEMS.pdf}
+  pdf =		 {https://github.com/openresearchlabs/openresearchlabs.github.io/blob/master/content/publication_resources/papers/2019-Stolaki-FEMS.pdf}
 }
 
 @InProceedings{Tolonen16dh,
@@ -772,7 +809,7 @@
   editor =	 {Costanza Navarretta and Manex Agirrezabal and Bente
                   Maegaard},
   url =		 {https://cst.dk/DHN2019Pro/papers/DHN2019_hill.pdf},
-  pdf =		 {papers/2019-Hill-DHN.pdf},
+  pdf =		 {https://github.com/openresearchlabs/openresearchlabs.github.io/blob/master/content/publication_resources/papers/2019-Hill-DHN.pdf},
   note =	 {Best paper award.},
   status =	 {dh},
   keywords =	 {dh}
@@ -795,7 +832,7 @@
   editor =	 {Steven Krauwer and Darja Fišer},
   status =	 {dh},
   keywords =	 {dh},
-  pdf =		 {papers/2019-Makela-DHN.pdf},
+  pdf =		 {https://github.com/openresearchlabs/openresearchlabs.github.io/blob/master/content/publication_resources/papers/2019-Makela-DHN.pdf},
   url =
                   {http://ceur-ws.org/Vol-2365/07-TwinTalks-DHN2019_paper_7.pdf}
 }
@@ -811,7 +848,7 @@
   address =	 {Copenhagen},
   editor =	 {Costanza Navarretta and Manex Agirrezabal and Bente
                   Maegaard},
-  pdf =		 {papers/2019-Tolonen-DHN.pdf},
+  pdf =		 {https://github.com/openresearchlabs/openresearchlabs.github.io/blob/master/content/publication_resources/papers/2019-Tolonen-DHN.pdf},
   status =	 {dh},
   keywords =	 {dh}
 }
@@ -828,7 +865,7 @@
   pages =	 {5--23},
   month =	 {January},
   doi =		 {10.1080/01639374.2018.1543747},
-  pdf =		 {papers/2019-Lahti-CCQ.pdf},
+  pdf =		 {https://github.com/openresearchlabs/openresearchlabs.github.io/blob/master/content/publication_resources/papers/2019-Lahti-CCQ.pdf},
   publisher =	 {Routledge},
   status =	 {dh},
   note =	 {Special issue.}
@@ -849,7 +886,7 @@
   doi =		 {10.1080/01615440.2018.1526657},
   status =	 {dh},
   keywords =	 {dh},
-  pdf =		 {papers/2019-Tolonen.pdf}
+  pdf =		 {https://github.com/openresearchlabs/openresearchlabs.github.io/blob/master/content/publication_resources/papers/2019-Tolonen.pdf}
 }
 
 @InProceedings{Lahti2018IDA,
@@ -885,7 +922,7 @@
   publisher =	 {Springer},
   status =	 {datascience},
   authorship =	 {pi},
-  pdf =		 {papers/2018-Laitinen-IDA.pdf},
+  pdf =		 {https://github.com/openresearchlabs/openresearchlabs.github.io/blob/master/content/publication_resources/papers/2018-Laitinen-IDA.pdf},
   note =	 {Conference proceedings.}
 }
 
@@ -901,7 +938,7 @@
   pages =	 {41-49},
   month =	 {July},
   doi =		 {10.1016/j.mib.2018.07.004},
-  pdf =		 {papers/2018-Gonze.pdf}
+  pdf =		 {https://github.com/openresearchlabs/openresearchlabs.github.io/blob/master/content/publication_resources/papers/2018-Gonze.pdf}
 }
 
 @Article{Youssef2018,
@@ -921,7 +958,7 @@
   authorship =	 {shared first},
   month =	 {July},
   keywords =	 {bioscience},
-  pdf =		 {papers/2018-Youssef.pdf},
+  pdf =		 {https://github.com/openresearchlabs/openresearchlabs.github.io/blob/master/content/publication_resources/papers/2018-Youssef.pdf},
   doi =		 {10.1007/s10620-018-5190-5}
 }
 
@@ -937,7 +974,7 @@
   category =	 {report},
   month =	 {May},
   year =	 2018,
-  pdf =		 {papers/2018-avoimen-tutkimuksen-politiikka-fi.pdf},
+  pdf =		 {https://github.com/openresearchlabs/openresearchlabs.github.io/blob/master/content/publication_resources/papers/2018-avoimen-tutkimuksen-politiikka-fi.pdf},
   url =
                   {https://www.utu.fi/sites/default/files/public\%3A//media/file/ty-avoimen-tutkimuksen-politiikka-fi.pdf},
   note =	 {(in Finnish)},
@@ -957,7 +994,7 @@
   volume =	 6,
   number =	 120,
   month =	 {June},
-  pdf =		 {papers/2018-Faust-Microbiome.pdf},
+  pdf =		 {https://github.com/openresearchlabs/openresearchlabs.github.io/blob/master/content/publication_resources/papers/2018-Faust-Microbiome.pdf},
   doi =		 {10.1186/s40168-018-0496-2}
 }
 
@@ -974,7 +1011,7 @@
   month =	 {May},
   keywords =	 {bioscience},
   doi =		 {10.1089/jwh.2017.6488},
-  pdf =		 {papers/2018-Aatsinki.pdf},
+  pdf =		 {https://github.com/openresearchlabs/openresearchlabs.github.io/blob/master/content/publication_resources/papers/2018-Aatsinki.pdf},
   note =	 {Epub ahead of print.}
 }
 
@@ -993,7 +1030,7 @@
   month =	 {Jun},
   publisher =	 {American Physical Society},
   status =	 {datascience},
-  pdf =		 {papers/2018-Arani-PhysRevE.pdf},
+  pdf =		 {https://github.com/openresearchlabs/openresearchlabs.github.io/blob/master/content/publication_resources/papers/2018-Arani-PhysRevE.pdf},
   doi =		 {10.1103/PhysRevE.97.062407},
   url =		 {https://link.aps.org/doi/10.1103/PhysRevE.97.062407}
 }
@@ -1090,7 +1127,7 @@
   status =	 {openscience},
   keywords =	 {openscience},
   url =		 {http://urn.fi/URN:NBN:fi-fe201802123334},
-  pdf =		 {papers/2018-Bjork-ATT.pdf}
+  pdf =		 {https://github.com/openresearchlabs/openresearchlabs.github.io/blob/master/content/publication_resources/papers/2018-Bjork-ATT.pdf}
 }
 
 @Article{Buelow2017,
@@ -1112,7 +1149,7 @@
   keywords =	 {bioscience},
   pages =	 88,
   month =	 {Aug},
-  pdf =		 {papers/2017-Buelow-Microbiome.pdf},
+  pdf =		 {https://github.com/openresearchlabs/openresearchlabs.github.io/blob/master/content/publication_resources/papers/2017-Buelow-Microbiome.pdf},
   doi =		 {10.1186/s40168-017-0309-z}
 }
 
@@ -1131,7 +1168,7 @@
   keywords =	 {highlight},
   status =	 {openscience},
   doi =		 {10.3897/rio.3.e13593},
-  pdf =		 {papers/2017-Lahti-PHOS.pdf},
+  pdf =		 {https://github.com/openresearchlabs/openresearchlabs.github.io/blob/master/content/publication_resources/papers/2017-Lahti-PHOS.pdf},
   keywords =	 {dh},
   note =	 {Review of the international conference, including
                   electronic material (video interviews, lectures and
@@ -1149,7 +1186,7 @@
   keywords =	 {highlight},
   volume =	 11,
   pages =	 {2159--2166},
-  pdf =		 {papers/2017-Faust-ISME.pdf},
+  pdf =		 {https://github.com/openresearchlabs/openresearchlabs.github.io/blob/master/content/publication_resources/papers/2017-Faust-ISME.pdf},
   month =	 {may},
   doi =		 {10.1038/ismej.2017.60}
 }
@@ -1165,7 +1202,7 @@
   category =	 {review},
   language =	 {Finnish},
   month =	 8,
-  pdf =		 {papers/2015-EnnenNyt-Tolonen.pdf},
+  pdf =		 {https://github.com/openresearchlabs/openresearchlabs.github.io/blob/master/content/publication_resources/papers/2015-EnnenNyt-Tolonen.pdf},
   status =	 {dh},
   url =
                   {http://www.ennenjanyt.net/2015/08/aatehistoria-ja-digitaalisten-aineistojen-mahdollisuudet}
@@ -1183,7 +1220,7 @@
   pages =	 {87-116},
   month =	 12,
   authorship =	 {first},
-  pdf =		 {papers/2015-Lahti-LIBERQuarterly.pdf},
+  pdf =		 {https://github.com/openresearchlabs/openresearchlabs.github.io/blob/master/content/publication_resources/papers/2015-Lahti-LIBERQuarterly.pdf},
   issn =	 {2213-056X},
   keywords =	 {dh},
   doi =		 {10.18352/lq.10112}
@@ -1196,7 +1233,7 @@
                   16S rRNA sequences by a dedicated reference
                   database},
   journal =	 {BMC Genomics},
-  pdf =		 {papers/2015-Ritari-BMCGenomics.pdf},
+  pdf =		 {https://github.com/openresearchlabs/openresearchlabs.github.io/blob/master/content/publication_resources/papers/2015-Ritari-BMCGenomics.pdf},
   year =	 2015,
   volume =	 16,
   keywords =	 {bioscience},
@@ -1224,7 +1261,7 @@
   location =	 {Tampere, Finland},
   isbn =	 {978-1-4503-3948-3},
   keywords =	 {openscience},
-  pdf =		 {papers/2015-Laine-Mindtrek.pdf},
+  pdf =		 {https://github.com/openresearchlabs/openresearchlabs.github.io/blob/master/content/publication_resources/papers/2015-Laine-Mindtrek.pdf},
   url =		 {http://dl.acm.org/citation.cfm?id=2818187}
 }
 
@@ -1242,7 +1279,7 @@
   number =	 35,
   doi =		 {10.1186/s13395-015-0059-1},
   month =	 10,
-  pdf =		 {papers/2015-Su-SkeletalMuscle.pdf}
+  pdf =		 {https://github.com/openresearchlabs/openresearchlabs.github.io/blob/master/content/publication_resources/papers/2015-Su-SkeletalMuscle.pdf}
 }
 
 @Misc{Lahti13icml,
@@ -1277,7 +1314,7 @@
   number =	 17284,
   month =	 11,
   doi =		 {10.1038/srep17284},
-  pdf =		 {papers/2015-Atagashi.pdf}
+  pdf =		 {https://github.com/openresearchlabs/openresearchlabs.github.io/blob/master/content/publication_resources/papers/2015-Atagashi.pdf}
 }
 
 @Article{Faust15,
@@ -1295,7 +1332,7 @@
   month =	 6,
   authorship =	 {shared first},
   doi =		 {10.1016/j.mib.2015.04.004},
-  pdf =		 {papers/2015-Faust-CurrOpMicrob.pdf}
+  pdf =		 {https://github.com/openresearchlabs/openresearchlabs.github.io/blob/master/content/publication_resources/papers/2015-Faust-CurrOpMicrob.pdf}
 }
 
 @Article{OKeefe15,
@@ -1318,7 +1355,7 @@
   month =	 {Apr},
   doi =		 {10.1038/ncomms7342},
   note =	 {Top science article in Guardian on the release day.},
-  pdf =		 {papers/2015-OKeefe-NComms.pdf},
+  pdf =		 {https://github.com/openresearchlabs/openresearchlabs.github.io/blob/master/content/publication_resources/papers/2015-OKeefe-NComms.pdf},
   annote =	 {Guardian:
                   http://www.theguardian.com/science/2015/apr/28/bowel-cancer-risk-may-be-reduced-by-rural-african-diet-study-finds}
 }
@@ -1343,7 +1380,7 @@
   pages =	 271,
   note =	 {AllBio: Open Science & Reproducibility Best Practice
                   Workshop},
-  pdf =		 {papers/2014-Aleksic.pdf},
+  pdf =		 {https://github.com/openresearchlabs/openresearchlabs.github.io/blob/master/content/publication_resources/papers/2014-Aleksic.pdf},
   doi =		 {10.12688/f1000research.5686.2}
 }
 
@@ -1376,7 +1413,7 @@
   number =	 {Suppl. 4},
   keywords =	 {bioscience},
   pages =	 {16–20},
-  pdf =		 {papers/2012-Salonen-CMI.pdf},
+  pdf =		 {https://github.com/openresearchlabs/openresearchlabs.github.io/blob/master/content/publication_resources/papers/2012-Salonen-CMI.pdf},
   doi =		 {10.1111/j.1469-0691.2012.03855.x},
 }
 
@@ -1394,7 +1431,7 @@
   number =	 11,
   pages =	 {545-51},
   keywords =	 {bioscience},
-  pdf =		 {papers/2012-Mosakhani-CG.pdf},
+  pdf =		 {https://github.com/openresearchlabs/openresearchlabs.github.io/blob/master/content/publication_resources/papers/2012-Mosakhani-CG.pdf},
   authorship =	 {second},
   month =	 11,
   doi =		 {10.1016/j.cancergen.2012.08.003}
@@ -1413,7 +1450,7 @@
   month =	 6,
   keywords =	 {bioscience},
   authorship =	 {first, corresponding},
-  pdf =		 {papers/2013-Lahti-BriefBioinf.pdf},
+  pdf =		 {https://github.com/openresearchlabs/openresearchlabs.github.io/blob/master/content/publication_resources/papers/2013-Lahti-BriefBioinf.pdf},
   category =	 {review},
   pages =	 {27--35},
   doi =		 {10.1093/bib/bbs005}
@@ -1433,7 +1470,7 @@
   pages =	 {e32},
   keywords =	 {bioscience},
   authorship =	 {corresponding, shared first},
-  pdf =		 {papers/2013-Lahti-PeerJ.pdf},
+  pdf =		 {https://github.com/openresearchlabs/openresearchlabs.github.io/blob/master/content/publication_resources/papers/2013-Lahti-PeerJ.pdf},
   doi =		 {10.7717/peerj.32},
   note =	 {Highly accessed, featured in PeerJ journal blog and
                   Top-10 Microbiology collection.},
@@ -1451,7 +1488,7 @@
                   Leukemia Yields Concordant Results with Array CGH
                   and Reveals Novel Genomic Alterations},
   journal =	 {Genomics},
-  pdf =		 {papers/2013-Sarhadi-Genomics.pdf},
+  pdf =		 {https://github.com/openresearchlabs/openresearchlabs.github.io/blob/master/content/publication_resources/papers/2013-Sarhadi-Genomics.pdf},
   year =	 2013,
   volume =	 102,
   month =	 9,
@@ -1469,7 +1506,7 @@
                   leukemia: novel prognostic tools},
   journal =	 {Leukemia \& Lymphoma},
   year =	 2012,
-  pdf =		 {papers/2012-Mosakhani-LL.pdf},
+  pdf =		 {https://github.com/openresearchlabs/openresearchlabs.github.io/blob/master/content/publication_resources/papers/2012-Mosakhani-LL.pdf},
   volume =	 53,
   number =	 12,
   pages =	 {2517-2520},
@@ -1491,7 +1528,7 @@
   volume =	 105,
   number =	 3,
   pages =	 {516--529},
-  pdf =		 {papers/2017-Harris-IEEE.pdf},
+  pdf =		 {https://github.com/openresearchlabs/openresearchlabs.github.io/blob/master/content/publication_resources/papers/2017-Harris-IEEE.pdf},
   month =	 {March},
   doi =		 {10.1109/JPROC.2015.2428213}
 }
@@ -1509,7 +1546,7 @@
   keywords =	 {highlight},
   volume =	 11,
   number =	 {1144--1146},
-  pdf =		 {papers/2014-Alneberg-NatMeth.pdf},
+  pdf =		 {https://github.com/openresearchlabs/openresearchlabs.github.io/blob/master/content/publication_resources/papers/2014-Alneberg-NatMeth.pdf},
   note =	 {CONCOCT algorithm},
   doi =		 {10.1038/nmeth.3103}
 }
@@ -1522,7 +1559,7 @@
   year =	 2014,
   volume =	 5,
   pages =	 4344,
-  pdf =		 {papers/2014-Lahti-NatComm.pdf},
+  pdf =		 {https://github.com/openresearchlabs/openresearchlabs.github.io/blob/master/content/publication_resources/papers/2014-Lahti-NatComm.pdf},
   month =	 7,
   authorship =	 {first},
   keywords =	 {bioscience},
@@ -1543,7 +1580,7 @@
   year =	 2014,
   keywords =	 {bioscience},
   volume =	 8,
-  pdf =		 {papers/2014-Salonen-ISME.pdf},
+  pdf =		 {https://github.com/openresearchlabs/openresearchlabs.github.io/blob/master/content/publication_resources/papers/2014-Salonen-ISME.pdf},
   authorship =	 {second},
   pages =	 {2218--2230},
   doi =		 {10.1038/ismej.2014.63}
@@ -1591,7 +1628,7 @@
   keywords =	 {bioscience},
   authorship =	 {first, corresponding},
   doi =		 {10.1109/TCBB.2009.38},
-  pdf =		 {papers/2011-Lahti-TCBB.pdf},
+  pdf =		 {https://github.com/openresearchlabs/openresearchlabs.github.io/blob/master/content/publication_resources/papers/2011-Lahti-TCBB.pdf},
   publisher =	 {IEEE Computer Society},
   address =	 {Los Alamitos, CA, USA},
   annote =	 {R/Bioconductor: RPA}
@@ -1643,7 +1680,7 @@
   month =	 7,
   pages =	 {e23035},
   url =		 {10.1371/journal.pone.0023035},
-  pdf =		 {papers/2011-JalankaTuovinen-PLoS.pdf},
+  pdf =		 {https://github.com/openresearchlabs/openresearchlabs.github.io/blob/master/content/publication_resources/papers/2011-JalankaTuovinen-PLoS.pdf},
 }
 
 @article{Louhimo14,
@@ -1663,7 +1700,7 @@
                   workshop},
   year =	 2014,
   month =	 4,
-  pdf =		 {papers/2014-Louhimo.pdf},
+  pdf =		 {https://github.com/openresearchlabs/openresearchlabs.github.io/blob/master/content/publication_resources/papers/2014-Louhimo.pdf},
   doi =		 {10.4161/sysb.28904}
 }
 
@@ -1674,7 +1711,7 @@
   category =	 {abstract},
   authorship =	 {first, corresponding},
   keywords =	 {bioscience},
-  pdf =		 {papers/2011-MLSB-Lahti.pdf},
+  pdf =		 {https://github.com/openresearchlabs/openresearchlabs.github.io/blob/master/content/publication_resources/papers/2011-MLSB-Lahti.pdf},
   month =	 {July},
   year =	 2011,
   note =	 {Machine Learning for Systems Biology workshop, ISMB,
@@ -1689,7 +1726,7 @@
                   Reveals Asbestos- and Histology-Related Changes in
                   Lung Cancer},
   journal =	 {Genes, Chromosomes and Cancer},
-  pdf =		 {papers/2011-Nymark-GCC.pdf},
+  pdf =		 {https://github.com/openresearchlabs/openresearchlabs.github.io/blob/master/content/publication_resources/papers/2011-Nymark-GCC.pdf},
   year =	 2011,
   volume =	 50,
   number =	 8,
@@ -1710,7 +1747,7 @@
   journal =	 {Genes, Chromosomes and Cancer},
   year =	 2011,
   authorship =	 {second},
-  pdf =		 {papers/2011-Niini-GCC.pdf},
+  pdf =		 {https://github.com/openresearchlabs/openresearchlabs.github.io/blob/master/content/publication_resources/papers/2011-Niini-GCC.pdf},
   volume =	 50,
   number =	 5,
   month =	 5,
@@ -1733,7 +1770,7 @@
   authorship =	 {second},
   keywords =	 {bioscience},
   doi =		 {10.1093/nar/gni193},
-  pdf =		 {papers/2005-Elo-NAR.pdf},
+  pdf =		 {https://github.com/openresearchlabs/openresearchlabs.github.io/blob/master/content/publication_resources/papers/2005-Elo-NAR.pdf},
   year =	 2005
 }
 
@@ -1754,7 +1791,7 @@
   note =	 {Special Issue on Machine Learning for Bioinformatics
                   -- Part 2},
   doi =		 {10.1109/TCBB.2005.32},
-  pdf =		 {papers/2005-TCBB–Kaski-AC.pdf}
+  pdf =		 {https://github.com/openresearchlabs/openresearchlabs.github.io/blob/master/content/publication_resources/papers/2005-TCBB–Kaski-AC.pdf}
 }
 
 @MastersThesis{Lahti03,
@@ -1804,19 +1841,7 @@
   annote =	 {CCA on two asbestos-exposed cell lines.}
 }
 
-@TechReport{Sinkkonen05tr,
-  author =	 {Janne Sinkkonen and Samuel Kaski and Janne
-                  Nikkil{\"a} and Leo Lahti},
-  title =	 {Associative Clustering (AC): Technical Details},
-  institution =	 {Helsinki University of Technology},
-  year =	 2005,
-  number =	 {A84},
-  address =	 {Espoo, Finland},
-  month =	 {April},
-  status =	 {datascience},
-  pdf =		 {papers/2005-TechRep-Sinkkonen-ACtechdetails.pdf},
-  note =	 {Publications in Computer and Information Science}
-}
+
 
 @InCollection{Sinkkonen04ecml,
   author =	 {Janne Sinkkonen and Janne Nikkil\"{a} and Leo Lahti
@@ -1833,7 +1858,7 @@
   year =	 2004,
   url =
                   {http://www.cis.hut.fi/projects/mi/abstracts/ecml04.html},
-  pdf =		 {papers/2004-ECML-Sinkkonen-AC.pdf}
+  pdf =		 {https://github.com/openresearchlabs/openresearchlabs.github.io/blob/master/content/publication_resources/papers/2004-ECML-Sinkkonen-AC.pdf}
 }
 
 @TechReport{Sinkkonen03tr,
@@ -1846,7 +1871,7 @@
   year =	 2003,
   month =	 6,
   number =	 {A68},
-  pdf =		 {papers/2003-TechRep-Sinkkonen-ACBayesFactor.pdf},
+  pdf =		 {https://github.com/openresearchlabs/openresearchlabs.github.io/blob/master/content/publication_resources/papers/2003-TechRep-Sinkkonen-ACBayesFactor.pdf},
   address =	 {Espoo, Finland}
 }
 
@@ -1864,7 +1889,7 @@
   software =	 {yes},
   volume =	 9,
   number =	 1,
-  pdf =		 {papers/2017-Lahti-RJournal.pdf},
+  pdf =		 {https://github.com/openresearchlabs/openresearchlabs.github.io/blob/master/content/publication_resources/papers/2017-Lahti-RJournal.pdf},
   authorship =	 {first, corresponding},
   annote =	 {R package homepage URL:
                   http://ropengov.github.io/eurostat/}
@@ -1884,7 +1909,7 @@
   keywords =	 {review},
   pages =	 {182--199},
   year =	 2017,
-  pdf =		 {papers/2017-Shetty-FEMS.pdf},
+  pdf =		 {https://github.com/openresearchlabs/openresearchlabs.github.io/blob/master/content/publication_resources/papers/2017-Shetty-FEMS.pdf},
   pages =	 {fuw045},
   doi =		 {10.1093/femsre/fuw045}
 }
@@ -1917,7 +1942,7 @@
   number =	 10,
   year =	 2013,
   pages =	 {e110},
-  pdf =		 {papers/2013-Lahti-NAR.pdf},
+  pdf =		 {https://github.com/openresearchlabs/openresearchlabs.github.io/blob/master/content/publication_resources/papers/2013-Lahti-NAR.pdf},
   authorship =	 {first, corresponding},
   doi =		 {10.1093/nar/gkt229},
   note =	 {Implementation available through Bioconductor RPA
@@ -1933,7 +1958,7 @@
                   Predictive Models in Personalized Medicine},
   category =	 {abstract},
   keywords =	 {bioscience},
-  pdf =		 {papers/2011-Faisal-NIPS.pdf},
+  pdf =		 {https://github.com/openresearchlabs/openresearchlabs.github.io/blob/master/content/publication_resources/papers/2011-Faisal-NIPS.pdf},
   year =	 2011
 }
 
@@ -1963,7 +1988,7 @@
                   learning, computational biology, open source, open
                   access, creative commons},
   url =		 {http://lib.tkk.fi/Diss/2010/isbn9789526033686/},
-  pdf =		 {papers/2010-Lahti-thesis.pdf},
+  pdf =		 {https://github.com/openresearchlabs/openresearchlabs.github.io/blob/master/content/publication_resources/papers/2010-Lahti-thesis.pdf},
   issn =	 {1797-5069},
   abstract =	 {Recent advances in high-throughput measurement
                   technologies and efficient sharing of biomedical
@@ -2036,7 +2061,7 @@
                   http://netpro.r-forge.r-project.org/},
   url =
                   {http://bioinformatics.oxfordjournals.org/content/early/2010/09/02/bioinformatics.btq500.abstract.html?ijkey=N1zzjtUBRng3wCM&keytype=ref},
-  pdf =		 {papers/2010-Bioinformatics-Lahti-NetResponse.pdf},
+  pdf =		 {https://github.com/openresearchlabs/openresearchlabs.github.io/blob/master/content/publication_resources/papers/2010-Bioinformatics-Lahti-NetResponse.pdf},
   annote =	 {ArXiv: http://arxiv.org/abs/1202.0501; R/Matlab
                   source code http://netpro.r-forge.r-project.org}
 }
@@ -2053,7 +2078,7 @@
   pages =	 {1544--1522},
   month =	 11,
   doi =		 {10.1038/modpathol.2010.146},
-  pdf =		 {papers/2010-ModernPathology-Mosakhani-Dupuytre.pdf},
+  pdf =		 {https://github.com/openresearchlabs/openresearchlabs.github.io/blob/master/content/publication_resources/papers/2010-ModernPathology-Mosakhani-Dupuytre.pdf},
   note =	 {International Dupuytren Award for best research
                   paper in 2011}
 }
@@ -2143,7 +2168,7 @@
   volume =	 48,
   number =	 7,
   month =	 7,
-  pdf =		 {papers/2009-GCC-Guled-miRNA.pdf},
+  pdf =		 {https://github.com/openresearchlabs/openresearchlabs.github.io/blob/master/content/publication_resources/papers/2009-GCC-Guled-miRNA.pdf},
   authorship =	 {second},
   pages =	 {615--623},
   doi =		 {10.1002/gcc.20669}
@@ -2160,7 +2185,7 @@
   howpublished = {software},
   pages =	 {198--203},
   address =	 {Piscataway, NJ},
-  pdf =		 {papers/2009-MLSP-Lahti-SimCCA.pdf},
+  pdf =		 {https://github.com/openresearchlabs/openresearchlabs.github.io/blob/master/content/publication_resources/papers/2009-MLSP-Lahti-SimCCA.pdf},
   note =	 {R/Bioconductor: pint},
   authorship =	 {first, corresponding},
   url =		 {http://arxiv.org/abs/1101.5919},

--- a/content/publication_resources/bibtex/lahti.bib
+++ b/content/publication_resources/bibtex/lahti.bib
@@ -1,75 +1,38 @@
-@Article{Ruuskanen2021diabetes,
-  author =	 {Matti O. Ruuskanen and Pande P. Erawijantari and Aki S. Havulinna and Yang Liu and Guillaume Meric and Michael Inouye and Pekka Jousilahti and Veikko Salomaa and Mohit Jain and Rob Knight and Leo Lahti and Teemu J. Niiranen},
-  title =	 {Gut microbiome composition is predictive of incident type 2 diabetes},
-  journal =	 {medRxiv},
-  year =	 {2021},
-  volume =	 {},
-  number =	 {},
-  pages =	 {2021.11.10.21266163},
-  month =	 {},
-  url =		 {},
-  pubstate = {preprint},
-  note =	 {},
-  doi = {10.1101/2021.11.10.21266163 },
-  annote =	 {}  
-}
-
-
-
-
-
-
-
-@Article{Mokkala2021,
-  author =	 {Kati Mokkala and Tero Vahlberg and Noora Houttu and
-                  Ella Koivuniemi and Leo Lahti and Kirsi Laitinen},
-  title =	 {Impact of combined consumption of fish oil and
-                  probiotics on the serum metabolome in pregnant women
-                  with overweight or obesity},
-  journal =	 {EbioMedicine},
-  year =	 2021,
-  volume =	 73,
-  pages =	 103655,
-  month =	 {November},
-  doi =		 {10.1016/j.ebiom.2021.103655},
-  keywords =	 {bioscience}
-}
-
-
-@article{Liu2021liver,
-	title        = {Early prediction of liver disease using conventional risk factors and gut microbiome-augmented gradient boosting},
-	author       = {Liu, Yang and Meric, Guillaume and Havulinna, Aki S. and Teo, Shu Mei and Ruuskanen, Matti and Sanders, Jon and Zhu, Qiyun and Tripathi, Anupriya and Verspoor, Karin and Cheng, Susan and Jain, Mo and Jousilahti, Pekka and Vazquez-Baeza, Yoshiki and Loomba, Rohit and Lahti, Leo and Niiranen, Teemu and Salomaa, Veikko and Knight, Rob and Inouye, Michael},
-	year         = 2020,
+@article{Ruuskanen2021diabetes,
+	title        = {Gut microbiome composition is predictive of incident type 2 diabetes},
+	author       = {Matti O. Ruuskanen and Pande P. Erawijantari and Aki S. Havulinna and Yang Liu and Guillaume Meric and Michael Inouye and Pekka Jousilahti and Veikko Salomaa and Mohit Jain and Rob Knight and Leo Lahti and Teemu J. Niiranen},
+	year         = 2021,
+	month        = {},
 	journal      = {medRxiv},
-	doi          = {10.1101/2020.06.24.20138933},
-	url          = {https://www.medrxiv.org/content/early/2020/06/25/2020.06.24.20138933},
-	eprint       = {https://www.medrxiv.org/content/early/2020/06/25/2020.06.24.20138933.full.pdf},
-	keywords       = {preprint}
+	volume       = {},
+	number       = {},
+	pages        = {2021.11.10.21266163},
+	doi          = {10.1101/2021.11.10.21266163},
+	url          = {},
+	note         = {},
+	pubstate     = {preprint},
+	annote       = {}
 }
-
-
-@Article{Qin2021,
-  author =	 {Youwen Qin and Aki S. Havulinna and Yang Liu and
-                  Pekka Jousilahti and Scott C. Ritchie and Alex
-                  Tokolyi and Jon G. Sanders and Liisa Valsta and
-                  Marta Brożyńska and Qiyun Zhu and Anupriya Tripathi
-                  and Yoshiki Vazquez-Baeza and Rohit Loomba and Susan
-                  Cheng and Mohit Jain and Teemu Niiranen and Leo
-                  Lahti and Rob Knight and Veikko Salomaa and Michael
-                  Inouye and Guillaume Méric},
-  title =	 {Combined effects of host genetics and diet on human
-                  gut microbiota and incident disease in a single
-                  population cohort},
-  journal =	 {medRxiv (preprint)},
-  year =	 2021,
-  pages =	 {2020.09.12.20193045},
-  keywords =	 {preprint},
-  doi =		 {10.1101/2020.09.12.20193045}
+@article{Mokkala2021,
+	title        = {Impact of combined consumption of fish oil and probiotics on the serum metabolome in pregnant women with overweight or obesity},
+	author       = {Kati Mokkala and Tero Vahlberg and Noora Houttu and Ella Koivuniemi and Leo Lahti and Kirsi Laitinen},
+	year         = 2021,
+	month        = 11,
+	journal      = {EbioMedicine},
+	volume       = 73,
+	pages        = 103655,
+	doi          = {10.1016/j.ebiom.2021.103655},
+	keywords     = {bioscience}
 }
-
-
-
-
+@article{Qin2021,
+	title        = {Combined effects of host genetics and diet on human gut microbiota and incident disease in a single population cohort},
+	author       = {Youwen Qin and Aki S. Havulinna and Yang Liu and Pekka Jousilahti and Scott C. Ritchie and Alex Tokolyi and Jon G. Sanders and Liisa Valsta and Marta Brożyńska and Qiyun Zhu and Anupriya Tripathi and Yoshiki Vazquez-Baeza and Rohit Loomba and Susan Cheng and Mohit Jain and Teemu Niiranen and Leo Lahti and Rob Knight and Veikko Salomaa and Michael Inouye and Guillaume Méric},
+	year         = 2021,
+	journal      = {medRxiv (preprint)},
+	pages        = {2020.09.12.20193045},
+	doi          = {10.1101/2020.09.12.20193045},
+	keywords     = {preprint}
+}
 @article{Zhu2021,
 	title        = {OGUs enable effective, phylogeny-aware analysis of even shallow metagenome community structures},
 	author       = {Zhu, Qiyun and Huang, Shi and Gonzalez, Antonio and McGrath, Imran and McDonald, Daniel and Haiminen, Niina and Armstrong, George and V{\'a}zquez-Baeza, Yoshiki and Yu, Julian and Kuczynski, Justin and Sepich-Poore, Gregory D and Swafford, Austin D and Das, Promi and Shaffer, Justin P and Lejzerowicz, Franck and Belda-Ferre, Pedro and Havulinna, Aki S and M{\'e}ric, Guillaume and Niiranen, Teemu and Lahti, Leo and Salomaa, Veikko and Kim, Ho-Cheol and Jain, Mohit and Inouye, Michael and Gilbert, Jack and Knight, Rob},
@@ -81,117 +44,23 @@
 	eprint       = {https://www.biorxiv.org/content/early/2021/04/06/2021.04.04.438427.full.pdf},
 	keywords     = {preprint}
 }
-
-
-
-@Article{Laitinen2021ews,
-  author =	 {Ville Laitinen and Vasilis Dakos and Leo Lahti},
-  title =	 {Probabilistic early warning signals},
-  journal =	 {Ecology & Evolution},
-  year =	 2021,
-  volume =	 11,
-  number =	 20,
-  pages =	 {14101-14114},
-  month =	 {September},
-  keywords     = {bioscience},  
-  doi =		 {10.1002/ece3.8123}
-}
-
-
-
-@article{Aatsinki2018,
-	title        = {Gut Microbiota Composition in Mid-Pregnancy Is Associated with Gestational Weight Gain but Not Prepregnancy Body Mass Index},
-	author       = {Anna-Katariina Aatsinki and Henna-Maria Uusitupa and Eveliina Munukka and Henri Pesonen and Anniina Rintala and Sami Pietilä and Leo Lahti and Erkki Eerola and Linnea Karlsson and Hasse Karlsson},
-	year         = 2018,
-	month        = {May},
-	journal      = {Journal of Womens Health},
-	doi          = {10.1089/jwh.2017.6488},
-	note         = {Epub ahead of print.},
-	keywords     = {bioscience},
-	url          = {https://github.com/openresearchlabs/openresearchlabs.github.io/blob/master/content/publication_resources/papers/2018-Aatsinki.pdf}
-}
-
-@article{Aatsinki2019,
-	title        = {Gut microbiota composition is associated with temperament traits in infants},
-	author       = {Anna Aatsinki and Leo Lahti and Henna Uusitupa and Eveliina Munukka and Anniina Keskitalo, Saara Nolvi and Siobhain O'Mahony and Sami Pietilä and Laura Elo and Erkki Eerola and Hasse Karlsson and Linnea Karlsson},
-	year         = 2019,
-	month        = {May},
-	journal      = {Brain Behavior and Immunity},
-	volume       = 80,
-	pages        = {849--858},
-	doi          = {10.1016/j.bbi.2019.05.035},
-	url          = {https://github.com/openresearchlabs/openresearchlabs.github.io/blob/master/content/publication_resources/papers/2019-Aatsinki.pdf},
-	keywords     = {bioscience}
-}
-
-
-@article{Aatsinki2020,
-	title        = {Maternal prenatal psychological distress and hair cortisol levels associate with infant fecal microbiota composition at 2.5 months of age},
-	author       = {Anna-Katariina Aatsinki and Anniina Keskitalo and Ville Laitinen and Eveliina Munukka and Henna-Maria Uusitupa and Leo Lahti and Susanna Kortesluoma and Paula Mustonen and Ana João Rodrigues and Bárbara Coimbra and Pentti Huovinen and Hasse Karlsson and Linnea Karlsson},
-	year         = 2020,
-	journal      = {Psychoneuroendocrinology},
-	volume       = 119,
-	pages        = 104754,
-	doi          = {10.1016/j.psyneuen.2020.104754},
-	keywords     = {bioscience}
-}
-
-@article{Aleksic14,
-	title        = {The Open Science Peer Review Oath},
-	author       = {Jelena Aleksic and Adrian Alexa and Teresa K Attwood and Neil Chue Hong and Martin Dahl{\"o} and Robert Davey and Holger Dinkel and Konrad U F{\"o}rstner and Ivo Grigorov and Jean-Karim Hériché and Leo Lahti and Dan MacLean and Michael L Markie and Jenny Molloy and Maria Victoria Schneider and Camille Scott and Richard Smith-Unna and Bruno Miguel Vieira},
-	year         = 2015,
-	month        = 1,
-	journal      = {F1000Research},
-	volume       = 3,
-	pages        = 271,
-	doi          = {10.12688/f1000research.5686.2},
-	category     = {perspective},
-	note         = {AllBio: Open Science & Reproducibility Best Practice Workshop},
-	keywords     = {openscience},
-	url          = {https://github.com/openresearchlabs/openresearchlabs.github.io/blob/master/content/publication_resources/papers/2014-Aleksic.pdf}
-}
-
-
-@article{Alneberg14,
-	title        = {Binning metagenomic contigs by coverage and composition},
-	author       = {Johannes Alneberg and Brynjar Smári Bjarnason and Ino de Bruijn and Melanie Schirmer and Joshua Quick and Umer Z Ijaz and Leo Lahti and Nicholas J Loman and Anders F Andersson and Christopher Quince},
-	year         = 2014,
-	journal      = {Nature Methods},
+@article{Laitinen2021ews,
+	title        = {Probabilistic early warning signals},
+	author       = {Ville Laitinen and Vasilis Dakos and Leo Lahti},
+	year         = 2021,
+	month        = 9,
+	journal      = {Ecology & Evolution},
 	volume       = 11,
-	number       = {1144--1146},
-	doi          = {10.1038/nmeth.3103},
-	note         = {CONCOCT algorithm},
-	keywords     = {bioscience},
-	url          = {https://github.com/openresearchlabs/openresearchlabs.github.io/blob/master/content/publication_resources/papers/2014-Alneberg-NatMeth.pdf}
+	number       = 20,
+	pages        = {14101--14114},
+	doi          = {10.1002/ece3.8123},
+	keywords     = {bioscience}
 }
-
-
-@article{Arani2018,
-	title        = {Stability estimation of autoregulated genes under Michaelis-Menten type kinetics},
-	author       = {Arani, Babak M. S. and Mahmoudi, Mahdi and Lahti, Leo and Gonz\'alez, Javier and Wit, Ernst C.},
-	year         = 2018,
-	month        = {Jun},
-	journal      = {Physical Review E},
-	publisher    = {American Physical Society},
-	volume       = 97,
-	number       = 6,
-	pages        = 062407,
-	doi          = {10.1103/PhysRevE.97.062407},
-	issn         = {2470-0045},
-	url          = {https://link.aps.org/doi/10.1103/PhysRevE.97.062407},
-	numpages     = 10,
-	keywords       = {datascience},
-	url          = {https://github.com/openresearchlabs/openresearchlabs.github.io/blob/master/content/publication_resources/papers/2018-Arani-PhysRevE.pdf}
-}
-
-
-
-
 @article{Arani2021,
 	title        = {Exit Time as a Measure of Ecological Resilience},
 	author       = {Babak M.S. Arani and Egbert van Nes and Leo Lahti and Stephen R. Carpenter and Marten Scheffer},
 	year         = 2021,
-	month        = {June},
+	month        = 6,
 	journal      = {Science},
 	volume       = 372,
 	number       = 6547,
@@ -199,223 +68,11 @@
 	doi          = {10.1126/science.aay4895},
 	keywords     = {datascience}
 }
-
-
-
-
-
-
-@techreport{Bjork2018,
-	title        = {Opening academic publishing: development and application of systematic evaluation criteria},
-	author       = {Anna Björk and Juho-Matti Paavolainen and Teemu Ropponen and Mikael Laakso and Leo Lahti},
-	year         = 2018,
-	month        = {January},
-	publisher    = {Open Science and Research Initiative (ATT)},
-	url          = {http://urn.fi/URN:NBN:fi-fe201802123334},
-	category     = {report},
-	note         = {Report on the openness of major scientific publishers commissioned by Finnish Ministry of Education and Culture},
-	institution  = {unknown},
-	authorship   = {corresponding},
-	pubstate     = {openscience},
-	keywords     = {openscience},
-	url          = {https://github.com/openresearchlabs/openresearchlabs.github.io/blob/master/content/publication_resources/papers/2018-Bjork-ATT.pdf}
-}
-
-@article{Borze11,
-	title        = {MicroRNA microarrays on archive bone marrow core biopsies of leukemias - method validation},
-	author       = {Ioana Borze and Mohamed Guled and Suad Musse and Anna Raunio and Erkki Elonen and Ulla Saarinen-Pihkala and Marja-Liisa Karjalainen-Lindsberg and Leo Lahti and Sakari Knuutila.},
-	year         = 2011,
-	month        = 2,
-	journal      = {Leukemia Research},
-	volume       = 35,
-	pages        = {188--195},
-	doi          = {10.1016/j.leukres.2010.08.005},
-	issue        = 2,
-	keywords     = {bioscience},	
-}
-
-
-
-@article{Buelow2017,
-	title        = {Comparative gut microbiota and resistome profiling of intensive care patients receiving selective digestive tract decontamination and healthy subjects},
-	author       = {Elena Buelow and Teresita {d.J.} Bello González and Susana Fuentes and Wouter A.A. {de Steenhuijsen Piters} and Leo Lahti and Jumamurat R. Bayjanov and Eline A.M. Majoor and Johanna C. Braat and Maaike S. van Mourik and Evelien A.N. Oostdijk and Rob J.L. Willems and Marc J.M. Bonten and Mark W.J. van Passel and Hauke Smidt and Willem van Schaik},
-	year         = 2017,
-	month        = {Aug},
-	journal      = {Microbiome},
-	volume       = 5,
-	number       = 1,
-	pages        = 88,
-	doi          = {10.1186/s40168-017-0309-z},
-	keywords     = {bioscience},
-	url          = {https://github.com/openresearchlabs/openresearchlabs.github.io/blob/master/content/publication_resources/papers/2017-Buelow-Microbiome.pdf}
-}
-
-
-
-
-
-@article{Elo05,
-	title        = {Integrating probe-level expression changes across generations of Affymetrix arrays},
-	author       = {Elo, Laura L. and Lahti, Leo and Skottman, Heli and Kyl{\"a}niemi, Minna and Lahesmaa, Riitta and Aittokallio, Tero},
-	year         = 2005,
-	month        = 12,
-	journal      = {Nucleic Acids Research},
-	volume       = 33,
-	number       = 22,
-	pages        = {e193},
-	doi          = {10.1093/nar/gni193},
-	authorship   = {second},
-	keywords     = {bioscience},
-	url          = {https://github.com/openresearchlabs/openresearchlabs.github.io/blob/master/content/publication_resources/papers/2005-Elo-NAR.pdf}
-}
-
-
-
-@inproceedings{Faisal2011,
-	title        = {Biomarker discovery via dependency analysis of multi-view functional genomics data},
-	author       = {Ali Faisal and Riku Louhimo and Leo Lahti and Sampsa Hautaniemi and Samuel Kaski},
-	year         = 2011,
-	booktitle    = {NIPS 2011 workshop From Statistical Genetics to Predictive Models in Personalized Medicine},
-	category     = {abstract},
-	keywords     = {bioscience},
-	url          = {https://github.com/openresearchlabs/openresearchlabs.github.io/blob/master/content/publication_resources/papers/2011-Faisal-NIPS.pdf}
-}
-
-
-@article{Faust15,
-	title        = {Metagenomics meets time series analysis: unraveling microbial community dynamics},
-	author       = {Karoline Faust and Leo Lahti and Didier Gonze and Willem M de Vos and Jeroen Raes},
-	year         = 2015,
-	month        = 6,
-	journal      = {Current Opinion in Microbiology},
-	volume       = 25,
-	pages        = {56--66},
-	doi          = {10.1016/j.mib.2015.04.004},
-	category     = {review},
-	keywords     = {bioscience},
-	authorship   = {shared first},
-	url          = {https://github.com/openresearchlabs/openresearchlabs.github.io/blob/master/content/publication_resources/papers/2015-Faust-CurrOpMicrob.pdf}
-}
-
-
-
-
-@article{Faust2017,
-	title        = {Multi-stability and the origin of microbial community types},
-	author       = {Didier Gonze and Leo Lahti and Jeroen Raes and Karoline Faust},
-	year         = 2017,
-	month        = {may},
-	journal      = {ISME Journal},
-	volume       = 11,
-	pages        = {2159--2166},
-	doi          = {10.1038/ismej.2017.60},
-	keywords     = {bioscience},
-	url          = {https://github.com/openresearchlabs/openresearchlabs.github.io/blob/master/content/publication_resources/papers/2017-Faust-ISME.pdf}
-}
-
-
-
-
-@article{Faust2018,
-	title        = {Signatures of ecological processes in microbial community time series},
-	author       = {Karoline Faust and Franziska Bauchinger and Beatrice Laroche and Sophie de Buyl and Leo Lahti and Alex D Washburne and Didier Gonze and Stefanie Widder},
-	year         = 2018,
-	month        = {June},
-	journal      = {Microbiome},
-	volume       = 6,
-	number       = 120,
-	doi          = {10.1186/s40168-018-0496-2},
-	keywords     = {bioscience},
-	url          = {https://github.com/openresearchlabs/openresearchlabs.github.io/blob/master/content/publication_resources/papers/2018-Faust-Microbiome.pdf}
-}
-
-
-@article{Gonze2018,
-	title        = {Microbial communities as dynamical systems},
-	author       = {Didier Gonze and Katharine Z Coyte and Leo Lahti and Karoline Faust},
-	year         = 2018,
-	month        = {July},
-	journal      = {Current Opinion in Microbiology},
-	volume       = 44,
-	pages        = {41--49},
-	doi          = {10.1016/j.mib.2018.07.004},
-	keywords     = {bioscience},
-	url          = {https://github.com/openresearchlabs/openresearchlabs.github.io/blob/master/content/publication_resources/papers/2018-Gonze.pdf}
-}
-
-
-@article{Guled09,
-	title        = {CDKN2A, NF2 and JUN Are Dysregulated Among Other Genes by miRNAs in Malignant Mesothelioma - a miRNA Microarray Analysis},
-	author       = {Mohamed Guled and Leo Lahti and Pamela M. Lindholm and Kaisa Salmenkivi and Izhar Bagwan and Andrew G. Nicholson and Sakari Knuutila},
-	year         = 2009,
-	month        = 7,
-	journal      = {Genes, Chromosomes and Cancer},
-	volume       = 48,
-	number       = 7,
-	pages        = {615--623},
-	doi          = {10.1002/gcc.20669},
-	url          = {https://github.com/openresearchlabs/openresearchlabs.github.io/blob/master/content/publication_resources/papers/2009-GCC-Guled-miRNA.pdf},
-	keywords = {bioscience}
-}
-
-
-
-
-
-@article{Harris17,
-	title        = {Linking statistical and ecological theory: Hubbell's unified neutral theory of biodiversity as a hierarchical Dirichlet process},
-	author       = {Keith Harris and Todd L Parsons and Umer Z Ijaz and Leo Lahti and Ian Holmes and Christopher Quince},
-	year         = 2017,
-	month        = {March},
-	journal      = {Proceedings of the IEEE},
-	volume       = 105,
-	number       = 3,
-	pages        = {516--529},
-	doi          = {10.1109/JPROC.2015.2428213},
-	keywords     = {bioscience},
-	url          = {https://github.com/openresearchlabs/openresearchlabs.github.io/blob/master/content/publication_resources/papers/2017-Harris-IEEE.pdf}
-}
-
-
-
-@inproceedings{Hill2018,
-	title        = {Spheres of “public” in eighteenth-century Britain},
-	author       = {Mark J Hill and Antti Kanner and Jani Marjanen and Ville Vaara and Eetu Mäkelä and Leo Lahti and Mikko Tolonen},
-	year         = 2018,
-	month        = 3,
-	booktitle    = {Proceedings of the Digital Humanities in the Nordics Conference},
-	address      = {Helsinki, Finland},
-	category     = {abstract},
-	keywords       = {dh}
-}
-
-
-
-
-
-@inproceedings{Hill2019dhn,
-	title        = {Reconstructing intellectual networks: from the {ESTC}'s bibliographic metadata to historical material},
-	author       = {Mark J Hill and Ville Vaara and Tanja S{\"a}ily and Leo Lahti and Mikko Tolonen},
-	year         = 2019,
-	month        = {March},
-	booktitle    = {Proc. Digital Humanities in the Nordic Countries},
-	address      = {Copenhagen},
-	series       = {CEUR Workshop Proceedings},
-	volume       = 2364,
-	pages        = {201--219},
-	note         = {Best paper award.},
-	editor       = {Costanza Navarretta and Manex Agirrezabal and Bente Maegaard},
-	url          = {https://github.com/openresearchlabs/openresearchlabs.github.io/blob/master/content/publication_resources/papers/2019-Hill-DHN.pdf},
-	keywords     = {dh}
-}
-
-
-
 @article{Hintikka2021,
 	title        = {Xylo-Oligosaccharides in Prevention of Hepatic Steatosis and Adipose Tissue Inflammation: Associating Taxonomic and Metabolomic Patterns in Fecal Microbiomes with Biclustering},
 	author       = {Hintikka, J and Lensu, S and Mäkinen, E and Karvinen, S and Honkanen, M and Linden, J and Garrels, T and Pekkala, S and Lahti, L},
 	year         = 2021,
-	month        = {April},
+	month        = 4,
 	journal      = {International Journal of Environmental Research and Public Health},
 	volume       = 18,
 	number       = 8,
@@ -423,583 +80,19 @@
 	doi          = {10.3390/ijerph18084049},
 	keywords     = {bioscience}
 }
-
-
-
-
-
-@inproceedings{Ijaz2019dh,
-	title        = {Analytical Edition Detection In Bibliographic Metadata},
-	author       = {Ali Ijaz and Hege Roivainen and Leo Lahti},
-	year         = 2019,
-	month        = {July},
-	booktitle    = {Proceedings of the Digital Humanities (DH2019)},
-	note         = {In press.},
-	keywords     = {dh}
-}
-
-
-@inproceedings{Ijaz2019rdhum,
-	title        = {Analytical determination of editions from bibliographic metadata},
-	author       = {Ali Ijaz and Mikko Tolonen and Leo Lahti},
-	year         = 2019,
-	month        = {August},
-	booktitle    = {Proceedings of the Research Data in the Humanities Conference},
-	address      = {Oulu},
-	url          = {https://github.com/openresearchlabs/openresearchlabs.github.io/blob/master/content/publication_resources/papers/2019-Ijaz-RDHum.pdf},
-	keywords = {dh}
-}
-
-@article{Jalanka-Tuovinen11,
-	title        = {Intestinal microbiota in healthy adults: Temporal analysis reveals individual and common core and relation to intestinal symptoms},
-	author       = {Jonna Jalanka-Tuovinen and Anne Salonen and Janne Nikkil{\"a} and Outi Immonen and Riina Kekkonen and Leo Lahti and Airi Palva and Willem M. de Vos},
-	year         = 2011,
-	month        = 7,
-	journal      = {PLoS One},
-	volume       = 6,
-	number       = 7,
-	pages        = {e23035},
-	url          = {10.1371/journal.pone.0023035},
-	keywords     = {bioscience},
-	url          = {https://github.com/openresearchlabs/openresearchlabs.github.io/blob/master/content/publication_resources/papers/2011-JalankaTuovinen-PLoS.pdf}
-}
-
-
-
-
-@article{Kaski05,
-	title        = {Associative clustering for exploring dependencies between functional genomics data sets},
-	author       = {Samuel Kaski and Janne Nikkil{\"a} and Janne Sinkkonen and Leo Lahti and Juha Knuuttila and Christophe Roos},
-	year         = 2005,
-	month        = {September},
-	journal      = {IEEE/ACM Transactions on Computational Biology and Bioinformatics},
-	volume       = 2,
-	number       = 3,
-	pages        = {203--216},
-	doi          = {10.1109/TCBB.2005.32},
-	note         = {Special Issue on Machine Learning for Bioinformatics -- Part 2},
-	keywords       = {datascience},
-	url          = {https://github.com/openresearchlabs/openresearchlabs.github.io/blob/master/content/publication_resources/papers/2005-TCBB–Kaski-AC.pdf}
-}
-
 @article{Keskitalo2021,
 	title        = {Gut microbiota diversity but not composition is related to saliva cortisol stress response at the age of 2.5 months},
 	author       = {Keskitalo, A and Aatsinki, A-K and Kortesluoma, S and Pelto, J and Korhonen, L and Lahti, L and Lukkarinen, M and Munukka, E and Karlsson, H and Karlsson, L},
 	year         = 2021,
-	month        = {March},
+	month        = 3,
 	journal      = {Stress},
 	volume       = 24,
 	number       = 5,
 	pages        = {551--560},
 	doi          = {10.1080/10253890.2021.1895110},
 	note         = {In press.},
-	keywords       = {bioscience}
-}
-
-
-@article{Khalighi2021,
-	title        = {Three-species Lotka-Volterra model with respect to Caputo and Caputo-Fabrizio fractional operators},
-	author       = {Moein Khalighi and Leila Eftekhari and Soleiman Hosseinpour and Leo Lahti},
-	year         = 2020,
-	month        = {January},
-	journal      = {Symmetry},
-	volume       = 13,
-	pages        = 368,
-	doi          = {10.3390/sym13030368},
-	issue        = 3,
-	keywords       = {datascience}
-}
-
-
-
-@article{Koffert2020,
-	title        = {Partial restoration of normal intestinal microbiota in morbidly obese women six months after bariatric surgery},
-	author       = {Jukka Koffert and Leo Lahti and Lotta Nylund and Seppo Salminen and Jarna C Hannukainen and Paulina Salminen and Willem de Vos and Pirjo Nuutila},
-	year         = 2020,
-	journal      = {PeerJ – Life & Environment},
-	volume       = 8,
-	pages        = {e10442},
-	doi          = {10.7717/peerj.10442},
-	note         = {Shared first authorship.},
 	keywords     = {bioscience}
 }
-
-
-@mastersthesis{Lahti03,
-	title        = {Comparative functional genome analysis using associative clustering},
-	author       = {Lahti, Leo},
-	year         = 2003,
-	month        = 12,
-	url          = {https://github.com/antagomir/thesis/tree/master/msc03},
-	category     = {thesis},
-	note         = {(in Finnish)},
-	school       = {Helsinki University of Technology},
-	language     = {Finnish},
-	url          = {https://github.com/antagomir/thesis/blob/master/msc03/dtyo.pdf},
-	keywords = {thesis}
-}
-
-@misc{Lahti09bsc,
-	title        = {Concerning Blackburn's quasi-realism in securing moral discussion},
-	author       = {Leo Lahti},
-	year         = 2009,
-	month        = 7,
-	category     = {thesis},
-	keywords = {thesis},	
-	note         = {(In Finnish)},
-	howpublished = {B.Sc. thesis. University of Helsinki, Faculty of Political Sciences},
-	language     = {Finnish},
-	url          = {https://github.com/openresearchlabs/openresearchlabs.github.io/blob/master/content/publication_resources/theses/LeoLahti-BSc-2008.pdf}
-}
-
-@inproceedings{Lahti09mlsp,
-  title =	 {Dependency detection with similarity constraints},
-  author =	 {Leo Lahti and Samuel Myllykangas and Sakari Knuutila
-                  and Samuel Kaski},
-  year =	 2009,
-  booktitle =	 {Proc. MLSP'09 IEEE International Workshop on Machine
-                  Learning for Signal Processing XIX},
-  address =	 {Piscataway, NJ},
-  pages =	 {198--203},
-  url =		 {http://arxiv.org/abs/1101.5919},
-  note =	 {R/Bioconductor: pint},
-  editor =	 {Adali T, Chanussot J, Jutten C, and Larsen J},
-  howpublished = {software},
-  url =		 {https://github.com/openresearchlabs/openresearchlabs.github.io/blob/master/content/publication_resources/papers/2009-MLSP-Lahti-SimCCA.pdf},
-  authorship =	 {first, corresponding},
-  arxiv =	 {1101.5919},
-  keywords =	 {datascience}
-}
-
-@misc{Lahti09rpa,
-  title =	 {RPA: probe reliability and differential gene
-                  expression analysis},
-  author =	 {Leo Lahti},
-  year =	 2009,
-  month =	 {October},
-  doi =		 {10.18129/B9.BIOC.RPA},
-  url =
-                  {http://bioconductor.org/packages/release/bioc/html/RPA.html},
-  note =	 {R/Bioconductor: RPA},
-  howpublished = {software},
-  keywords =	 {bioscience}
-}
-
-@article{Lahti10bioinf,
-	title        = {Global modeling of transcriptional responses in interaction networks},
-	author       = {Leo Lahti and Juha E.A. Knuuttila and Samuel Kaski},
-	year         = 2010,
-	month        = 11,
-	journal      = {Bioinformatics},
-	volume       = 26,
-	pages        = {2713--2720},
-	doi          = {10.1093/bioinformatics/btq500},
-	url          = {http://bioinformatics.oxfordjournals.org/content/early/2010/09/02/bioinformatics.btq500.abstract.html?ijkey=N1zzjtUBRng3wCM&keytype=ref},
-	note         = {R/Matlab implementations available at http://netpro.r-forge.r-project.org/},
-	issue        = 21,
-	keywords     = {bioscience},
-	authorship   = {first},
-	url          = {https://github.com/openresearchlabs/openresearchlabs.github.io/blob/master/content/publication_resources/papers/2010-Bioinformatics-Lahti-NetResponse.pdf},
-	annote       = {ArXiv: http://arxiv.org/abs/1202.0501; R/Matlab source code http://netpro.r-forge.r-project.org}
-}
-
-@misc{Lahti10blog,
-  title =	 {opencomp blog},
-  author =	 {Leo Lahti},
-  url =		 {http://antagomir.wordpress.com/},
-  category =	 {blog},
-  keywords =	 {blog}
-}
-
-@misc{Lahti10dmt,
-  title =	 {Dependency modeling toolkit},
-  author =	 {Leo Lahti and Abhishek Tripathi and Olli-Pekka
-                  Huovilainen},
-  year =	 2010,
-  month =	 6,
-  publisher =	 {ICML workshop},
-  url =		 {http://dmt.r-forge.r-project.org/},
-  note =	 {CRAN: dmt},
-  howpublished = {software},
-  keywords =	 {datascience}
-}
-
-@misc{Lahti10netresponse,
-  title =	 {NetResponse (functional network analysis)},
-  author =	 {Leo Lahti and Antonio Gusmao and Olli-Pekka
-                  Huovilainen},
-  year =	 2010,
-  month =	 {October},
-  doi =		 {10.18129/B9.BIOC.NETRESPONSE},
-  url =
-                  {http://www.bioconductor.org/help/bioc-views/devel/bioc/html/netresponse.html},
-  note =	 {R/Bioconductor: netresponse},
-  keywords =	 {datascience},
-  howpublished = {software}
-}
-
-@misc{Lahti10pint,
-  title =	 {Pairwise integration of functional genomics data},
-  author =	 {Olli-Pekka Huovilainen and Leo Lahti},
-  year =	 2010,
-  month =	 {April},
-  url =
-                  {http://bioconductor.org/packages/devel/bioc/html/pint.html},
-  note =	 {R/BioConductor: pint},
-  keywords =	 {datascience},
-  howpublished = {software}
-}
-
-@phdthesis{Lahti10thesis,
-	title        = {Probabilistic analysis of the human transcriptome with side information},
-	author       = {Leo Lahti},
-	year         = 2010,
-	month        = 12,
-	address      = {Espoo},
-	series       = {TKK Dissertations in Information and Computer Science},
-	number       = {TKK-ICS-D19},
-	issn         = {1797-5069},
-	url          = {http://lib.tkk.fi/Diss/2010/isbn9789526033686/},
-	category     = {thesis},
-	note         = {LaTeX sources and the pdf version are openly available: https://github.com/antagomir/thesis/tree/master/phd10; Press release: https://github.com/antagomir/thesis/blob/master/phd10/Vaitostiedote-LeoLahti-20101207.pdf},
-	school       = {Aalto University School of Science and Technology, Faculty of Information and Natural Sciences, Department of Information and Computer Science},
-	language     = {Finnish},
-	keywords     = {thesis, probabilistic models, Bayesian analysis, data integration, gene expression, microarrays, computational science, data analysis, machine learning, computational biology, open source, open access, creative commons},
-	url          = {https://github.com/openresearchlabs/openresearchlabs.github.io/blob/master/content/publication_resources/papers/2010-Lahti-thesis.pdf},
-	abstract     = {Recent advances in high-throughput measurement technologies and efficient sharing of biomedical data through community databases have made it possible to investigate the complete collection of genetic material, the genome, which encodes the heritable genetic program of an organism. This has opened up new views to the study of living organisms with a profound impact on biological research. Functional genomics is a subdiscipline of molecular biology that investigates the functional organization of genetic information.  This thesis develops computational strategies to investigate a key functional layer of the genome, the transcriptome. The time- and context-specific transcriptional activity of the genes regulates the function of living cells through protein synthesis. Efficient computational techniques are needed in order to extract useful information from high-dimensional genomic observations that are associated with high levels of complex variation. Statistical learning and probabilistic models provide the theoretical framework for combining statistical evidence across multiple observations and the wealth of background information in genomic data repositories.  This thesis addresses three key challenges in transcriptome analysis. First, new preprocessing techniques that utilize side information in genomic sequence databases and microarray collections are developed to improve the accuracy of high-throughput microarray measurements.  Second, a novel exploratory approach is proposed in order to construct a global view of cell-biological network activation patterns and functional relatedness between tissues across normal human body. Information in genomic interaction databases is used to derive constraints that help to focus the modeling in those parts of the data that are supported by known or potential interactions between the genes, and to scale up the analysis. The third contribution is to develop novel approaches to model dependency between co-occurring measurement sources. The methods are used to study cancer mechanisms and transcriptome evolution; integrative analysis of the human transcriptome and other layers of genomic information allows the identification of functional mechanisms and interactions that could not be detected based on the individual measurement sources. Open source implementations of the key methodological contributions have been released to facilitat e their further adoption by the research community.}
-}
-
-@misc{Lahti11-louhos,
-	title        = {Louhos blog},
-	author       = {Leo Lahti and Joona Lehtomäki and Juuso Parkkinen and others},
-	url          = {http://louhos.github.io/},
-	note         = {Open government data analytics blog (in Finnish)},
-	keywords       = {blog}
-}
-
-@misc{Lahti11intcomp,
-	title        = {intcomp: a benchmarking pipeline for integrative cancer gene detection algorithms},
-	author       = {Leo Lahti and Martin Schäfer and Hans-Ulrich Klein and Silvio Bicciato and Martin Dugas},
-	year         = 2011,
-	month        = 2,
-	url          = {http://intcomp.r-forge.r-project.org/},
-	note         = {R-forge},
-	howpublished = {software},
-	keywords     = {bioscience}
-}
-
-@misc{Lahti11ismb,
-	title        = {Probabilistic dependency models for data integration in functional genomics},
-	author       = {Leo Lahti and Samuel Kaski},
-	year         = 2011,
-	month        = {July},
-	category     = {abstract},
-	note         = {Machine Learning for Systems Biology workshop, ISMB, Vienna, Austria},
-	authorship   = {first, corresponding},
-	keywords     = {bioscience},
-	url          = {https://github.com/openresearchlabs/openresearchlabs.github.io/blob/master/content/publication_resources/papers/2011-MLSB-Lahti.pdf}
-}
-
-@article{Lahti11rpa,
-	title        = {Probabilistic Analysis of Probe Reliability in Differential Gene Expression Studies with Short Oligonucleotide Arrays},
-	author       = {Leo Lahti and Laura L. Elo and Tero Aittokallio and Samuel Kaski},
-	year         = 2011,
-	month        = {Jan.-Mar.},
-	journal      = {IEEE/ACM Transactions on Computational Biology and Bioinformatics},
-	publisher    = {IEEE Computer Society},
-	address      = {Los Alamitos, CA, USA},
-	volume       = 8,
-	number       = 1,
-	pages        = {217--225},
-	doi          = {10.1109/TCBB.2009.38},
-	keywords     = {bioscience},
-	authorship   = {first, corresponding},
-	url          = {https://github.com/openresearchlabs/openresearchlabs.github.io/blob/master/content/publication_resources/papers/2011-Lahti-TCBB.pdf},
-	annote       = {R/Bioconductor: RPA}
-}
-
-@article{Lahti12cmi,
-	title        = {The adult intestinal core microbiota is determined by analysis depth and health status},
-	author       = {Anne Salonen and Jarkko Saloj{\"a}rvi and Leo Lahti and and Willem M. de Vos},
-	year         = 2012,
-	journal      = {Clinical Microbiology and Infection},
-	volume       = 18,
-	number       = {Suppl. 4},
-	pages        = {16–20},
-	doi          = {10.1111/j.1469-0691.2012.03855.x},
-	keywords     = {bioscience},
-	url          = {https://github.com/openresearchlabs/openresearchlabs.github.io/blob/master/content/publication_resources/papers/2012-Salonen-CMI.pdf}
-}
-
-@misc{Lahti13-ropengov,
-	title        = {rOpenGov blog},
-	author       = {Leo Lahti and Joona Lehtomäki and Markus Kainu and Juuso Parkkinen and others},
-	url          = {http://ropengov.github.io/},
-	note         = {Open government data analytics blog},
-	keywords       = {blog}
-}
-
-@misc{Lahti13icml,
-	title        = {rOpenGov: open source ecosystem for computational social sciences and digital humanities},
-	author       = {Leo Lahti, Juuso Parkkinen, Joona Lehtomäki and Markus Kainu},
-	year         = 2013,
-	month        = 12,
-	url          = {http://ropengov.github.io},
-	category     = {abstract},
-	note         = {ICML/MLOSS workshop (Int'l Conf. on Machine Learning - Open Source Software workshop).},
-	keywords     = {dh},
-	howpublished = {software},
-	keywords       = {datascience}
-}
-
-@article{Lahti13nar,
-	title        = {A fully scalable online pre-processing algorithm for short oligonucleotide microarray atlases},
-	author       = {Leo Lahti and Aurora Torrente and Laura L Elo and Alvis Brazma and Johan Rung},
-	year         = 2013,
-	journal      = {Nucleic Acids Research},
-	volume       = 41,
-	number       = 10,
-	pages        = {e110},
-	doi          = {10.1093/nar/gkt229},
-	note         = {Implementation available through Bioconductor RPA package.},
-	url          = {https://github.com/openresearchlabs/openresearchlabs.github.io/blob/master/content/publication_resources/papers/2013-Lahti-NAR.pdf},
-	authorship   = {first, corresponding},
-	keywords = {bioscience}
-}
-
-@article{Lahti13provasI,
-	title        = {Associations between the human intestinal microbiota, Lactobacillus rhamnosus GG and serum lipids indicated by integrated analysis of high-throughput profiling data},
-	author       = {Leo Lahti and Anne Salonen and Riina A. Kekkonen and Jarkko Salojärvi and Jonna Jalanka-Tuovinen and Airi Palva and Matej Orešič and Willem M. de Vos},
-	year         = 2013,
-	journal      = {PeerJ},
-	volume       = 1,
-	pages        = {e32},
-	doi          = {10.7717/peerj.32},
-	note         = {Highly accessed, featured in PeerJ journal blog and Top-10 Microbiology collection.},
-	keywords     = {bioscience},
-	authorship   = {corresponding, shared first},
-	url          = {https://github.com/openresearchlabs/openresearchlabs.github.io/blob/master/content/publication_resources/papers/2013-Lahti-PeerJ.pdf},
-	pmid         = 23638368
-}
-
-@article{Lahti15LIBER,
-	title        = {A quantitative study of history in the English short-title catalogue (ESTC) 1470-1800},
-	author       = {Leo Lahti and Niko Ilom{\"a}ki and Mikko Tolonen},
-	year         = 2015,
-	month        = 12,
-	journal      = {LIBER Quarterly},
-	volume       = 25,
-	number       = 2,
-	pages        = {87--116},
-	doi          = {10.18352/lq.10112},
-	issn         = {2213-056X},
-	pubstate     = {dh},
-	authorship   = {first},
-	url          = {https://github.com/openresearchlabs/openresearchlabs.github.io/blob/master/content/publication_resources/papers/2015-Lahti-LIBERQuarterly.pdf},
-	keywords     = {dh}
-}
-
-@article{Lahti17eurostat,
-	title        = {Retrieval and Analysis of Eurostat Open Data with the eurostat Package},
-	author       = {Leo Lahti and Janne Huovari and Markus Kainu and Przemysław Biecek},
-	year         = 2017,
-	journal      = {The R Journal},
-	volume       = 9,
-	number       = 1,
-	pages        = {385--392},
-	url          = {https://journal.r-project.org/archive/2017/RJ-2017-019/index.html},
-	keywords     = {dh},
-	software     = {yes},
-	url          = {https://github.com/openresearchlabs/openresearchlabs.github.io/blob/master/content/publication_resources/papers/2017-Lahti-RJournal.pdf},
-	authorship   = {first, corresponding},
-	annote       = {R package homepage URL: http://ropengov.github.io/eurostat/}
-}
-
-@article{Lahti17phos,
-	title        = {Alchemy & algorithms: perspectives on the philosophy and history of open science},
-	author       = {Leo Lahti and Filipe da Silva and Markus Petteri Laine and Viivi Lähteenoja and Mikko Tolonen},
-	year         = 2017,
-	month        = {May},
-	journal      = {RIO Journal},
-	volume       = 3,
-	pages        = {e13593},
-	doi          = {10.3897/rio.3.e13593},
-	category     = {perspective},
-	note         = {Review of the international conference, including electronic material (video interviews, lectures and podcasts.},
-	authorship   = {first, corresponding},
-	keywords     = {openscience},
-	pubstate     = {openscience},
-	url          = {https://github.com/openresearchlabs/openresearchlabs.github.io/blob/master/content/publication_resources/papers/2017-Lahti-PHOS.pdf},
-	keywords     = {dh}
-}
-
-@misc{Lahti2001,
-	title        = {Julian joukko iteraatioden valuma-altaan reunana},
-	author       = {Leo Lahti},
-	year         = 2001,
-	url          = {https://github.com/antagomir/thesis/tree/master/julia01},
-	category     = {thesis},
-	note         = {Special assignment in Mathematics (in Finnish)},
-	keywords       = {thesis},
-	language     = {Finnish}
-}
-
-@misc{Lahti2002,
-	title        = {Itsesimilaaristen joukkojen Hausdorffin dimension määrittäminen},
-	author       = {Leo Lahti},
-	year         = 2002,
-	url          = {https://github.com/antagomir/thesis/tree/master/hausdorff02},
-	category     = {thesis},
-	keywords       = {thesis},	
-	note         = {Special assignment in Mathematics (in Finnish)},
-	language     = {Finnish}
-}
-
-@misc{Lahti2006biopax,
-	title        = {A brief overview on the BioPAX and SBML standards},
-	author       = {Leo Lahti},
-	year         = 2007,
-	url          = {https://arxiv.org/abs/1109.4919},
-	category     = {thesis},
-	note         = {Overview of machine-readable representations of biological processes.},
-	note         = {(in Finnish)},
-	howpublished = {arXiv},
-	authorship   = {first},
-	keywords     = {bioscience},
-	arxiv        = {arXiv:1109.4919 [cs.DS]},
-	language     = {Finnish}
-}
-
-@article{Lahti2012intcomp,
-	title        = {Cancer gene prioritization by integrative analysis of mRNA expression and DNA copy number data: a comparative review},
-	author       = {Leo Lahti and Martin Sch{\"a}fer and Hans-Ulrich Klein and Silvio Bicciato and Martin Dugas},
-	year         = 2013,
-	month        = 6,
-	journal      = {Briefings in Bioinformatics},
-	volume       = 14,
-	number       = 1,
-	pages        = {27--35},
-	doi          = {10.1093/bib/bbs005},
-	category     = {review},
-	keywords     = {bioscience},
-	authorship   = {first, corresponding},
-	url          = {https://github.com/openresearchlabs/openresearchlabs.github.io/blob/master/content/publication_resources/papers/2013-Lahti-BriefBioinf.pdf}
-}
-
-@inproceedings{Lahti2018IDA,
-	title        = {Open Data Science},
-	author       = {Lahti, Leo},
-	year         = 2018,
-	month        = {October},
-	booktitle    = {Advances in Intelligent Data Analysis XVII. Lecture Notes in Computer Science 11191.},
-	publisher    = {Springer},
-	publisher    = {Springer Nature},
-	address      = {India},
-	volume       = 11191,
-	category     = {perspective},
-	note         = {Conference proceedings.},
-	keywords     = {openscience},
-	authorship   = {first},
-	url          = {https://github.com/openresearchlabs/openresearchlabs.github.io/blob/devel/publications/https://github.com/openresearchlabs/openresearchlabs.github.io/blob/master/content/publication_resources/papers/2018-Lahti-IDA.pdf}
-}
-
-@article{Lahti2019bds,
-	title        = {Bibliographic Data Science and the History of the Book (c. 1500–1800)},
-	author       = {Leo Lahti and Jani Marjanen and Hege Roivainen and Mikko Tolonen},
-	year         = 2019,
-	month        = {January},
-	journal      = {Cataloging \& Classification Quarterly},
-	publisher    = {Routledge},
-	volume       = 57,
-	number       = 1,
-	pages        = {5--23},
-	doi          = {10.1080/01639374.2018.1543747},
-	note         = {Special issue.},
-	url          = {https://github.com/openresearchlabs/openresearchlabs.github.io/blob/master/content/publication_resources/papers/2019-Lahti-CCQ.pdf},
-	keywords       = {dh}
-}
-
-@inproceedings{Lahti2019rdhum,
-	title        = {Best practices in bibliographic data science},
-	author       = {Leo Lahti and Ville Vaara and Jani Marjanen and Mikko Tolonen},
-	year         = 2019,
-	month        = {August},
-	booktitle    = {Proceedings of the Research Data in the Humanities Conference},
-	address      = {Oulu},
-	url          = {https://github.com/openresearchlabs/openresearchlabs.github.io/blob/master/content/publication_resources/papers/2019-Lahti-RDHUM.pdf},
-	keywords     = {dh}
-}
-
-@inproceedings{Lahti2020chr,
-	title        = {Quantifying bias and uncertainty in historical data collections with probabilistic programming},
-	author       = {Leo Lahti and Eetu Mäkelä and Mikko Tolonen},
-	year         = 2020,
-	month        = {Nov},
-	booktitle    = {{Proc. CEUR Workshop Proceedings on Computational Humanities Research}},
-	pages        = {80--89},
-	keywords     = {dh},	
-	url          = {http://ceur-ws.org/Vol-2723/short46.pdf}
-}
-
-
-
-@article{Lahti2020hs1,
-	title        = {Laskentamallit eivät lähtökohtaisesti ole salassa pidettävää tietoa},
-	author       = {Leo Lahti and Thomas Wallgren and Markku Kulmala},
-	year         = 2020,
-	month        = {May},
-	journal      = {HS Mielipide},
-	url          = {https://www.hs.fi/mielipide/art-2000006494641.html},
-	keywords       = {opinion}			
-}
-@article{Lahti2020hs2,
-	title        = {Lähdekoodin sisältämien yksityiskohtien avoimuus on keskeistä päätöksenteon läpinäkyvyydelle.},
-	author       = {Leo Lahti},
-	year         = 2020,
-	month        = {June},
-	journal      = {HS Mielipide},
-	url          = {https://www.hs.fi/mielipide/art-2000006545770.html},
-	keywords       = {opinion}
-}
-
-
-
-@article{Lahti2020okf1,
-	title        = {Tietopyyntö epidemialaskelmien lähdekoodeista},
-	author       = {Leo Lahti and Tarmo Toikkanen},
-	year         = 2020,
-	month        = {May},
-	journal      = {Open Knowledge Finland Blog},
-	url          = {https://www.okf.fi/fi/2020/05/13/tietopyynto-thln-epidemialaskelmien-lahdekoodeista},
-	keywords       = {opinion}		
-
-}
-
-@article{Lahti2020okf2,
-	title        = {Päätös epidemialaskelmien salaamisesta vastoin valtioneuvoston avoimuuslinjausta},
-	author       = {Leo Lahti},
-	year         = 2020,
-	month        = {June},
-	journal      = {Open Knowledge Finland Blog},
-	url          = {https://www.okf.fi/fi/2020/06/15/thln-paatos-epidemialaskelmien-salaamisesta-vastoin-valtioneuvoston-avoimuuslinjausta/},
-	keywords       = {opinion}	
-}
-
-
-
-@article{Lahti2020thinkopen,
-  title =	 {Avoimuus voi vahvistaa päätöksenteon tieteellistä
-                  pohjaa},
-  author =	 {Leo Lahti},
-  year =	 2020,
-  month =	 {August},
-  journal =	 {University of Helsinki, ThinkOpen blog},
-  keywords =	 {opinion},
-  url =
-                  {https://blogs.helsinki.fi/thinkopen/lahdekoodin-avoimuus-paatoksenteossa/}
-}
-
-
 @article{Lahti2021bioc,
 	title        = {Microbiome data science in the {\it SummarizedExperiment} universe},
 	author       = {Leo Lahti and Felix G.M. Ernst and Sudarshan A. Shetty and others},
@@ -1009,101 +102,17 @@
 	number       = 748,
 	doi          = {10.7490/f1000research.1118712.1},
 	note         = {(slides); version 1; not peer reviewed},
-	keywords = {bioscience}
+	keywords     = {bioscience}
 }
-
-
-@inproceedings{Laine15,
-	title        = {Beyond Open Access - The Changing Culture of Producing and Disseminating Scientific Knowledge},
-	author       = {Heidi Laine and Leo Lahti and Anne Lehto and Samuli Ollila and Markus Miettinen},
-	year         = 2015,
-	booktitle    = {Proceedings of the 19th International Academic Mindtrek Conference in Tampere, Finland, September 22-24},
-	location     = {Tampere, Finland},
-	publisher    = {ACM},
-	address      = {ACM New York, NY, USA},
-	address      = {New York, NY, USA},
-	isbn         = {978-1-4503-3948-3},
-	url          = {http://dl.acm.org/citation.cfm?id=2818187},
-	organization = {AcademicMindTrek'15: Proceedings of the 19th International Academic Mindtrek Conference},
-	authorship   = {second},
-	keywords     = {openscience},
-	url          = {https://github.com/openresearchlabs/openresearchlabs.github.io/blob/master/content/publication_resources/papers/2015-Laine-Mindtrek.pdf}
-}
-
-@inproceedings{Laitinen2018IDA,
-	title        = {A hierarchical Ornstein-Uhlenbeck model for stochastic time series analysis},
-	author       = {Laitinen, Ville and Lahti, Leo},
-	year         = 2018,
-	month        = {October},
-	booktitle    = {Advances in Intelligent Data Analysis XVII. Lecture Notes in Computer Science 11191.},
-	publisher    = {Springer},
-	address      = {India},
-	url          = {https://github.com/velait/OUP},
-	note         = {Conference proceedings.},
-	keywords       = {datascience},
-	authorship   = {pi},
-	url          = {https://github.com/openresearchlabs/openresearchlabs.github.io/blob/master/content/publication_resources/papers/2018-Laitinen-IDA.pdf}
-}
-
-
-@article{Louhimo14,
-	title        = {Systematic Use of Computational Methods Allows Stratifying Treatment Responders in Glioblastoma Multiforme},
-	author       = {Riku Louhimo and Viljami Aittom{\"a}ki and Ali Faisal and Marko Laakso and Ping Chen and Kristian Ovaska and Erkka Valo and Leo Lahti and Vladimir Rogojin and Samuel Kaski and Sampsa Hautaniemi.},
-	year         = 2014,
-	month        = 4,
-	journal      = {Systems Biomedicine (special issue)},
-	volume       = 1,
-	pages        = {130--136},
-	doi          = {10.4161/sysb.28904},
-	note         = {Critical Assessment of Massive Data Analysis (CAMDA) workshop},
-	issue        = 2,
-	keywords     = {bioscience},
-	url          = {https://github.com/openresearchlabs/openresearchlabs.github.io/blob/master/content/publication_resources/papers/2014-Louhimo.pdf}
-}
-
-@inproceedings{Makela2019dhn,
-	title        = {Interdisciplinary collaboration in studying newspaper materiality},
-	author       = {Eetu M{\"a}kel{\"a} and Mikko Tolonen and Jani Marjanen and Antti Kanner and Ville Vaara and Leo Lahti},
-	year         = 2019,
-	month        = {March},
-	booktitle    = {Proc. Twin Talks workshop. Digital Humanities in the Nordic Countries},
-	address      = {Copenhagen},
-	series       = {CEUR Workshop Proceedings},
-	volume       = 2365,
-	pages        = {55--66},
-	url          = {http://ceur-ws.org/Vol-2365/07-TwinTalks-DHN2019_paper_7.pdf},
-	editor       = {Steven Krauwer and Darja Fišer},
-	pubstate     = {dh},
-	keywords     = {dh},
-	url          = {https://github.com/openresearchlabs/openresearchlabs.github.io/blob/master/content/publication_resources/papers/2019-Makela-DHN.pdf}
-}
-
-@inproceedings{Makela2020,
-	title        = {Wrangling with Non-Standard Data},
-	author       = {Eetu, M and Lagus, K and Lahti, L and Säily, T and Tolonen, M and Hämäläinen, M and Kaislaniemi, S and Nevalainen, T},
-	year         = 2020,
-	month        = {March},
-	booktitle    = {Proc. Digital Humanities in the Nordic Countries},
-	series       = {CEUR Workshop Proceedings},
-	volume       = 2612,
-	pages        = {81--96},
-	editor       = {Sanita Reinsone and Inguna Skadiņa and Anda Baklāne and Jānis Daugavietis},
-	url          = {https://github.com/openresearchlabs/openresearchlabs.github.io/blob/master/content/publication_resources/papers/2020-Makela-DHN.pdf},
-	keywords       = {dh}
-}
-
 @misc{Makela2021hs,
-  author =	 {Eetu Mäkelä and Leo Lahti and Johanna Lilja and
-                  Pekka Heikkinen},
-  title =	 {Laki estää tehokkaiden tutkimusmenetelmien käytön},
-  howpublished = {HS Mielipide},
-  month =	 {October},
-  year =	 2021,
-  url =
-                  {https://www.hs.fi/mielipide/art-2000008325656.html?share=6421b425ce95dfc19d87511d90f6d3c4},
-  keywords =	 {opinion}
+	title        = {Laki estää tehokkaiden tutkimusmenetelmien käytön},
+	author       = {Eetu Mäkelä and Leo Lahti and Johanna Lilja and Pekka Heikkinen},
+	year         = 2021,
+	month        = 10,
+	url          = {https://www.hs.fi/mielipide/art-2000008325656.html?share=6421b425ce95dfc19d87511d90f6d3c4},
+	howpublished = {HS Mielipide},
+	keywords     = {opinion}
 }
-
 @article{MarcosZambrano2021,
 	title        = {Applications of Machine Learning in Human Microbiome Studies: A Review on Feature Selection, Biomarker Identification, Disease Prediction and Treatment},
 	author       = {Marcos-Zambrano, Laura Judith and Karaduzovic-Hadziabdic, Kanita and Loncar Turukalo, Tatjana and Przymus, Piotr and Trajkovik, Vladimir and Aasmets, Oliver and Berland, Magali and Gruca, Aleksandra and Hasic, Jasminka and Hron, Karel and Klammsteiner, Thomas and Kolev, Mikhail and Lahti, Leo and Lopes, Marta B and Moreno, Victor and Naskinova, Irina and Org, Elin and Paciência, Inês and Papoutsoglou, Georgios and Shigdel, Rajesh and Stres, Blaz and Vilne, Baiba and Yousef, Malik and Zdravevski, Eftim and Tsamarindos, Ioannis and Carrillo de Santa Pau, Enrique and Claesson, Marcus J. and Moreno-Indias, Isabel and Truu, Jaak},
@@ -1116,109 +125,231 @@
 	url          = {https://www.frontiersin.org/article/10.3389/fmicb.2021.634511},
 	keywords     = {bioscience}
 }
-
-
-
-@article{Marjanen2019,
-	title        = {A National Public Sphere? Analyzing the Language, Location, and Form of Newspapers in Finland, 1771–1917},
-	author       = {Jani Marjanen and Ville Vaara and Antti Kanner and Hege Roivainen and Eetu Mäkelä and Leo Lahti and Mikko Tolonen},
-	year         = 2019,
-	month        = {June},
-	journal      = {Journal of European Periodical Studies},
-	volume       = 4,
-	number       = 1,
-	doi          = {10.21825/jeps.v4i1.10483},
-	url          = {https://ojs.ugent.be/jeps/article/view/10483},
-	note         = {Special issue: Digital Approaches Towards Serial Publications},
-	url          = {https://github.com/openresearchlabs/openresearchlabs.github.io/blob/master/content/publication_resources/papers/2019-Marjanen-JEPS.pdf},
-	pubstate     = {dh},
-	keywords     = {dh}
-}
-
 @article{MorenoIndias2021,
 	title        = {Statistical and machine learning techniques in human microbiome studies: contemporary challenges and solutions},
 	author       = {Isabel Moreno-Indias and Leo Lahti and Miroslava Nedyalkova and Ilze Elbere and Gennady V. Roshchupkin and Muhamed Adilovic and Onder Aydemir and Burcu Bakir-Gungor and Enrique Carrillo-de Santa Pau and Domenica D'Elia and Magesh S. Desai and Laurent Falquet and Aycan Gundogdu and Karel Hron and Thomas Klammsteiner and Marta B. Lopes and Laura J. Marcos Zambrano and Cláudia Marques and Michael Mason and Patrick May and Lejla Pašić and Gianvito Pio and Sándor Pongor and Vasilis J. Promponas and Piotr Przymus and Julio Sáez-Rodríguez and Alexia Sampri and Rajesh Shigdel and Blaz Stres and Ramona Suharoschi and Jaak Truu and Ciprian-Octavian Truică and Baiba Vilne and Dimitrios P. Vlachakis and Ercüment Yılmaz and Georg Zeller and Aldert Zomer and David Gómez-Cabrero and Marcus Claesson},
 	year         = 2021,
-	month        = {February},
+	month        = 2,
 	journal      = {Frontiers in Microbiology},
 	volume       = 12,
 	pages        = 277,
 	doi          = {10.3389/fmicb.2021.635781},
 	keywords     = {bioscience}
 }
-
-
-@article{Mosakhani10,
-	title        = {Unique microRNA profile in Dupuytren's contracture supports deregulation of beta-catenin pathway},
-	author       = {Neda Mosakhani and Mohamed Guled and Leo Lahti and Ioana Borze and Minna Forsman and Jorma Ryh{\"a}nen and Sakari Knuutila},
-	year         = 2010,
-	month        = 11,
-	journal      = {Modern Pathology},
-	volume       = 23,
-	pages        = {1544--1522},
-	doi          = {10.1038/modpathol.2010.146},
-	note         = {International Dupuytren Award for best research paper in 2011},
-	url          = {https://github.com/openresearchlabs/openresearchlabs.github.io/blob/master/content/publication_resources/papers/2010-ModernPathology-Mosakhani-Dupuytre.pdf},
-		keywords     = {bioscience}
-}
-
-@article{Mosakhani12,
-	title        = {MicroRNA profiling predicts survival in anti-EGFR treated chemorefractory metastatic colorectal cancer patients with wild-type KRAS and BRAF},
-	author       = {Neda Mosakhani and Leo Lahti and Ioana Borze and Marja-Liisa Karjalainen-Lindsberg and Jari Sundstrom and Raija Ristamaki and Pia Osterlund and Sakari Knuutila and and Virinder Kaur Sarhadi},
-	year         = 2012,
-	month        = 11,
-	journal      = {Cancer Genetics},
-	volume       = 205,
-	number       = 11,
-	pages        = {545--51},
-	doi          = {10.1016/j.cancergen.2012.08.003},
+@article{Palmu2021ijerph,
+	title        = {Targeting gut microbiota to treat hypertension: a systematic review},
+	author       = {Joonatan Palmu and Leo Lahti and Teemu Niiranen},
+	year         = 2021,
+	month        = 1,
+	journal      = {International Journal of Environmental Research and Public Health},
+	volume       = 18,
+	number       = 3,
+	pages        = 1248,
+	doi          = {10.3390/ijerph18031248},
 	keywords     = {bioscience},
-	url          = {https://github.com/openresearchlabs/openresearchlabs.github.io/blob/master/content/publication_resources/papers/2012-Mosakhani-CG.pdf},
-	authorship   = {second}
+	tag          = {review}
 }
-@article{Mosakhani12LL,
-	title        = {MicroRNA profiling in pediatric acute lymphoblastic leukemia: novel prognostic tools},
-	author       = {N Mosakhani and VK Sarhadi and A Usvasalo and ML Karjalainen-Lindsberg and L Lahti and K Tuononen and UM Saarinen-Pihkala and S Knuutila},
-	year         = 2012,
-	month        = {Dec},
-	journal      = {Leukemia \& Lymphoma},
-	volume       = 53,
-	number       = 12,
-	pages        = {2517--2520},
-	doi          = {10.3109/10428194.2012.685731},
-	url          = {https://github.com/openresearchlabs/openresearchlabs.github.io/blob/master/content/publication_resources/papers/2012-Mosakhani-LL.pdf},
-	keywords     = {bioscience}
-}
-
-@article{Niini11mfh,
-	title        = {Array Comparative Genomic Hybridization Reveals Frequent Alterations of G1/S Checkpoint Genes in Undifferentiated Pleomorphic Sarcoma of Bone},
-	author       = {Tarja Niini and Leo Lahti and Francesca Michelacci and Shinsuke Ninomiya and Claudia Maria Hattinger and Mohamed Guled and Tom B{\"o}hling and Piero Picci and Massimo Serra and Sakari Knuutila},
-	year         = 2011,
+@article{Ruuskanen2021,
+	title        = {Modeling spatial patterns in host-associated microbial communities},
+	author       = {Matti Ruuskanen and Guilhem Sommeria-Klein and Aki Havulinna and Teemu Niiranen and Leo Lahti},
+	year         = 2021,
 	month        = 5,
-	journal      = {Genes, Chromosomes and Cancer},
-	volume       = 50,
+	journal      = {Environmental Microbiology},
+	volume       = 23,
 	number       = 5,
-	pages        = {291--306},
-	doi          = {10.1002/gcc.20851},
-	authorship   = {second},
-	url          = {https://github.com/openresearchlabs/openresearchlabs.github.io/blob/master/content/publication_resources/papers/2011-Niini-GCC.pdf},
+	pages        = {2374--2388},
+	doi          = {10.1111/1462-2920.15462},
 	keywords     = {bioscience}
 }
-
-@article{Niini12,
-	title        = {Homozygous Deletions of Cadherin Genes in Chondrosarcoma – an Array CGH Study},
-	author       = {Tarja Niini and Ilari Scheinin and Leo Lahti and Suvi Savola and Fredrik Mertens and Jaakko Hollmén and Tom Böhling and Aarne Kivioja and Karolin H Nord and Sakari Knuutila},
-	year         = 2012,
-	month        = 11,
-	journal      = {Cancer Genetics},
-	volume       = 205,
-	number       = 11,
-	pages        = {588--93},
-	doi          = {10.1016/j.cancergen.2012.09.007},
-	keywords     = {bioscience},
-	pmid         = 23146407
+@article{Ruuskanen2021gutmicrobes,
+	title        = {Links between gut microbiome composition and fatty liver disease in a large population sample},
+	author       = {Matti O. Ruuskanen and Fredrik Åberg and Ville Männistö and Aki S. Havulinna and Guillaume Méric and Yang Liu and Rohit Loomba and Yoshiki Vázquez-Baeza and Anupriya Tripathi and Liisa M. Valsta and Michael Inouye and Pekka Jousilahti and Veikko Salomaa and Mohit Jain and Rob Knight and Leo Lahti and Teemu J. Niiranen},
+	year         = 2021,
+	month        = 3,
+	journal      = {Gut Microbes},
+	volume       = 13,
+	doi          = {10.1080/19490976.2021.1888673},
+	issue        = 1,
+	keywords     = {bioscience}
 }
-
+@article{Salosensaari2021,
+	title        = {Taxonomic signatures of cause-specific mortality risk in human gut microbiome},
+	author       = {Aaro Salosensaari* and Ville Laitinen* and Aki S Havulinna and Guillaume Meric and Susan Cheng and Markus Perola and Liisa Valsta and Georg Alfthan and Michael Inouye and Jeramie D Watrous and Tao Long and Rodolfo Salido and Karenina Sanders and Caitriona Brennan and Gregory C Humphrey and Jon G Sanders and Mohit Jain and Pekka Jousilahti and Veikko Salomaa and Rob Knight and Leo Lahti* and Teemu Niiranen*},
+	year         = 2021,
+	journal      = {Nature Communications},
+	volume       = 12,
+	pages        = 2671,
+	doi          = {10.1038/s41467-021-22962-y},
+	keywords     = {bioscience},
+	annote       = {Preprint featured in HS Tiede Jan 30, 2020. Featured in Science Magazine Jan 22, 2020 https://www.sciencemag.org/news/2020/01/microbes-your-gut-could-predict-whether-you-re-likely-die-next-15-years}
+}
+@article{Sarhadi2021,
+	title        = {Gut microbiota of patients with different subtypes of gastric cancer and gastrointestinal stromal tumors},
+	author       = {Virinder Sarhadi and Binu Mathew and Arto Kokkola A and Tiina Karla and Milja Tikkanen and Hilpi Rautelin and Leo Lahti and Pauli Puolakkainen and Sakari Knuutila},
+	year         = 2021,
+	journal      = {Gut Pathogens},
+	volume       = 13,
+	pages        = {1--9},
+	doi          = {10.1186/s13099-021-00403-x},
+	keywords     = {bioscience},
+	issue        = 11
+}
+@incollection{Tolonen2021canon,
+	title        = {Examining the Early Modern Canon: The English Short Title Catalogue and Large-Scale Patterns of Cultural Production.},
+	author       = {Mikko Tolonen and Mark J. Hill and Ali Zeeshan Ijaz and Ville Vaara and Leo Lahti},
+	year         = 2021,
+	month        = 3,
+	booktitle    = {Data Visualization in Enlightenment Literature and Culture},
+	publisher    = {Palgrave Macmillan, Cham.},
+	doi          = {10.1007/978-3-030-54913-8_3},
+	note         = {Book chapter in: Data Visualization in Enlightenment Literature and Culture},
+	editor       = {Baird, I.},
+	chapter      = 3,
+	keywords     = {dh}
+}
+@inproceedings{Tiihonen2021chr,
+	title        = {Probabilistic Analysis of Early Modern British Book Prices},
+	author       = {Iiro Tiihonen and Mikko Tolonen and Leo Lahti},
+	year         = 2021,
+	month        = 10,
+	booktitle    = {{Proc. CEUR Workshop Proceedings on Computational Humanities Research}},
+	pages        = {39--48},
+	url          = {https://github.com/openresearchlabs/openresearchlabs.github.io/blob/master/content/publication_resources/papers/2021-Tiihonen-CHR.pdf},
+	note         = {In M Ehrmann, F Karsdorp et al. (eds).},
+	keywords     = {dh}
+}
+@article{Tolonen2021rcl,
+	title        = {Corpus Linguistics and Eighteenth Century Collections Online (ECCO)},
+	author       = {Tolonen, M and M{\"a}kel{\"a}, E and Ijaz, A and Lahti, L},
+	year         = 2021,
+	journal      = {Research in Corpus Linguistics},
+	volume       = 9,
+	number       = 1,
+	pages        = {19--34},
+	doi          = {10.32714/ricl.09.01.03},
+	keywords     = {dh}
+}
+@article{crossys2021,
+	title        = {Systemic cross-talk between brain, gut, and peripheral tissues in glucose homeostasis: effects of exercise training (CROSSYS): Exercise training intervention in monozygotic twins discordant for body weight},
+	author       = {Marja A. Heiskanen and Sanna M. Honkala and Ronja A. Ojala and Riikka Lautamäki and Kalle Koskensalo and Martin Lietzén and Jaakko Hentilä and Virva Saunavaara and Jani Saunavaara and Mika Helmiö and Eliisa Löyttyniemi and Lauri Nummenmaa and Maria C. Collado and Tarja Malm and Leo Lahti and Kirsi H. Pietiläinen and Jaakko Kaprio and Juha O. Rinne and Jarna C. Hannukainen},
+	year         = 2021,
+	journal      = {BMC Sports Science, Medicine and Rehabilitation},
+	volume       = 13,
+	pages        = 16,
+	doi          = {10.1186/s13102-021-00241-z},
+	keywords     = {bioscience}
+}
+@article{Liu2021liver,
+	title        = {Early prediction of liver disease using conventional risk factors and gut microbiome-augmented gradient boosting},
+	author       = {Liu, Yang and Meric, Guillaume and Havulinna, Aki S. and Teo, Shu Mei and Ruuskanen, Matti and Sanders, Jon and Zhu, Qiyun and Tripathi, Anupriya and Verspoor, Karin and Cheng, Susan and Jain, Mo and Jousilahti, Pekka and Vazquez-Baeza, Yoshiki and Loomba, Rohit and Lahti, Leo and Niiranen, Teemu and Salomaa, Veikko and Knight, Rob and Inouye, Michael},
+	year         = 2020,
+	journal      = {medRxiv},
+	doi          = {10.1101/2020.06.24.20138933},
+	url          = {https://www.medrxiv.org/content/early/2020/06/25/2020.06.24.20138933},
+	eprint       = {https://www.medrxiv.org/content/early/2020/06/25/2020.06.24.20138933.full.pdf},
+	keywords     = {preprint}
+}
+@article{Aatsinki2020,
+	title        = {Maternal prenatal psychological distress and hair cortisol levels associate with infant fecal microbiota composition at 2.5 months of age},
+	author       = {Anna-Katariina Aatsinki and Anniina Keskitalo and Ville Laitinen and Eveliina Munukka and Henna-Maria Uusitupa and Leo Lahti and Susanna Kortesluoma and Paula Mustonen and Ana João Rodrigues and Bárbara Coimbra and Pentti Huovinen and Hasse Karlsson and Linnea Karlsson},
+	year         = 2020,
+	journal      = {Psychoneuroendocrinology},
+	volume       = 119,
+	pages        = 104754,
+	doi          = {10.1016/j.psyneuen.2020.104754},
+	keywords     = {bioscience}
+}
+@article{Khalighi2021,
+	title        = {Three-species Lotka-Volterra model with respect to Caputo and Caputo-Fabrizio fractional operators},
+	author       = {Moein Khalighi and Leila Eftekhari and Soleiman Hosseinpour and Leo Lahti},
+	year         = 2020,
+	month        = {January},
+	journal      = {Symmetry},
+	volume       = 13,
+	pages        = 368,
+	doi          = {10.3390/sym13030368},
+	issue        = 3,
+	keywords     = {datascience}
+}
+@article{Koffert2020,
+	title        = {Partial restoration of normal intestinal microbiota in morbidly obese women six months after bariatric surgery},
+	author       = {Jukka Koffert and Leo Lahti and Lotta Nylund and Seppo Salminen and Jarna C Hannukainen and Paulina Salminen and Willem de Vos and Pirjo Nuutila},
+	year         = 2020,
+	journal      = {PeerJ – Life & Environment},
+	volume       = 8,
+	pages        = {e10442},
+	doi          = {10.7717/peerj.10442},
+	note         = {Shared first authorship.},
+	keywords     = {bioscience}
+}
+@inproceedings{Lahti2020chr,
+	title        = {Quantifying bias and uncertainty in historical data collections with probabilistic programming},
+	author       = {Leo Lahti and Eetu Mäkelä and Mikko Tolonen},
+	year         = 2020,
+	month        = {Nov},
+	booktitle    = {{Proc. CEUR Workshop Proceedings on Computational Humanities Research}},
+	pages        = {80--89},
+	url          = {http://ceur-ws.org/Vol-2723/short46.pdf},
+	keywords     = {dh}
+}
+@article{Lahti2020hs1,
+	title        = {Laskentamallit eivät lähtökohtaisesti ole salassa pidettävää tietoa},
+	author       = {Leo Lahti and Thomas Wallgren and Markku Kulmala},
+	year         = 2020,
+	month        = {May},
+	journal      = {HS Mielipide},
+	url          = {https://www.hs.fi/mielipide/art-2000006494641.html},
+	keywords     = {opinion}
+}
+@article{Lahti2020hs2,
+	title        = {Lähdekoodin sisältämien yksityiskohtien avoimuus on keskeistä päätöksenteon läpinäkyvyydelle.},
+	author       = {Leo Lahti},
+	year         = 2020,
+	month        = {June},
+	journal      = {HS Mielipide},
+	url          = {https://www.hs.fi/mielipide/art-2000006545770.html},
+	keywords     = {opinion}
+}
+@article{Lahti2020okf1,
+	title        = {Tietopyyntö epidemialaskelmien lähdekoodeista},
+	author       = {Leo Lahti and Tarmo Toikkanen},
+	year         = 2020,
+	month        = {May},
+	journal      = {Open Knowledge Finland Blog},
+	url          = {https://www.okf.fi/fi/2020/05/13/tietopyynto-thln-epidemialaskelmien-lahdekoodeista},
+	keywords     = {opinion}
+}
+@article{Lahti2020okf2,
+	title        = {Päätös epidemialaskelmien salaamisesta vastoin valtioneuvoston avoimuuslinjausta},
+	author       = {Leo Lahti},
+	year         = 2020,
+	month        = {June},
+	journal      = {Open Knowledge Finland Blog},
+	url          = {https://www.okf.fi/fi/2020/06/15/thln-paatos-epidemialaskelmien-salaamisesta-vastoin-valtioneuvoston-avoimuuslinjausta/},
+	keywords     = {opinion}
+}
+@article{Lahti2020thinkopen,
+	title        = {Avoimuus voi vahvistaa päätöksenteon tieteellistä pohjaa},
+	author       = {Leo Lahti},
+	year         = 2020,
+	month        = {August},
+	journal      = {University of Helsinki, ThinkOpen blog},
+	url          = {https://blogs.helsinki.fi/thinkopen/lahdekoodin-avoimuus-paatoksenteossa/},
+	keywords     = {opinion}
+}
+@inproceedings{Makela2020,
+	title        = {Wrangling with Non-Standard Data},
+	author       = {Eetu, M and Lagus, K and Lahti, L and Säily, T and Tolonen, M and Hämäläinen, M and Kaislaniemi, S and Nevalainen, T},
+	year         = 2020,
+	month        = {March},
+	booktitle    = {Proc. Digital Humanities in the Nordic Countries},
+	series       = {CEUR Workshop Proceedings},
+	volume       = 2612,
+	pages        = {81--96},
+	url          = {https://github.com/openresearchlabs/openresearchlabs.github.io/blob/master/content/publication_resources/papers/2020-Makela-DHN.pdf},
+	editor       = {Sanita Reinsone and Inguna Skadiņa and Anda Baklāne and Jānis Daugavietis},
+	keywords     = {dh}
+}
 @article{Nylund2020,
 	title        = {Diet, perceived intestinal well-being, fecal microbiota and short chain fatty acids in oat-using subjects with celiac disease or gluten sensitivity.},
 	author       = {Lotta Nylund and Salla Hakkola and Leo Lahti and Seppo Salminen and Marko Kalliomäki and Baoru Yang and Kaisa M. Linderborg},
@@ -1232,51 +363,6 @@
 	issue        = 9,
 	keywords     = {bioscience}
 }
-
-
-@article{Nymark07,
-	title        = {Gene Expression Profiles in Asbestos-exposed Epithelial and Mesothelial Lung Cell Lines},
-	author       = {Penny Nymark and Pamela M. Lindholm and Mikko V. Korpela and Leo Lahti and Salla Ruosaari and Samuel Kaski and Jaakko Hollmen and Sisko Anttila and Vuokko L. Kinnula and Sakari Knuutila},
-	year         = 2007,
-	month        = 3,
-	journal      = {BMC Genomics},
-	volume       = 8,
-	number       = 62,
-	doi          = {10.1186/1471-2164-8-62},
-	keywords     = {bioscience},
-	annote       = {CCA on two asbestos-exposed cell lines.}
-}
-
-@article{Nymark11,
-	title        = {Integrative Analysis of microRNA, mRNA and aCGH Data Reveals Asbestos- and Histology-Related Changes in Lung Cancer},
-	author       = {Penny Nymark and Mohamed Guled and Ioana Borze and Ali Faisal and Leo Lahti and Kaisa Salmenkivi and Eeva Kettunen and Sisko Anttila and Sakari Knuutila},
-	year         = 2011,
-	month        = 8,
-	journal      = {Genes, Chromosomes and Cancer},
-	volume       = 50,
-	number       = 8,
-	pages        = {585--597},
-	doi          = {10.1002/gcc.20880},
-	url          = {https://github.com/openresearchlabs/openresearchlabs.github.io/blob/master/content/publication_resources/papers/2011-Nymark-GCC.pdf},
-	keywords     = {bioscience}
-}
-
-@article{OKeefe15,
-	title        = {Fat, Fiber and Cancer Risk in African, Americans and Rural Africans},
-	author       = {SJD O'Keefe and JV Li and L Lahti and J Ou and F Carbonero and K Mohammed and JM Posma and J Kinross and E Wahl and E Ruder and K Vipperla and V Naidoo and L Mtshali and S Tims and PGB Puylaert, J DeLany and A Krasinskas and AC Benefiel and HO Kaseb and K Newton and JK Nicholson and WM de Vos and HR Gaskins and EG Zoetendal},
-	year         = 2015,
-	month        = {Apr},
-	journal      = {Nature Communications},
-	volume       = 6,
-	pages        = 6342,
-	doi          = {10.1038/ncomms7342},
-	note         = {Top science article in Guardian on the release day.},
-	keywords     = {gut},
-	keywords     = {bioscience},
-	url          = {https://github.com/openresearchlabs/openresearchlabs.github.io/blob/master/content/publication_resources/papers/2015-OKeefe-NComms.pdf},
-	annote       = {Guardian: http://www.theguardian.com/science/2015/apr/28/bowel-cancer-risk-may-be-reduced-by-rural-african-diet-study-finds}
-}
-
 @article{Palmu2020,
 	title        = {Association Between the Gut Microbiota and Blood Pressure in a Population Cohort of 6953 Individuals},
 	author       = {Joonatan Palmu and Aaro Salosensaari and Aki S. Havulinna and Susan Cheng and Michael Inouye and Mohit Jain and Rodolfo A. Salido and Karenina Sanders and Caitriona Brennan and Gregory C. Humphrey and Jon G. Sanders and Erkki Vartiainen and Tiina Laatikainen and Pekka Jousilahti and Veikko Salomaa and Rob Knight and Leo Lahti and Teemu J. Niiranen},
@@ -1285,11 +371,6 @@
 	journal      = {Journal of the American Heart Association},
 	doi          = {10.1161/JAHA.120.016641},
 	keywords     = {bioscience}
-
-
-
-
-
 }
 @article{Palmu2020JAHA,
 	title        = {Eicosanoid Inflammatory Mediators Are Robustly Associated with Blood Pressure in the General Population},
@@ -1302,27 +383,11 @@
 	issue        = 15,
 	keywords     = {bioscience}
 }
-
-@article{Palmu2021ijerph,
-	title        = {Targeting gut microbiota to treat hypertension: a systematic review},
-	author       = {Joonatan Palmu and Leo Lahti and Teemu Niiranen},
-	year         = 2021,
-	month        = January,
-	journal      = {International Journal of Environmental Research and Public Health},
-	volume       = 18,
-	number       = 3,
-	pages        = 1248,
-	doi          = {10.3390/ijerph18031248},
-	keywords     = {bioscience},
-	tag          = {review}
-}
-
-
 @article{Pekkala2020,
 	title        = {Prebiotic Xylo-oligosaccharides Targeting Faecalibacterium prausnitzii Prevent High Fat Diet-induced Hepatic Steatosis in Rats},
 	author       = {Sanna Lensu and Raghunath Pariyani and Elina Mäkinen and Baoru Yang and Wisam Saleem and Eveliina Munukka and Maarit Lehti and Baoru Yang and Jere Linden and Marja Tiirola and Leo Lahti and Satu Pekkala},
 	year         = 2020,
-	month        = {October},
+	month        = 10,
 	journal      = {Nutrients},
 	volume       = 12,
 	number       = 11,
@@ -1330,202 +395,156 @@
 	doi          = {10.3390/nu12113225},
 	keywords     = {bioscience}
 }
-
-@article{Ritari15,
-	title        = {Improved taxonomic assignment of human intestinal 16S rRNA sequences by a dedicated reference database},
-	author       = {Jarmo Ritari and Jarkko Salojärvi and Leo Lahti and Willem M. de Vos},
-	year         = 2015,
-	month        = 12,
-	journal      = {BMC Genomics},
-	volume       = 16,
-	pages        = 1056,
-	doi          = {10.1186/s12864-015-2265-y},
-	url          = {https://github.com/openresearchlabs/openresearchlabs.github.io/blob/master/content/publication_resources/papers/2015-Ritari-BMCGenomics.pdf},
-	keywords     = {bioscience}
-}
-
-@article{Ruuskanen2021,
-	title        = {Modeling spatial patterns in host-associated microbial communities},
-	author       = {Matti Ruuskanen and Guilhem Sommeria-Klein and Aki Havulinna and Teemu Niiranen and Leo Lahti},
-	year         = 2021,
-	month        = {May},
-	journal      = {Environmental Microbiology},
-	volume       = 23,
-	number       = 5,
-	pages        = {2374--2388},
-	keywords     = {bioscience},
-	doi          = {10.1111/1462-2920.15462}
-}
-
-
-
-@article{Ruuskanen2021gutmicrobes,
-	title        = {Links between gut microbiome composition and fatty liver disease in a large population sample},
-	author       = {Matti O. Ruuskanen and Fredrik Åberg and Ville Männistö and Aki S. Havulinna and Guillaume Méric and Yang Liu and Rohit Loomba and Yoshiki Vázquez-Baeza and Anupriya Tripathi and Liisa M. Valsta and Michael Inouye and Pekka Jousilahti and Veikko Salomaa and Mohit Jain and Rob Knight and Leo Lahti and Teemu J. Niiranen},
-	year         = 2021,
-	month        = {March},
-	journal      = {Gut Microbes},
-	volume       = 13,
-	doi          = {10.1080/19490976.2021.1888673},
-	issue        = 1,
-	keywords     = {bioscience}
-}
-
-
-@article{Salosensaari2021,
-	title        = {Taxonomic signatures of cause-specific mortality risk in human gut microbiome},
-	author       = {Aaro Salosensaari* and Ville Laitinen* and Aki S Havulinna and Guillaume Meric and Susan Cheng and Markus Perola and Liisa Valsta and Georg Alfthan and Michael Inouye and Jeramie D Watrous and Tao Long and Rodolfo Salido and Karenina Sanders and Caitriona Brennan and Gregory C Humphrey and Jon G Sanders and Mohit Jain and Pekka Jousilahti and Veikko Salomaa and Rob Knight and Leo Lahti* and Teemu Niiranen*},
-	year         = 2021,
-	journal      = {Nature Communications},
-	volume       = 12,
-	pages        = 2671,
-	doi          = {10.1038/s41467-021-22962-y},
-	keywords     = {bioscience},
-	annote       = {Preprint featured in HS Tiede Jan 30, 2020. Featured in Science Magazine Jan 22, 2020 https://www.sciencemag.org/news/2020/01/microbes-your-gut-could-predict-whether-you-re-likely-die-next-15-years}
-}
-
-
-
-@article{Sarhadi13,
-	title        = {Targeted Resequencing of 9p in Acute Lymphoblastic Leukemia Yields Concordant Results with Array CGH and Reveals Novel Genomic Alterations},
-	author       = {Virinder Kaur Sarhadi and Leo Lahti and Ilari Scheinin and Anne Tyyb{\"a}kinoja and Suvi Savola and Anu Usvasalo and Riikka R{\"a}ty and Erkki Elonen and Pekka Ellonen and Ulla M Saarinen-Pihkala and Sakari Knuutila},
-	year         = 2013,
-	month        = 9,
-	journal      = {Genomics},
-	volume       = 102,
-	number       = 3,
-	pages        = {182--188},
-	doi          = {10.1016/j.ygeno.2013.01.001},
-	keywords     = {bioscience},
-	url          = {https://github.com/openresearchlabs/openresearchlabs.github.io/blob/master/content/publication_resources/papers/2013-Sarhadi-Genomics.pdf},
-	authorship   = {shared first}
-}
-
-
 @article{Sarhadi2020,
 	title        = {Gut Microbiota and Host Gene Mutations in Colorectal Cancer Patients and Controls of Iranian and Finnish Origin},
 	author       = {Sarhadi, V and Lahti, L and Saberi, F and Youssef, O and Kokkola, A and Karla, T and Tikkanen, M and Rautelin, H and Puolakkainen, P and Salehi, R and Knuutila, S},
 	year         = 2020,
-	month        = {March},
+	month        = 3,
 	journal      = {Anticancer Research},
 	volume       = 40,
 	number       = 3,
 	pages        = {1325--1334},
 	doi          = {10.21873/anticanres.14074},
-	keywords     = {bioscience},
-	url          = {https://github.com/openresearchlabs/openresearchlabs.github.io/blob/master/content/publication_resources/papers/2020-Sarhadi-Anticanc.pdf}
+	url          = {https://github.com/openresearchlabs/openresearchlabs.github.io/blob/master/content/publication_resources/papers/2020-Sarhadi-Anticanc.pdf},
+	keywords     = {bioscience}
 }
-
-@article{Sarhadi2021,
-	title        = {Gut microbiota of patients with different subtypes of gastric cancer and gastrointestinal stromal tumors},
-	author       = {Virinder Sarhadi and Binu Mathew and Arto Kokkola A and Tiina Karla and Milja Tikkanen and Hilpi Rautelin and Leo Lahti and Pauli Puolakkainen and Sakari Knuutila},
-	year         = 2021,
-	journal      = {Gut Pathogens},
-	volume       = 13,
-	pages        = {1--9},
-	doi          = {10.1186/s13099-021-00403-x},
-	keywords     = {bioscience},
-	issue        = 11
+@article{Vaura2020jch,
+	title        = {Unsupervised hierarchical clustering identifies a metabolically challenged subgroup of hypertensive individuals},
+	author       = {Felix C. Vaura and Veikko V. Salomaa and Ilkka M. Kantola and Risto Kaaja and Leo Lahti and Teemu J. Niiranen},
+	year         = 2020,
+	month        = 8,
+	journal      = {Journal of Clinical Hypertension},
+	volume       = 22,
+	number       = 9,
+	pages        = {1546--1553},
+	doi          = {10.1111/jch.13984},
+	keywords     = {bioscience}
 }
-
-
-@article{Shetty2017,
-	title        = {Intestinal microbiome landscaping: Insight in community assemblage and implications for microbial modulation strategies},
-	author       = {Shetty, SA and Hugenholtz, F and Lahti, L and Smidt, H and de Vos, WM and Danchin, A},
-	year         = 2017,
+@techreport{openedu2020,
+	title        = {National policy and executive plan by the higher education and research community for 2021-2025 - Policy component 1: Open access to educational resources.},
+	author       = {Expert Panel in Open Education (Open Science Coordination in Finland)},
+	year         = 2020,
+	journal      = {Responsible Research Series},
+	publisher    = {Committee for Public Information (TJNK) and Federation of Finnish Learned Societies (TSV).},
+	address      = {Helsinki, Finland},
+	volume       = 16,
+	keywords     = {openscience}
+}
+@article{Aatsinki2019,
+	title        = {Gut microbiota composition is associated with temperament traits in infants},
+	author       = {Anna Aatsinki and Leo Lahti and Henna Uusitupa and Eveliina Munukka and Anniina Keskitalo, Saara Nolvi and Siobhain O'Mahony and Sami Pietilä and Laura Elo and Erkki Eerola and Hasse Karlsson and Linnea Karlsson},
+	year         = 2019,
+	month        = {May},
+	journal      = {Brain Behavior and Immunity},
+	volume       = 80,
+	pages        = {849--858},
+	doi          = {10.1016/j.bbi.2019.05.035},
+	url          = {https://github.com/openresearchlabs/openresearchlabs.github.io/blob/master/content/publication_resources/papers/2019-Aatsinki.pdf},
+	keywords     = {bioscience}
+}
+@inproceedings{Hill2019dhn,
+	title        = {Reconstructing intellectual networks: from the {ESTC}'s bibliographic metadata to historical material},
+	author       = {Mark J Hill and Ville Vaara and Tanja S{\"a}ily and Leo Lahti and Mikko Tolonen},
+	year         = 2019,
 	month        = {March},
-	journal      = {FEMS Microbiology Reviews},
-	volume       = 41,
-	pages        = {182--199},
-	note        = {fuw045},
-	doi          = {10.1093/femsre/fuw045},
-	issue        = 2,
-	keywords     = {bioscience},
-	note     = {review},
-	url          = {https://github.com/openresearchlabs/openresearchlabs.github.io/blob/master/content/publication_resources/papers/2017-Shetty-FEMS.pdf}
+	booktitle    = {Proc. Digital Humanities in the Nordic Countries},
+	address      = {Copenhagen},
+	series       = {CEUR Workshop Proceedings},
+	volume       = 2364,
+	pages        = {201--219},
+	url          = {https://github.com/openresearchlabs/openresearchlabs.github.io/blob/master/content/publication_resources/papers/2019-Hill-DHN.pdf},
+	note         = {Best paper award.},
+	editor       = {Costanza Navarretta and Manex Agirrezabal and Bente Maegaard},
+	keywords     = {dh}
 }
-
+@inproceedings{Ijaz2019dh,
+	title        = {Analytical Edition Detection In Bibliographic Metadata},
+	author       = {Ali Ijaz and Hege Roivainen and Leo Lahti},
+	year         = 2019,
+	month        = {July},
+	booktitle    = {Proceedings of the Digital Humanities (DH2019)},
+	note         = {In press.},
+	keywords     = {dh}
+}
+@inproceedings{Ijaz2019rdhum,
+	title        = {Analytical determination of editions from bibliographic metadata},
+	author       = {Ali Ijaz and Mikko Tolonen and Leo Lahti},
+	year         = 2019,
+	month        = {August},
+	booktitle    = {Proceedings of the Research Data in the Humanities Conference},
+	address      = {Oulu},
+	url          = {https://github.com/openresearchlabs/openresearchlabs.github.io/blob/master/content/publication_resources/papers/2019-Ijaz-RDHum.pdf},
+	keywords     = {dh}
+}
+@article{Lahti2019bds,
+	title        = {Bibliographic Data Science and the History of the Book (c. 1500–1800)},
+	author       = {Leo Lahti and Jani Marjanen and Hege Roivainen and Mikko Tolonen},
+	year         = 2019,
+	month        = {January},
+	journal      = {Cataloging \& Classification Quarterly},
+	publisher    = {Routledge},
+	volume       = 57,
+	number       = 1,
+	pages        = {5--23},
+	doi          = {10.1080/01639374.2018.1543747},
+	url          = {https://github.com/openresearchlabs/openresearchlabs.github.io/blob/master/content/publication_resources/papers/2019-Lahti-CCQ.pdf},
+	note         = {Special issue.},
+	keywords     = {dh}
+}
+@inproceedings{Lahti2019rdhum,
+	title        = {Best practices in bibliographic data science},
+	author       = {Leo Lahti and Ville Vaara and Jani Marjanen and Mikko Tolonen},
+	year         = 2019,
+	month        = {August},
+	booktitle    = {Proceedings of the Research Data in the Humanities Conference},
+	address      = {Oulu},
+	url          = {https://github.com/openresearchlabs/openresearchlabs.github.io/blob/master/content/publication_resources/papers/2019-Lahti-RDHUM.pdf},
+	keywords     = {dh}
+}
+@inproceedings{Makela2019dhn,
+	title        = {Interdisciplinary collaboration in studying newspaper materiality},
+	author       = {Eetu M{\"a}kel{\"a} and Mikko Tolonen and Jani Marjanen and Antti Kanner and Ville Vaara and Leo Lahti},
+	year         = 2019,
+	month        = {March},
+	booktitle    = {Proc. Twin Talks workshop. Digital Humanities in the Nordic Countries},
+	address      = {Copenhagen},
+	series       = {CEUR Workshop Proceedings},
+	volume       = 2365,
+	pages        = {55--66},
+	url          = {http://ceur-ws.org/Vol-2365/07-TwinTalks-DHN2019_paper_7.pdf},
+	url          = {https://github.com/openresearchlabs/openresearchlabs.github.io/blob/master/content/publication_resources/papers/2019-Makela-DHN.pdf},
+	editor       = {Steven Krauwer and Darja Fišer},
+	pubstate     = {dh},
+	keywords     = {dh}
+}
+@article{Marjanen2019,
+	title        = {A National Public Sphere? Analyzing the Language, Location, and Form of Newspapers in Finland, 1771–1917},
+	author       = {Jani Marjanen and Ville Vaara and Antti Kanner and Hege Roivainen and Eetu Mäkelä and Leo Lahti and Mikko Tolonen},
+	year         = 2019,
+	month        = {June},
+	journal      = {Journal of European Periodical Studies},
+	volume       = 4,
+	number       = 1,
+	doi          = {10.21825/jeps.v4i1.10483},
+	url          = {https://ojs.ugent.be/jeps/article/view/10483},
+	url          = {https://github.com/openresearchlabs/openresearchlabs.github.io/blob/master/content/publication_resources/papers/2019-Marjanen-JEPS.pdf},
+	note         = {Special issue: Digital Approaches Towards Serial Publications},
+	pubstate     = {dh},
+	keywords     = {dh}
+}
 @article{Shetty2019,
-  title =	 {Microbiome data science},
-  author =	 {Sudarshan Shetty and Leo Lahti},
-  year =	 2019,
-  month =	 {October},
-  journal =	 {Journal of Biosciences},
-  volume =	 44,
-  pages =	 115,
-  doi =		 {10.1007/s12038-019-9930-2},
-  url =
-                  {https://github.com/openresearchlabs/openresearchlabs.github.io/blob/master/content/publication_resources/papers/2019-Shetty-MDS.pdf},
-  keywords =	 {bioscience},
-  category =	 {review}
+	title        = {Microbiome data science},
+	author       = {Sudarshan Shetty and Leo Lahti},
+	year         = 2019,
+	month        = {October},
+	journal      = {Journal of Biosciences},
+	volume       = 44,
+	pages        = 115,
+	doi          = {10.1007/s12038-019-9930-2},
+	url          = {https://github.com/openresearchlabs/openresearchlabs.github.io/blob/master/content/publication_resources/papers/2019-Shetty-MDS.pdf},
+	category     = {review},
+	keywords     = {bioscience}
 }
-
-@article{Siavash15,
-	title        = {Impact of a wastewater treatment plant on microbial community composition and function in a hyporheic zone of a eutrophic river},
-	author       = {Siavash Atashgahi and Rozelin Aydin and Mauricio R. Dimitrov and Detmer Sipkema and Kelly Hamonts and Leo Lahti and Farai Maphosa and Thomas Kruse and Edoardo Saccenti and Dirk Springael, Winnie Dejonghe and Hauke Smidt},
-	year         = 2015,
-	month        = 11,
-	journal      = {Scientific Reports},
-	volume       = 5,
-	number       = 17284,
-	doi          = {10.1038/srep17284},
-	keywords     = {bioscience},
-	url          = {https://github.com/openresearchlabs/openresearchlabs.github.io/blob/master/content/publication_resources/papers/2015-Atagashi.pdf}
-}
-
-@techreport{Sinkkonen03tr,
-	title        = {Associative Clustering by Maximizing a {B}ayes Factor},
-	author       = {Janne Sinkkonen and Janne Nikkil\"{a} and Leo Lahti and Samuel Kaski},
-	year         = 2003,
-	month        = 6,
-	address      = {Espoo, Finland},
-	number       = {A68},
-	institution  = {Helsinki University of Technology and Laboratory of Computer and Information Science},
-	keywords     = {bioscience},	
-	url          = {https://github.com/openresearchlabs/openresearchlabs.github.io/blob/master/content/publication_resources/papers/2003-TechRep-Sinkkonen-ACBayesFactor.pdf}
-}
-
-@incollection{Sinkkonen04ecml,
-	title        = {Associative Clustering},
-	author       = {Janne Sinkkonen and Janne Nikkil\"{a} and Leo Lahti and Samuel Kaski},
-	year         = 2004,
-	booktitle    = {Proceedings of the ECML'04, 15th European Conference on Machine Learning},
-	publisher    = {Springer},
-	address      = {Berlin},
-	pages        = {396--406},
-	url          = {http://www.cis.hut.fi/projects/mi/abstracts/ecml04.html},
-	category     = {abstract},
-	editor       = {Boulicaut and Esposito and Giannotti and Pedreschi},
-	keywords       = {datascience},
-	url          = {https://github.com/openresearchlabs/openresearchlabs.github.io/blob/master/content/publication_resources/papers/2004-ECML-Sinkkonen-AC.pdf}
-}
-
-@techreport{Sinkkonen05tr,
-	title        = {Associative Clustering (AC): Technical Details},
-	author       = {Janne Sinkkonen and Samuel Kaski and Janne Nikkil{\"a} and Leo Lahti},
-	year         = 2005,
-	month        = {April},
-	address      = {Espoo, Finland},
-	number       = {A84},
-	note         = {Publications in Computer and Information Science},
-	institution  = {Helsinki University of Technology},
-	keywords       = {datascience},
-	url          = {https://github.com/openresearchlabs/openresearchlabs.github.io/blob/master/content/publication_resources/papers/2005-TechRep-Sinkkonen-ACtechdetails.pdf}
-}
-
-@article{Su2015,
-	title        = {A novel atlas of gene expression in human skeletal muscle reveals molecular changes associated with aging},
-	author       = {Jing Su and Carl Ekman and Nikolay Oskolkov and Leo Lahti and Kristoffer Ström and Alvis Brazma and Leif Groop and Johan Rung and and Ola Hansson},
-	year         = 2015,
-	month        = 10,
-	journal      = {Skeletal Muscle},
-	volume       = 5,
-	number       = 35,
-	doi          = {10.1186/s13395-015-0059-1},
-	keywords     = {bioscience},
-	url          = {https://github.com/openresearchlabs/openresearchlabs.github.io/blob/master/content/publication_resources/papers/2015-Su-SkeletalMuscle.pdf}
-}
-
 @article{Timmis2019,
 	title        = {Microbiome yarns: The Global Phenotype-Genotype Survey. Episode III: importance of microbiota diversification for microbiome function and biome health},
 	author       = {Timmis, K and Jebok, F and Rohde, M and Lahti, L and Molinari, G},
@@ -1536,36 +555,160 @@
 	keywords     = {misc},
 	annote       = {Comics piece for the popularization of microbiome research.}
 }
-
-@article{Tolonen15EnnenNyt,
-  title =	 {Aatehistoria ja digitaalisten aineistojen
-                  mahdollisuudet},
-  author =	 {Mikko Tolonen and Leo Lahti},
-  year =	 2015,
-  month =	 8,
-  journal =	 {Ennen \& Nyt 2},
-  volume =	 2,
-  keywords =	 {dh},
-  authorship =	 {shared first},
-  language =	 {Finnish},
-  url =		 {https://github.com/openresearchlabs/openresearchlabs.github.io/blob/master/content/publication_resources/papers/2015-EnnenNyt-Tolonen.pdf},
-  keywords =	 {dh}
+@inproceedings{Tolonen2019dhn,
+	title        = {Scaling up bibliographic data science},
+	author       = {Mikko Tolonen and Jani Marjanen and Hege Roivainen and Leo Lahti},
+	year         = 2019,
+	month        = {March},
+	booktitle    = {Proceedings of the Digital Humanities in the Nordics (DHN2019)},
+	address      = {Copenhagen},
+	url          = {https://github.com/openresearchlabs/openresearchlabs.github.io/blob/master/content/publication_resources/papers/2019-Tolonen-DHN.pdf},
+	editor       = {Costanza Navarretta and Manex Agirrezabal and Bente Maegaard},
+	pubstate     = {dh},
+	keywords     = {dh}
 }
-
-@inproceedings{Tolonen16dh,
-	title        = {Printing in a Periphery: a Quantitative Study of Finnish Knowledge Production, 1640-1828},
-	author       = {Mikko Tolonen and Niko Ilom{\"a}ki and Hege Roivainen and Leo Lahti},
-	year         = 2016,
-	month        = 7,
-	booktitle    = {Digital Humanities 2016: Conference Abstracts},
-	publisher    = {Jagiellonian University & Pedagogical University, Kraków},
-	address      = {Krakow, Poland},
-	pages        = {383--385},
-	url          = {http://dh2016.adho.org/abstracts/9},
+@inproceedings{Vaara2019dh,
+	title        = {The Emerging Paradigm of Bibliographic Data Science},
+	author       = {Ville Vaara and Ali Ijaz and Iiro Tiihonen and Simon Hengchen and Antti Kanner and Tanja S{\"a}ily and Leo Lahti},
+	year         = 2019,
+	month        = {July},
+	booktitle    = {Proceedings of the Digital Humanities (DH2019)},
+	note         = {In press.},
+	keywords     = {dh}
+}
+@article{stolaki2019,
+	title        = {Microbial communities in a dynamic {it in vitro} model for the human ileum resemble the human ileal microbiota},
+	author       = {Stolaki, Maria and Minekus, Mans and Venema, Koen and Lahti, Leo and Smid, Eddy J. and Kleerebezem, Michiel and Zoetendal, Erwin G},
+	year         = 2019,
+	month        = {August},
+	journal      = {FEMS Microbiology Ecology},
+	number       = 8,
+	pages        = {fiz096},
+	doi          = {10.1093/femsec/fiz096},
+	url          = {https://github.com/openresearchlabs/openresearchlabs.github.io/blob/master/content/publication_resources/papers/2019-Stolaki-FEMS.pdf},
+	keywords     = {bioscience},
+	vol          = 95
+}
+@article{tolonen2019,
+	title        = {A Quantitative Approach to Book-Printing in Sweden and Finland, 1640–1828},
+	author       = {Mikko Tolonen and Leo Lahti and Hege Roivainen and Jani Marjanen},
+	year         = 2019,
+	journal      = {Historical Methods: A Journal of Quantitative and Interdisciplinary History},
+	publisher    = {Routledge},
+	volume       = 52,
+	pages        = {57--78},
+	doi          = {10.1080/01615440.2018.1526657},
+	url          = {https://github.com/openresearchlabs/openresearchlabs.github.io/blob/master/content/publication_resources/papers/2019-Tolonen.pdf},
+	issue        = 1,
+	keywords     = {dh}
+}
+@article{Aatsinki2018,
+	title        = {Gut Microbiota Composition in Mid-Pregnancy Is Associated with Gestational Weight Gain but Not Prepregnancy Body Mass Index},
+	author       = {Anna-Katariina Aatsinki and Henna-Maria Uusitupa and Eveliina Munukka and Henri Pesonen and Anniina Rintala and Sami Pietilä and Leo Lahti and Erkki Eerola and Linnea Karlsson and Hasse Karlsson},
+	year         = 2018,
+	month        = {May},
+	journal      = {Journal of Womens Health},
+	doi          = {10.1089/jwh.2017.6488},
+	url          = {https://github.com/openresearchlabs/openresearchlabs.github.io/blob/master/content/publication_resources/papers/2018-Aatsinki.pdf},
+	note         = {Epub ahead of print.},
+	keywords     = {bioscience}
+}
+@article{Arani2018,
+	title        = {Stability estimation of autoregulated genes under Michaelis-Menten type kinetics},
+	author       = {Arani, Babak M. S. and Mahmoudi, Mahdi and Lahti, Leo and Gonz\'alez, Javier and Wit, Ernst C.},
+	year         = 2018,
+	month        = {Jun},
+	journal      = {Physical Review E},
+	publisher    = {American Physical Society},
+	volume       = 97,
+	number       = 6,
+	pages        = 062407,
+	doi          = {10.1103/PhysRevE.97.062407},
+	issn         = {2470-0045},
+	url          = {https://link.aps.org/doi/10.1103/PhysRevE.97.062407},
+	url          = {https://github.com/openresearchlabs/openresearchlabs.github.io/blob/master/content/publication_resources/papers/2018-Arani-PhysRevE.pdf},
+	numpages     = 10,
+	keywords     = {datascience}
+}
+@techreport{Bjork2018,
+	title        = {Opening academic publishing: development and application of systematic evaluation criteria},
+	author       = {Anna Björk and Juho-Matti Paavolainen and Teemu Ropponen and Mikael Laakso and Leo Lahti},
+	year         = 2018,
+	month        = {January},
+	publisher    = {Open Science and Research Initiative (ATT)},
+	url          = {http://urn.fi/URN:NBN:fi-fe201802123334},
+	url          = {https://github.com/openresearchlabs/openresearchlabs.github.io/blob/master/content/publication_resources/papers/2018-Bjork-ATT.pdf},
+	category     = {report},
+	note         = {Report on the openness of major scientific publishers commissioned by Finnish Ministry of Education and Culture},
+	institution  = {unknown},
+	authorship   = {corresponding},
+	pubstate     = {openscience},
+	keywords     = {openscience}
+}
+@article{Faust2018,
+	title        = {Signatures of ecological processes in microbial community time series},
+	author       = {Karoline Faust and Franziska Bauchinger and Beatrice Laroche and Sophie de Buyl and Leo Lahti and Alex D Washburne and Didier Gonze and Stefanie Widder},
+	year         = 2018,
+	month        = {June},
+	journal      = {Microbiome},
+	volume       = 6,
+	number       = 120,
+	doi          = {10.1186/s40168-018-0496-2},
+	url          = {https://github.com/openresearchlabs/openresearchlabs.github.io/blob/master/content/publication_resources/papers/2018-Faust-Microbiome.pdf},
+	keywords     = {bioscience}
+}
+@article{Gonze2018,
+	title        = {Microbial communities as dynamical systems},
+	author       = {Didier Gonze and Katharine Z Coyte and Leo Lahti and Karoline Faust},
+	year         = 2018,
+	month        = {July},
+	journal      = {Current Opinion in Microbiology},
+	volume       = 44,
+	pages        = {41--49},
+	doi          = {10.1016/j.mib.2018.07.004},
+	url          = {https://github.com/openresearchlabs/openresearchlabs.github.io/blob/master/content/publication_resources/papers/2018-Gonze.pdf},
+	keywords     = {bioscience}
+}
+@inproceedings{Hill2018,
+	title        = {Spheres of “public” in eighteenth-century Britain},
+	author       = {Mark J Hill and Antti Kanner and Jani Marjanen and Ville Vaara and Eetu Mäkelä and Leo Lahti and Mikko Tolonen},
+	year         = 2018,
+	month        = 3,
+	booktitle    = {Proceedings of the Digital Humanities in the Nordics Conference},
+	address      = {Helsinki, Finland},
 	category     = {abstract},
 	keywords     = {dh}
 }
-
+@inproceedings{Lahti2018IDA,
+	title        = {Open Data Science},
+	author       = {Lahti, Leo},
+	year         = 2018,
+	month        = {October},
+	booktitle    = {Advances in Intelligent Data Analysis XVII. Lecture Notes in Computer Science 11191.},
+	publisher    = {Springer},
+	publisher    = {Springer Nature},
+	address      = {India},
+	volume       = 11191,
+	url          = {https://github.com/openresearchlabs/openresearchlabs.github.io/blob/master/content/publication_resources/papers/2018-Lahti-IDA.pdf},
+	category     = {perspective},
+	note         = {Conference proceedings.},
+	keywords     = {openscience},
+	authorship   = {first}
+}
+@inproceedings{Laitinen2018IDA,
+	title        = {A hierarchical Ornstein-Uhlenbeck model for stochastic time series analysis},
+	author       = {Laitinen, Ville and Lahti, Leo},
+	year         = 2018,
+	month        = {October},
+	booktitle    = {Advances in Intelligent Data Analysis XVII. Lecture Notes in Computer Science 11191.},
+	publisher    = {Springer},
+	address      = {India},
+	url          = {https://github.com/velait/OUP},
+	url          = {https://github.com/openresearchlabs/openresearchlabs.github.io/blob/master/content/publication_resources/papers/2018-Laitinen-IDA.pdf},
+	note         = {Conference proceedings.},
+	keywords     = {datascience},
+	authorship   = {pi}
+}
 @article{Tolonen2018gaudeamus,
 	title        = {Digitaaliset ihmistieteet ja historiantutkimus},
 	author       = {Mikko Tolonen and Leo Lahti},
@@ -1579,89 +722,9 @@
 	language     = {Finnish},
 	editor       = {Hannikainen, MO and Danielsbacka, M and Tepora, T},
 	journaltitle = {Menneisyyden rakentajat},
-	keywords       = {dh},
+	keywords     = {dh},
 	annote       = {This is a book chapter but classified as article as could not find a way to include this to CSL automatically generated bibliography yet.}
 }
-
-@inproceedings{Tolonen2019dhn,
-	title        = {Scaling up bibliographic data science},
-	author       = {Mikko Tolonen and Jani Marjanen and Hege Roivainen and Leo Lahti},
-	year         = 2019,
-	month        = {March},
-	booktitle    = {Proceedings of the Digital Humanities in the Nordics (DHN2019)},
-	address      = {Copenhagen},
-	editor       = {Costanza Navarretta and Manex Agirrezabal and Bente Maegaard},
-	url          = {https://github.com/openresearchlabs/openresearchlabs.github.io/blob/master/content/publication_resources/papers/2019-Tolonen-DHN.pdf},
-	pubstate     = {dh},
-	keywords     = {dh}
-}
-
-
-@incollection{Tolonen2021canon,
-	title        = {Examining the Early Modern Canon: The English Short Title Catalogue and Large-Scale Patterns of Cultural Production.},
-	author       = {Mikko Tolonen and Mark J. Hill and Ali Zeeshan Ijaz and Ville Vaara and Leo Lahti},
-	year         = 2021,
-	month        = {March},
-	booktitle    = {Data Visualization in Enlightenment Literature and Culture},
-	publisher    = {Palgrave Macmillan, Cham.},
-	doi          = {10.1007/978-3-030-54913-8_3},
-	note         = {Book chapter in: Data Visualization in Enlightenment Literature and Culture},
-	editor       = {Baird, I.},
-	chapter      = 3,
-	keywords={dh}
-}
-
-@InProceedings{Tiihonen2021chr,
-  author =	 {Iiro Tiihonen and Mikko Tolonen and Leo Lahti},
-  title =	 {Probabilistic Analysis of Early Modern British Book
-                  Prices},
-  booktitle =	 {{Proc. CEUR Workshop Proceedings on Computational
-                  Humanities Research}},
-  year =	 2021,
-  pages =	 {39--48},
-  keywords =	 {dh},
-  month =	 {Nov},
-  url =
-                  {https://github.com/openresearchlabs/openresearchlabs.github.io/blob/master/content/publication_resources/papers/2021-Tiihonen-CHR.pdf},
-  note =	 {In M Ehrmann, F Karsdorp et al. (eds).}
-}
-
-
-@article{Tolonen2021rcl,
-	title        = {Corpus Linguistics and Eighteenth Century Collections Online (ECCO)},
-	author       = {Tolonen, M and M{\"a}kel{\"a}, E and Ijaz, A and Lahti, L},
-	year         = 2021,
-	journal      = {Research in Corpus Linguistics},
-	volume       = 9,
-	number       = 1,
-	pages        = {19--34},
-	doi          = {10.32714/ricl.09.01.03},
-	keywords     = {dh}
-}
-
-@inproceedings{Vaara2019dh,
-	title        = {The Emerging Paradigm of Bibliographic Data Science},
-	author       = {Ville Vaara and Ali Ijaz and Iiro Tiihonen and Simon Hengchen and Antti Kanner and Tanja S{\"a}ily and Leo Lahti},
-	year         = 2019,
-	month        = {July},
-	booktitle    = {Proceedings of the Digital Humanities (DH2019)},
-	note         = {In press.},
-	keywords     = {dh}
-}
-
-@article{Vaura2020jch,
-	title        = {Unsupervised hierarchical clustering identifies a metabolically challenged subgroup of hypertensive individuals},
-	author       = {Felix C. Vaura and Veikko V. Salomaa and Ilkka M. Kantola and Risto Kaaja and Leo Lahti and Teemu J. Niiranen},
-	year         = 2020,
-	month        = {August},
-	journal      = {Journal of Clinical Hypertension},
-	volume       = 22,
-	number       = 9,
-	pages        = {1546--1553},
-	doi          = {10.1111/jch.13984},
-	keywords     = {bioscience}
-}
-
 @article{Youssef2018,
 	title        = {Stool Microbiota Composition Differs in Patients with Stomach, Colon, and Rectal Neoplasms},
 	author       = {Omar Youssef and Leo Lahti and Arto Kokkola and Tiina Karla and Milja Tikkanen and Homa Ehsan and Monika Carpelan‑Holmström and Selja Koskensalo and Tom Böhling and Hilpi Rautelin and Pauli Puolakkainen and Sakari Knuutila and Virinder Sarhadi},
@@ -1672,13 +735,381 @@
 	number       = 11,
 	pages        = {2950--2958},
 	doi          = {10.1007/s10620-018-5190-5},
+	url          = {https://github.com/openresearchlabs/openresearchlabs.github.io/blob/master/content/publication_resources/papers/2018-Youssef.pdf},
 	authorship   = {shared first},
-	keywords     = {bioscience},
-	url          = {https://github.com/openresearchlabs/openresearchlabs.github.io/blob/master/content/publication_resources/papers/2018-Youssef.pdf}
+	keywords     = {bioscience}
 }
-
-
-
+@techreport{openutu2018,
+	title        = {Turun yliopiston avoimen tutkimuksen politiikka / Open Research Policy},
+	author       = {{OpenUTU work group}},
+	year         = 2018,
+	month        = {May},
+	journal      = {unknwown},
+	url          = {https://github.com/openresearchlabs/openresearchlabs.github.io/blob/master/content/publication_resources/papers/2018-avoimen-tutkimuksen-politiikka-fi.pdf},
+	category     = {report},
+	note         = {(in Finnish)},
+	key          = {report},
+	institution  = {University of Turku},
+	howpublished = {Report},
+	journaltitle = {unknown},
+	keywords     = {openscience},
+	annote       = {Member in the work group that developed the report.}
+}
+@article{Buelow2017,
+	title        = {Comparative gut microbiota and resistome profiling of intensive care patients receiving selective digestive tract decontamination and healthy subjects},
+	author       = {Elena Buelow and Teresita {d.J.} Bello González and Susana Fuentes and Wouter A.A. {de Steenhuijsen Piters} and Leo Lahti and Jumamurat R. Bayjanov and Eline A.M. Majoor and Johanna C. Braat and Maaike S. van Mourik and Evelien A.N. Oostdijk and Rob J.L. Willems and Marc J.M. Bonten and Mark W.J. van Passel and Hauke Smidt and Willem van Schaik},
+	year         = 2017,
+	month        = {Aug},
+	journal      = {Microbiome},
+	volume       = 5,
+	number       = 1,
+	pages        = 88,
+	doi          = {10.1186/s40168-017-0309-z},
+	url          = {https://github.com/openresearchlabs/openresearchlabs.github.io/blob/master/content/publication_resources/papers/2017-Buelow-Microbiome.pdf},
+	keywords     = {bioscience}
+}
+@article{Faust2017,
+	title        = {Multi-stability and the origin of microbial community types},
+	author       = {Didier Gonze and Leo Lahti and Jeroen Raes and Karoline Faust},
+	year         = 2017,
+	month        = {may},
+	journal      = {ISME Journal},
+	volume       = 11,
+	pages        = {2159--2166},
+	doi          = {10.1038/ismej.2017.60},
+	url          = {https://github.com/openresearchlabs/openresearchlabs.github.io/blob/master/content/publication_resources/papers/2017-Faust-ISME.pdf},
+	keywords     = {bioscience}
+}
+@article{Harris17,
+	title        = {Linking statistical and ecological theory: Hubbell's unified neutral theory of biodiversity as a hierarchical Dirichlet process},
+	author       = {Keith Harris and Todd L Parsons and Umer Z Ijaz and Leo Lahti and Ian Holmes and Christopher Quince},
+	year         = 2017,
+	month        = {March},
+	journal      = {Proceedings of the IEEE},
+	volume       = 105,
+	number       = 3,
+	pages        = {516--529},
+	doi          = {10.1109/JPROC.2015.2428213},
+	url          = {https://github.com/openresearchlabs/openresearchlabs.github.io/blob/master/content/publication_resources/papers/2017-Harris-IEEE.pdf},
+	keywords     = {bioscience}
+}
+@article{Lahti17eurostat,
+	title        = {Retrieval and Analysis of Eurostat Open Data with the eurostat Package},
+	author       = {Leo Lahti and Janne Huovari and Markus Kainu and Przemysław Biecek},
+	year         = 2017,
+	journal      = {The R Journal},
+	volume       = 9,
+	number       = 1,
+	pages        = {385--392},
+	url          = {https://journal.r-project.org/archive/2017/RJ-2017-019/index.html},
+	url          = {https://github.com/openresearchlabs/openresearchlabs.github.io/blob/master/content/publication_resources/papers/2017-Lahti-RJournal.pdf},
+	keywords     = {dh},
+	software     = {yes},
+	authorship   = {first, corresponding},
+	annote       = {R package homepage URL: http://ropengov.github.io/eurostat/}
+}
+@article{Lahti17phos,
+	title        = {Alchemy & algorithms: perspectives on the philosophy and history of open science},
+	author       = {Leo Lahti and Filipe da Silva and Markus Petteri Laine and Viivi Lähteenoja and Mikko Tolonen},
+	year         = 2017,
+	month        = {May},
+	journal      = {RIO Journal},
+	volume       = 3,
+	pages        = {e13593},
+	doi          = {10.3897/rio.3.e13593},
+	url          = {https://github.com/openresearchlabs/openresearchlabs.github.io/blob/master/content/publication_resources/papers/2017-Lahti-PHOS.pdf},
+	category     = {perspective},
+	note         = {Review of the international conference, including electronic material (video interviews, lectures and podcasts.},
+	authorship   = {first, corresponding},
+	keywords     = {openscience},
+	pubstate     = {openscience},
+	keywords     = {dh}
+}
+@article{Shetty2017,
+	title        = {Intestinal microbiome landscaping: Insight in community assemblage and implications for microbial modulation strategies},
+	author       = {Shetty, SA and Hugenholtz, F and Lahti, L and Smidt, H and de Vos, WM and Danchin, A},
+	year         = 2017,
+	month        = {March},
+	journal      = {FEMS Microbiology Reviews},
+	volume       = 41,
+	pages        = {182--199},
+	doi          = {10.1093/femsre/fuw045},
+	url          = {https://github.com/openresearchlabs/openresearchlabs.github.io/blob/master/content/publication_resources/papers/2017-Shetty-FEMS.pdf},
+	note         = {fuw045},
+	note         = {review},
+	issue        = 2,
+	keywords     = {bioscience}
+}
+@inproceedings{Tolonen16dh,
+	title        = {Printing in a Periphery: a Quantitative Study of Finnish Knowledge Production, 1640-1828},
+	author       = {Mikko Tolonen and Niko Ilom{\"a}ki and Hege Roivainen and Leo Lahti},
+	year         = 2016,
+	month        = 7,
+	booktitle    = {Digital Humanities 2016: Conference Abstracts},
+	publisher    = {Jagiellonian University & Pedagogical University, Kraków},
+	address      = {Krakow, Poland},
+	pages        = {383--385},
+	url          = {http://dh2016.adho.org/abstracts/9},
+	category     = {abstract},
+	keywords     = {dh}
+}
+@article{Aleksic14,
+	title        = {The Open Science Peer Review Oath},
+	author       = {Jelena Aleksic and Adrian Alexa and Teresa K Attwood and Neil Chue Hong and Martin Dahl{\"o} and Robert Davey and Holger Dinkel and Konrad U F{\"o}rstner and Ivo Grigorov and Jean-Karim Hériché and Leo Lahti and Dan MacLean and Michael L Markie and Jenny Molloy and Maria Victoria Schneider and Camille Scott and Richard Smith-Unna and Bruno Miguel Vieira},
+	year         = 2015,
+	month        = 1,
+	journal      = {F1000Research},
+	volume       = 3,
+	pages        = 271,
+	doi          = {10.12688/f1000research.5686.2},
+	url          = {https://github.com/openresearchlabs/openresearchlabs.github.io/blob/master/content/publication_resources/papers/2014-Aleksic.pdf},
+	category     = {perspective},
+	note         = {AllBio: Open Science & Reproducibility Best Practice Workshop},
+	keywords     = {openscience}
+}
+@article{Faust15,
+	title        = {Metagenomics meets time series analysis: unraveling microbial community dynamics},
+	author       = {Karoline Faust and Leo Lahti and Didier Gonze and Willem M de Vos and Jeroen Raes},
+	year         = 2015,
+	month        = 6,
+	journal      = {Current Opinion in Microbiology},
+	volume       = 25,
+	pages        = {56--66},
+	doi          = {10.1016/j.mib.2015.04.004},
+	url          = {https://github.com/openresearchlabs/openresearchlabs.github.io/blob/master/content/publication_resources/papers/2015-Faust-CurrOpMicrob.pdf},
+	category     = {review},
+	keywords     = {bioscience},
+	authorship   = {shared first}
+}
+@article{Lahti15LIBER,
+	title        = {A quantitative study of history in the English short-title catalogue (ESTC) 1470-1800},
+	author       = {Leo Lahti and Niko Ilom{\"a}ki and Mikko Tolonen},
+	year         = 2015,
+	month        = 12,
+	journal      = {LIBER Quarterly},
+	volume       = 25,
+	number       = 2,
+	pages        = {87--116},
+	doi          = {10.18352/lq.10112},
+	issn         = {2213-056X},
+	url          = {https://github.com/openresearchlabs/openresearchlabs.github.io/blob/master/content/publication_resources/papers/2015-Lahti-LIBERQuarterly.pdf},
+	pubstate     = {dh},
+	authorship   = {first},
+	keywords     = {dh}
+}
+@inproceedings{Laine15,
+	title        = {Beyond Open Access - The Changing Culture of Producing and Disseminating Scientific Knowledge},
+	author       = {Heidi Laine and Leo Lahti and Anne Lehto and Samuli Ollila and Markus Miettinen},
+	year         = 2015,
+	booktitle    = {Proceedings of the 19th International Academic Mindtrek Conference in Tampere, Finland, September 22-24},
+	location     = {Tampere, Finland},
+	publisher    = {ACM},
+	address      = {ACM New York, NY, USA},
+	address      = {New York, NY, USA},
+	isbn         = {978-1-4503-3948-3},
+	url          = {http://dl.acm.org/citation.cfm?id=2818187},
+	url          = {https://github.com/openresearchlabs/openresearchlabs.github.io/blob/master/content/publication_resources/papers/2015-Laine-Mindtrek.pdf},
+	organization = {AcademicMindTrek'15: Proceedings of the 19th International Academic Mindtrek Conference},
+	authorship   = {second},
+	keywords     = {openscience}
+}
+@article{OKeefe15,
+	title        = {Fat, Fiber and Cancer Risk in African, Americans and Rural Africans},
+	author       = {SJD O'Keefe and JV Li and L Lahti and J Ou and F Carbonero and K Mohammed and JM Posma and J Kinross and E Wahl and E Ruder and K Vipperla and V Naidoo and L Mtshali and S Tims and PGB Puylaert, J DeLany and A Krasinskas and AC Benefiel and HO Kaseb and K Newton and JK Nicholson and WM de Vos and HR Gaskins and EG Zoetendal},
+	year         = 2015,
+	month        = {Apr},
+	journal      = {Nature Communications},
+	volume       = 6,
+	pages        = 6342,
+	doi          = {10.1038/ncomms7342},
+	url          = {https://github.com/openresearchlabs/openresearchlabs.github.io/blob/master/content/publication_resources/papers/2015-OKeefe-NComms.pdf},
+	note         = {Top science article in Guardian on the release day.},
+	keywords     = {gut},
+	keywords     = {bioscience},
+	annote       = {Guardian: http://www.theguardian.com/science/2015/apr/28/bowel-cancer-risk-may-be-reduced-by-rural-african-diet-study-finds}
+}
+@article{Ritari15,
+	title        = {Improved taxonomic assignment of human intestinal 16S rRNA sequences by a dedicated reference database},
+	author       = {Jarmo Ritari and Jarkko Salojärvi and Leo Lahti and Willem M. de Vos},
+	year         = 2015,
+	month        = 12,
+	journal      = {BMC Genomics},
+	volume       = 16,
+	pages        = 1056,
+	doi          = {10.1186/s12864-015-2265-y},
+	url          = {https://github.com/openresearchlabs/openresearchlabs.github.io/blob/master/content/publication_resources/papers/2015-Ritari-BMCGenomics.pdf},
+	keywords     = {bioscience}
+}
+@article{Siavash15,
+	title        = {Impact of a wastewater treatment plant on microbial community composition and function in a hyporheic zone of a eutrophic river},
+	author       = {Siavash Atashgahi and Rozelin Aydin and Mauricio R. Dimitrov and Detmer Sipkema and Kelly Hamonts and Leo Lahti and Farai Maphosa and Thomas Kruse and Edoardo Saccenti and Dirk Springael, Winnie Dejonghe and Hauke Smidt},
+	year         = 2015,
+	month        = 11,
+	journal      = {Scientific Reports},
+	volume       = 5,
+	number       = 17284,
+	doi          = {10.1038/srep17284},
+	url          = {https://github.com/openresearchlabs/openresearchlabs.github.io/blob/master/content/publication_resources/papers/2015-Atagashi.pdf},
+	keywords     = {bioscience}
+}
+@article{Su2015,
+	title        = {A novel atlas of gene expression in human skeletal muscle reveals molecular changes associated with aging},
+	author       = {Jing Su and Carl Ekman and Nikolay Oskolkov and Leo Lahti and Kristoffer Ström and Alvis Brazma and Leif Groop and Johan Rung and and Ola Hansson},
+	year         = 2015,
+	month        = 10,
+	journal      = {Skeletal Muscle},
+	volume       = 5,
+	number       = 35,
+	doi          = {10.1186/s13395-015-0059-1},
+	url          = {https://github.com/openresearchlabs/openresearchlabs.github.io/blob/master/content/publication_resources/papers/2015-Su-SkeletalMuscle.pdf},
+	keywords     = {bioscience}
+}
+@article{Tolonen15EnnenNyt,
+	title        = {Aatehistoria ja digitaalisten aineistojen mahdollisuudet},
+	author       = {Mikko Tolonen and Leo Lahti},
+	year         = 2015,
+	month        = 8,
+	journal      = {Ennen \& Nyt 2},
+	volume       = 2,
+	url          = {https://github.com/openresearchlabs/openresearchlabs.github.io/blob/master/content/publication_resources/papers/2015-EnnenNyt-Tolonen.pdf},
+	keywords     = {dh},
+	authorship   = {shared first},
+	language     = {Finnish},
+	keywords     = {dh}
+}
+@article{Alneberg14,
+	title        = {Binning metagenomic contigs by coverage and composition},
+	author       = {Johannes Alneberg and Brynjar Smári Bjarnason and Ino de Bruijn and Melanie Schirmer and Joshua Quick and Umer Z Ijaz and Leo Lahti and Nicholas J Loman and Anders F Andersson and Christopher Quince},
+	year         = 2014,
+	journal      = {Nature Methods},
+	volume       = 11,
+	number       = {1144--1146},
+	doi          = {10.1038/nmeth.3103},
+	url          = {https://github.com/openresearchlabs/openresearchlabs.github.io/blob/master/content/publication_resources/papers/2014-Alneberg-NatMeth.pdf},
+	note         = {CONCOCT algorithm},
+	keywords     = {bioscience}
+}
+@article{Louhimo14,
+	title        = {Systematic Use of Computational Methods Allows Stratifying Treatment Responders in Glioblastoma Multiforme},
+	author       = {Riku Louhimo and Viljami Aittom{\"a}ki and Ali Faisal and Marko Laakso and Ping Chen and Kristian Ovaska and Erkka Valo and Leo Lahti and Vladimir Rogojin and Samuel Kaski and Sampsa Hautaniemi.},
+	year         = 2014,
+	month        = 4,
+	journal      = {Systems Biomedicine (special issue)},
+	volume       = 1,
+	pages        = {130--136},
+	doi          = {10.4161/sysb.28904},
+	url          = {https://github.com/openresearchlabs/openresearchlabs.github.io/blob/master/content/publication_resources/papers/2014-Louhimo.pdf},
+	note         = {Critical Assessment of Massive Data Analysis (CAMDA) workshop},
+	issue        = 2,
+	keywords     = {bioscience}
+}
+@article{lahti14natcomm,
+	title        = {Tipping elements in the human intestinal ecosystem},
+	author       = {Leo Lahti and Jarkko Saloj{\"a}rvi and Anne Salonen and Marten Scheffer and Willem M. de Vos},
+	year         = 2014,
+	month        = 7,
+	journal      = {Nature Communications},
+	volume       = 5,
+	pages        = 4344,
+	doi          = {10.1038/ncomms5344},
+	url          = {https://github.com/openresearchlabs/openresearchlabs.github.io/blob/master/content/publication_resources/papers/2014-Lahti-NatComm.pdf},
+	authorship   = {first},
+	keywords     = {bioscience}
+}
+@article{salonen14,
+	title        = {Impact of diet and individual variation on intestinal microbiota composition and fermentation products in obese men},
+	author       = {Anne Salonen and Leo Lahti and Jarkko Saloj{\"a}rvi and Grietje Holtrop and Katri Korpela and Sylvia Duncan and Priya Date and Alexandra Johnstone and Gerald Lobley and Petra Louis and Harry Flint and Willem M. de Vos},
+	year         = 2014,
+	journal      = {ISME Journal},
+	volume       = 8,
+	pages        = {2218--2230},
+	doi          = {10.1038/ismej.2014.63},
+	url          = {https://github.com/openresearchlabs/openresearchlabs.github.io/blob/master/content/publication_resources/papers/2014-Salonen-ISME.pdf},
+	keywords     = {bioscience},
+	authorship   = {second}
+}
+@article{sarhadi14,
+	title        = {Copy Number Alterations and Neoplasia Specific Mutations in MELK, PDCD1LG2, TLN1, and PAX5 at 9p in Different Neoplasias},
+	author       = {Virinder Sarhadi and Leo Lahti and Ilari Scheinin and Pekka Ellonen and Eeva Kettunen and Massimo Serra and Katia Scotlandi and Pierro Picci and Sakari Knuutila},
+	year         = 2014,
+	month        = 7,
+	journal      = {Genes, Chromosomes and Cancer},
+	volume       = 53,
+	number       = 7,
+	pages        = {579--588},
+	doi          = {10.1002/gcc.22168},
+	keywords     = {bioscience},
+	authorship   = {second}
+}
+@misc{Lahti13icml,
+	title        = {rOpenGov: open source ecosystem for computational social sciences and digital humanities},
+	author       = {Leo Lahti, Juuso Parkkinen, Joona Lehtomäki and Markus Kainu},
+	year         = 2013,
+	month        = 12,
+	url          = {http://ropengov.github.io},
+	category     = {abstract},
+	note         = {ICML/MLOSS workshop (Int'l Conf. on Machine Learning - Open Source Software workshop).},
+	keywords     = {dh},
+	howpublished = {software},
+	keywords     = {datascience}
+}
+@article{Lahti13nar,
+	title        = {A fully scalable online pre-processing algorithm for short oligonucleotide microarray atlases},
+	author       = {Leo Lahti and Aurora Torrente and Laura L Elo and Alvis Brazma and Johan Rung},
+	year         = 2013,
+	journal      = {Nucleic Acids Research},
+	volume       = 41,
+	number       = 10,
+	pages        = {e110},
+	doi          = {10.1093/nar/gkt229},
+	url          = {https://github.com/openresearchlabs/openresearchlabs.github.io/blob/master/content/publication_resources/papers/2013-Lahti-NAR.pdf},
+	note         = {Implementation available through Bioconductor RPA package.},
+	authorship   = {first, corresponding},
+	keywords     = {bioscience}
+}
+@article{Lahti13provasI,
+	title        = {Associations between the human intestinal microbiota, Lactobacillus rhamnosus GG and serum lipids indicated by integrated analysis of high-throughput profiling data},
+	author       = {Leo Lahti and Anne Salonen and Riina A. Kekkonen and Jarkko Salojärvi and Jonna Jalanka-Tuovinen and Airi Palva and Matej Orešič and Willem M. de Vos},
+	year         = 2013,
+	journal      = {PeerJ},
+	volume       = 1,
+	pages        = {e32},
+	doi          = {10.7717/peerj.32},
+	url          = {https://github.com/openresearchlabs/openresearchlabs.github.io/blob/master/content/publication_resources/papers/2013-Lahti-PeerJ.pdf},
+	note         = {Highly accessed, featured in PeerJ journal blog and Top-10 Microbiology collection.},
+	keywords     = {bioscience},
+	authorship   = {corresponding, shared first},
+	pmid         = 23638368
+}
+@article{Lahti2012intcomp,
+	title        = {Cancer gene prioritization by integrative analysis of mRNA expression and DNA copy number data: a comparative review},
+	author       = {Leo Lahti and Martin Sch{\"a}fer and Hans-Ulrich Klein and Silvio Bicciato and Martin Dugas},
+	year         = 2013,
+	month        = 6,
+	journal      = {Briefings in Bioinformatics},
+	volume       = 14,
+	number       = 1,
+	pages        = {27--35},
+	doi          = {10.1093/bib/bbs005},
+	url          = {https://github.com/openresearchlabs/openresearchlabs.github.io/blob/master/content/publication_resources/papers/2013-Lahti-BriefBioinf.pdf},
+	category     = {review},
+	keywords     = {bioscience},
+	authorship   = {first, corresponding}
+}
+@article{Sarhadi13,
+	title        = {Targeted Resequencing of 9p in Acute Lymphoblastic Leukemia Yields Concordant Results with Array CGH and Reveals Novel Genomic Alterations},
+	author       = {Virinder Kaur Sarhadi and Leo Lahti and Ilari Scheinin and Anne Tyyb{\"a}kinoja and Suvi Savola and Anu Usvasalo and Riikka R{\"a}ty and Erkki Elonen and Pekka Ellonen and Ulla M Saarinen-Pihkala and Sakari Knuutila},
+	year         = 2013,
+	month        = 9,
+	journal      = {Genomics},
+	volume       = 102,
+	number       = 3,
+	pages        = {182--188},
+	doi          = {10.1016/j.ygeno.2013.01.001},
+	url          = {https://github.com/openresearchlabs/openresearchlabs.github.io/blob/master/content/publication_resources/papers/2013-Sarhadi-Genomics.pdf},
+	keywords     = {bioscience},
+	authorship   = {shared first}
+}
 @article{bender13,
 	title        = {Intestinal microbiota, individuality and health. In: Computational Methods Aiding Early-Stage Drug Design (Dagstuhl Seminar 13212)},
 	author       = {Leo Lahti},
@@ -1698,116 +1129,432 @@
 	urn          = {urn:nbn:de:0030-drops-41791},
 	annote       = {Keywords: Bioinformatics, Chemoinformatics, Machine learning, Statistics, Interdisciplinary applications. Short abstract for the Dagstuhl seminar.}
 }
-
-@article{crossys2021,
-	title        = {Systemic cross-talk between brain, gut, and peripheral tissues in glucose homeostasis: effects of exercise training (CROSSYS): Exercise training intervention in monozygotic twins discordant for body weight},
-	author       = {Marja A. Heiskanen and Sanna M. Honkala and Ronja A. Ojala and Riikka Lautamäki and Kalle Koskensalo and Martin Lietzén and Jaakko Hentilä and Virva Saunavaara and Jani Saunavaara and Mika Helmiö and Eliisa Löyttyniemi and Lauri Nummenmaa and Maria C. Collado and Tarja Malm and Leo Lahti and Kirsi H. Pietiläinen and Jaakko Kaprio and Juha O. Rinne and Jarna C. Hannukainen},
-	year         = 2021,
-	journal      = {BMC Sports Science, Medicine and Rehabilitation},
-	volume       = 13,
-	pages        = 16,
-	doi          = {10.1186/s13102-021-00241-z},
+@article{Lahti12cmi,
+	title        = {The adult intestinal core microbiota is determined by analysis depth and health status},
+	author       = {Anne Salonen and Jarkko Saloj{\"a}rvi and Leo Lahti and and Willem M. de Vos},
+	year         = 2012,
+	journal      = {Clinical Microbiology and Infection},
+	volume       = 18,
+	number       = {Suppl. 4},
+	pages        = {16–20},
+	doi          = {10.1111/j.1469-0691.2012.03855.x},
+	url          = {https://github.com/openresearchlabs/openresearchlabs.github.io/blob/master/content/publication_resources/papers/2012-Salonen-CMI.pdf},
 	keywords     = {bioscience}
 }
-
-
-@article{lahti14natcomm,
-	title        = {Tipping elements in the human intestinal ecosystem},
-	author       = {Leo Lahti and Jarkko Saloj{\"a}rvi and Anne Salonen and Marten Scheffer and Willem M. de Vos},
-	year         = 2014,
-	month        = 7,
-	journal      = {Nature Communications},
-	volume       = 5,
-	pages        = 4344,
-	doi          = {10.1038/ncomms5344},
-	url          = {https://github.com/openresearchlabs/openresearchlabs.github.io/blob/master/content/publication_resources/papers/2014-Lahti-NatComm.pdf},
-	authorship   = {first},
-	keywords     = {bioscience}
-}
-
-@techreport{openedu2020,
-	title        = {National policy and executive plan by the higher education and research community for 2021-2025 - Policy component 1: Open access to educational resources.},
-	author  = {Expert Panel in Open Education (Open Science Coordination in Finland)},
-	year         = 2020,
-	publisher    = {Committee for Public Information (TJNK) and Federation of Finnish Learned Societies (TSV).},
-	address      = {Helsinki, Finland},
-	journal      = {Responsible Research Series},
-	volume       = 16,
-	keywords       = {openscience}
-}
-
-
-
-@techreport{openutu2018,
-	title        = {Turun yliopiston avoimen tutkimuksen politiikka / Open Research Policy},
-	year         = 2018,
-	month        = {May},
-	author = {{OpenUTU work group}},
-	journal      = {unknwown},
-	category     = {report},
-	note         = {(in Finnish)},
-	key          = {report},
-	institution  = {University of Turku},
-	howpublished = {Report},
-	journaltitle = {unknown},
-	keywords       = {openscience},
-	url          = {https://github.com/openresearchlabs/openresearchlabs.github.io/blob/master/content/publication_resources/papers/2018-avoimen-tutkimuksen-politiikka-fi.pdf},
-	annote       = {Member in the work group that developed the report.}
-}
-
-
-@article{salonen14,
-	title        = {Impact of diet and individual variation on intestinal microbiota composition and fermentation products in obese men},
-	author       = {Anne Salonen and Leo Lahti and Jarkko Saloj{\"a}rvi and Grietje Holtrop and Katri Korpela and Sylvia Duncan and Priya Date and Alexandra Johnstone and Gerald Lobley and Petra Louis and Harry Flint and Willem M. de Vos},
-	year         = 2014,
-	journal      = {ISME Journal},
-	volume       = 8,
-	pages        = {2218--2230},
-	doi          = {10.1038/ismej.2014.63},
+@article{Mosakhani12,
+	title        = {MicroRNA profiling predicts survival in anti-EGFR treated chemorefractory metastatic colorectal cancer patients with wild-type KRAS and BRAF},
+	author       = {Neda Mosakhani and Leo Lahti and Ioana Borze and Marja-Liisa Karjalainen-Lindsberg and Jari Sundstrom and Raija Ristamaki and Pia Osterlund and Sakari Knuutila and and Virinder Kaur Sarhadi},
+	year         = 2012,
+	month        = 11,
+	journal      = {Cancer Genetics},
+	volume       = 205,
+	number       = 11,
+	pages        = {545--51},
+	doi          = {10.1016/j.cancergen.2012.08.003},
+	url          = {https://github.com/openresearchlabs/openresearchlabs.github.io/blob/master/content/publication_resources/papers/2012-Mosakhani-CG.pdf},
 	keywords     = {bioscience},
-	url          = {https://github.com/openresearchlabs/openresearchlabs.github.io/blob/master/content/publication_resources/papers/2014-Salonen-ISME.pdf},
 	authorship   = {second}
 }
-
-@article{sarhadi14,
-	title        = {Copy Number Alterations and Neoplasia Specific Mutations in MELK, PDCD1LG2, TLN1, and PAX5 at 9p in Different Neoplasias},
-	author       = {Virinder Sarhadi and Leo Lahti and Ilari Scheinin and Pekka Ellonen and Eeva Kettunen and Massimo Serra and Katia Scotlandi and Pierro Picci and Sakari Knuutila},
-	year         = 2014,
+@article{Mosakhani12LL,
+	title        = {MicroRNA profiling in pediatric acute lymphoblastic leukemia: novel prognostic tools},
+	author       = {N Mosakhani and VK Sarhadi and A Usvasalo and ML Karjalainen-Lindsberg and L Lahti and K Tuononen and UM Saarinen-Pihkala and S Knuutila},
+	year         = 2012,
+	month        = {Dec},
+	journal      = {Leukemia \& Lymphoma},
+	volume       = 53,
+	number       = 12,
+	pages        = {2517--2520},
+	doi          = {10.3109/10428194.2012.685731},
+	url          = {https://github.com/openresearchlabs/openresearchlabs.github.io/blob/master/content/publication_resources/papers/2012-Mosakhani-LL.pdf},
+	keywords     = {bioscience}
+}
+@article{Niini12,
+	title        = {Homozygous Deletions of Cadherin Genes in Chondrosarcoma – an Array CGH Study},
+	author       = {Tarja Niini and Ilari Scheinin and Leo Lahti and Suvi Savola and Fredrik Mertens and Jaakko Hollmén and Tom Böhling and Aarne Kivioja and Karolin H Nord and Sakari Knuutila},
+	year         = 2012,
+	month        = 11,
+	journal      = {Cancer Genetics},
+	volume       = 205,
+	number       = 11,
+	pages        = {588--93},
+	doi          = {10.1016/j.cancergen.2012.09.007},
+	keywords     = {bioscience},
+	pmid         = 23146407
+}
+@article{Borze11,
+	title        = {MicroRNA microarrays on archive bone marrow core biopsies of leukemias - method validation},
+	author       = {Ioana Borze and Mohamed Guled and Suad Musse and Anna Raunio and Erkki Elonen and Ulla Saarinen-Pihkala and Marja-Liisa Karjalainen-Lindsberg and Leo Lahti and Sakari Knuutila.},
+	year         = 2011,
+	month        = 2,
+	journal      = {Leukemia Research},
+	volume       = 35,
+	pages        = {188--195},
+	doi          = {10.1016/j.leukres.2010.08.005},
+	issue        = 2,
+	keywords     = {bioscience}
+}
+@inproceedings{Faisal2011,
+	title        = {Biomarker discovery via dependency analysis of multi-view functional genomics data},
+	author       = {Ali Faisal and Riku Louhimo and Leo Lahti and Sampsa Hautaniemi and Samuel Kaski},
+	year         = 2011,
+	booktitle    = {NIPS 2011 workshop From Statistical Genetics to Predictive Models in Personalized Medicine},
+	url          = {https://github.com/openresearchlabs/openresearchlabs.github.io/blob/master/content/publication_resources/papers/2011-Faisal-NIPS.pdf},
+	category     = {abstract},
+	keywords     = {bioscience}
+}
+@article{Jalanka-Tuovinen11,
+	title        = {Intestinal microbiota in healthy adults: Temporal analysis reveals individual and common core and relation to intestinal symptoms},
+	author       = {Jonna Jalanka-Tuovinen and Anne Salonen and Janne Nikkil{\"a} and Outi Immonen and Riina Kekkonen and Leo Lahti and Airi Palva and Willem M. de Vos},
+	year         = 2011,
+	month        = 7,
+	journal      = {PLoS One},
+	volume       = 6,
+	number       = 7,
+	pages        = {e23035},
+	url          = {10.1371/journal.pone.0023035},
+	url          = {https://github.com/openresearchlabs/openresearchlabs.github.io/blob/master/content/publication_resources/papers/2011-JalankaTuovinen-PLoS.pdf},
+	keywords     = {bioscience}
+}
+@misc{Lahti11intcomp,
+	title        = {intcomp: a benchmarking pipeline for integrative cancer gene detection algorithms},
+	author       = {Leo Lahti and Martin Schäfer and Hans-Ulrich Klein and Silvio Bicciato and Martin Dugas},
+	year         = 2011,
+	month        = 2,
+	url          = {http://intcomp.r-forge.r-project.org/},
+	note         = {R-forge},
+	howpublished = {software},
+	keywords     = {bioscience}
+}
+@misc{Lahti11ismb,
+	title        = {Probabilistic dependency models for data integration in functional genomics},
+	author       = {Leo Lahti and Samuel Kaski},
+	year         = 2011,
+	month        = {July},
+	url          = {https://github.com/openresearchlabs/openresearchlabs.github.io/blob/master/content/publication_resources/papers/2011-MLSB-Lahti.pdf},
+	category     = {abstract},
+	note         = {Machine Learning for Systems Biology workshop, ISMB, Vienna, Austria},
+	authorship   = {first, corresponding},
+	keywords     = {bioscience}
+}
+@article{Lahti11rpa,
+	title        = {Probabilistic Analysis of Probe Reliability in Differential Gene Expression Studies with Short Oligonucleotide Arrays},
+	author       = {Leo Lahti and Laura L. Elo and Tero Aittokallio and Samuel Kaski},
+	year         = 2011,
+	month        = {Jan.-Mar.},
+	journal      = {IEEE/ACM Transactions on Computational Biology and Bioinformatics},
+	publisher    = {IEEE Computer Society},
+	address      = {Los Alamitos, CA, USA},
+	volume       = 8,
+	number       = 1,
+	pages        = {217--225},
+	doi          = {10.1109/TCBB.2009.38},
+	url          = {https://github.com/openresearchlabs/openresearchlabs.github.io/blob/master/content/publication_resources/papers/2011-Lahti-TCBB.pdf},
+	keywords     = {bioscience},
+	authorship   = {first, corresponding},
+	annote       = {R/Bioconductor: RPA}
+}
+@article{Niini11mfh,
+	title        = {Array Comparative Genomic Hybridization Reveals Frequent Alterations of G1/S Checkpoint Genes in Undifferentiated Pleomorphic Sarcoma of Bone},
+	author       = {Tarja Niini and Leo Lahti and Francesca Michelacci and Shinsuke Ninomiya and Claudia Maria Hattinger and Mohamed Guled and Tom B{\"o}hling and Piero Picci and Massimo Serra and Sakari Knuutila},
+	year         = 2011,
+	month        = 5,
+	journal      = {Genes, Chromosomes and Cancer},
+	volume       = 50,
+	number       = 5,
+	pages        = {291--306},
+	doi          = {10.1002/gcc.20851},
+	url          = {https://github.com/openresearchlabs/openresearchlabs.github.io/blob/master/content/publication_resources/papers/2011-Niini-GCC.pdf},
+	authorship   = {second},
+	keywords     = {bioscience}
+}
+@article{Nymark11,
+	title        = {Integrative Analysis of microRNA, mRNA and aCGH Data Reveals Asbestos- and Histology-Related Changes in Lung Cancer},
+	author       = {Penny Nymark and Mohamed Guled and Ioana Borze and Ali Faisal and Leo Lahti and Kaisa Salmenkivi and Eeva Kettunen and Sisko Anttila and Sakari Knuutila},
+	year         = 2011,
+	month        = 8,
+	journal      = {Genes, Chromosomes and Cancer},
+	volume       = 50,
+	number       = 8,
+	pages        = {585--597},
+	doi          = {10.1002/gcc.20880},
+	url          = {https://github.com/openresearchlabs/openresearchlabs.github.io/blob/master/content/publication_resources/papers/2011-Nymark-GCC.pdf},
+	keywords     = {bioscience}
+}
+@article{Lahti10bioinf,
+	title        = {Global modeling of transcriptional responses in interaction networks},
+	author       = {Leo Lahti and Juha E.A. Knuuttila and Samuel Kaski},
+	year         = 2010,
+	month        = 11,
+	journal      = {Bioinformatics},
+	volume       = 26,
+	pages        = {2713--2720},
+	doi          = {10.1093/bioinformatics/btq500},
+	url          = {http://bioinformatics.oxfordjournals.org/content/early/2010/09/02/bioinformatics.btq500.abstract.html?ijkey=N1zzjtUBRng3wCM&keytype=ref},
+	url          = {https://github.com/openresearchlabs/openresearchlabs.github.io/blob/master/content/publication_resources/papers/2010-Bioinformatics-Lahti-NetResponse.pdf},
+	note         = {R/Matlab implementations available at http://netpro.r-forge.r-project.org/},
+	issue        = 21,
+	keywords     = {bioscience},
+	authorship   = {first},
+	annote       = {ArXiv: http://arxiv.org/abs/1202.0501; R/Matlab source code http://netpro.r-forge.r-project.org}
+}
+@misc{Lahti10dmt,
+	title        = {Dependency modeling toolkit},
+	author       = {Leo Lahti and Abhishek Tripathi and Olli-Pekka Huovilainen},
+	year         = 2010,
+	month        = 6,
+	publisher    = {ICML workshop},
+	url          = {http://dmt.r-forge.r-project.org/},
+	note         = {CRAN: dmt},
+	howpublished = {software},
+	keywords     = {datascience}
+}
+@misc{Lahti10netresponse,
+	title        = {NetResponse (functional network analysis)},
+	author       = {Leo Lahti and Antonio Gusmao and Olli-Pekka Huovilainen},
+	year         = 2010,
+	month        = {October},
+	doi          = {10.18129/B9.BIOC.NETRESPONSE},
+	url          = {http://www.bioconductor.org/help/bioc-views/devel/bioc/html/netresponse.html},
+	note         = {R/Bioconductor: netresponse},
+	keywords     = {datascience},
+	howpublished = {software}
+}
+@misc{Lahti10pint,
+	title        = {Pairwise integration of functional genomics data},
+	author       = {Olli-Pekka Huovilainen and Leo Lahti},
+	year         = 2010,
+	month        = {April},
+	url          = {http://bioconductor.org/packages/devel/bioc/html/pint.html},
+	note         = {R/BioConductor: pint},
+	keywords     = {datascience},
+	howpublished = {software}
+}
+@phdthesis{Lahti10thesis,
+	title        = {Probabilistic analysis of the human transcriptome with side information},
+	author       = {Leo Lahti},
+	year         = 2010,
+	month        = 12,
+	address      = {Espoo},
+	series       = {TKK Dissertations in Information and Computer Science},
+	number       = {TKK-ICS-D19},
+	issn         = {1797-5069},
+	url          = {http://lib.tkk.fi/Diss/2010/isbn9789526033686/},
+	url          = {https://github.com/openresearchlabs/openresearchlabs.github.io/blob/master/content/publication_resources/papers/2010-Lahti-thesis.pdf},
+	category     = {thesis},
+	note         = {LaTeX sources and the pdf version are openly available: https://github.com/antagomir/thesis/tree/master/phd10; Press release: https://github.com/antagomir/thesis/blob/master/phd10/Vaitostiedote-LeoLahti-20101207.pdf},
+	school       = {Aalto University School of Science and Technology, Faculty of Information and Natural Sciences, Department of Information and Computer Science},
+	language     = {Finnish},
+	keywords     = {thesis, probabilistic models, Bayesian analysis, data integration, gene expression, microarrays, computational science, data analysis, machine learning, computational biology, open source, open access, creative commons},
+	abstract     = {Recent advances in high-throughput measurement technologies and efficient sharing of biomedical data through community databases have made it possible to investigate the complete collection of genetic material, the genome, which encodes the heritable genetic program of an organism. This has opened up new views to the study of living organisms with a profound impact on biological research. Functional genomics is a subdiscipline of molecular biology that investigates the functional organization of genetic information.  This thesis develops computational strategies to investigate a key functional layer of the genome, the transcriptome. The time- and context-specific transcriptional activity of the genes regulates the function of living cells through protein synthesis. Efficient computational techniques are needed in order to extract useful information from high-dimensional genomic observations that are associated with high levels of complex variation. Statistical learning and probabilistic models provide the theoretical framework for combining statistical evidence across multiple observations and the wealth of background information in genomic data repositories.  This thesis addresses three key challenges in transcriptome analysis. First, new preprocessing techniques that utilize side information in genomic sequence databases and microarray collections are developed to improve the accuracy of high-throughput microarray measurements.  Second, a novel exploratory approach is proposed in order to construct a global view of cell-biological network activation patterns and functional relatedness between tissues across normal human body. Information in genomic interaction databases is used to derive constraints that help to focus the modeling in those parts of the data that are supported by known or potential interactions between the genes, and to scale up the analysis. The third contribution is to develop novel approaches to model dependency between co-occurring measurement sources. The methods are used to study cancer mechanisms and transcriptome evolution; integrative analysis of the human transcriptome and other layers of genomic information allows the identification of functional mechanisms and interactions that could not be detected based on the individual measurement sources. Open source implementations of the key methodological contributions have been released to facilitat e their further adoption by the research community.}
+}
+@article{Mosakhani10,
+	title        = {Unique microRNA profile in Dupuytren's contracture supports deregulation of beta-catenin pathway},
+	author       = {Neda Mosakhani and Mohamed Guled and Leo Lahti and Ioana Borze and Minna Forsman and Jorma Ryh{\"a}nen and Sakari Knuutila},
+	year         = 2010,
+	month        = 11,
+	journal      = {Modern Pathology},
+	volume       = 23,
+	pages        = {1544--1522},
+	doi          = {10.1038/modpathol.2010.146},
+	url          = {https://github.com/openresearchlabs/openresearchlabs.github.io/blob/master/content/publication_resources/papers/2010-ModernPathology-Mosakhani-Dupuytre.pdf},
+	note         = {International Dupuytren Award for best research paper in 2011},
+	keywords     = {bioscience}
+}
+@article{Guled09,
+	title        = {CDKN2A, NF2 and JUN Are Dysregulated Among Other Genes by miRNAs in Malignant Mesothelioma - a miRNA Microarray Analysis},
+	author       = {Mohamed Guled and Leo Lahti and Pamela M. Lindholm and Kaisa Salmenkivi and Izhar Bagwan and Andrew G. Nicholson and Sakari Knuutila},
+	year         = 2009,
 	month        = 7,
 	journal      = {Genes, Chromosomes and Cancer},
-	volume       = 53,
+	volume       = 48,
 	number       = 7,
-	pages        = {579--588},
-	doi          = {10.1002/gcc.22168},
-	keywords     = {bioscience},	
-	authorship   = {second}
+	pages        = {615--623},
+	doi          = {10.1002/gcc.20669},
+	url          = {https://github.com/openresearchlabs/openresearchlabs.github.io/blob/master/content/publication_resources/papers/2009-GCC-Guled-miRNA.pdf},
+	keywords     = {bioscience}
 }
-
-@article{stolaki2019,
-	title        = {Microbial communities in a dynamic {it in vitro} model for the human ileum resemble the human ileal microbiota},
-	author       = {Stolaki, Maria and Minekus, Mans and Venema, Koen and Lahti, Leo and Smid, Eddy J. and Kleerebezem, Michiel and Zoetendal, Erwin G},
-	year         = 2019,
-	month        = {August},
-	journal      = {FEMS Microbiology Ecology},
-	number       = 8,
-	pages        = {fiz096},
-	doi          = {10.1093/femsec/fiz096},
+@misc{Lahti09bsc,
+	title        = {Concerning Blackburn's quasi-realism in securing moral discussion},
+	author       = {Leo Lahti},
+	year         = 2009,
+	month        = 7,
+	url          = {https://github.com/openresearchlabs/openresearchlabs.github.io/blob/master/content/publication_resources/theses/LeoLahti-BSc-2008.pdf},
+	category     = {thesis},
+	note         = {(In Finnish)},
+	keywords     = {thesis},
+	howpublished = {B.Sc. thesis. University of Helsinki, Faculty of Political Sciences},
+	language     = {Finnish}
+}
+@inproceedings{Lahti09mlsp,
+	title        = {Dependency detection with similarity constraints},
+	author       = {Leo Lahti and Samuel Myllykangas and Sakari Knuutila and Samuel Kaski},
+	year         = 2009,
+	booktitle    = {Proc. MLSP'09 IEEE International Workshop on Machine Learning for Signal Processing XIX},
+	address      = {Piscataway, NJ},
+	pages        = {198--203},
+	url          = {http://arxiv.org/abs/1101.5919},
+	url          = {https://github.com/openresearchlabs/openresearchlabs.github.io/blob/master/content/publication_resources/papers/2009-MLSP-Lahti-SimCCA.pdf},
+	note         = {R/Bioconductor: pint},
+	editor       = {Adali T, Chanussot J, Jutten C, and Larsen J},
+	howpublished = {software},
+	authorship   = {first, corresponding},
+	arxiv        = {1101.5919},
+	keywords     = {datascience}
+}
+@misc{Lahti09rpa,
+	title        = {RPA: probe reliability and differential gene expression analysis},
+	author       = {Leo Lahti},
+	year         = 2009,
+	month        = {October},
+	doi          = {10.18129/B9.BIOC.RPA},
+	url          = {http://bioconductor.org/packages/release/bioc/html/RPA.html},
+	note         = {R/Bioconductor: RPA},
+	howpublished = {software},
+	keywords     = {bioscience}
+}
+@misc{Lahti2006biopax,
+	title        = {A brief overview on the BioPAX and SBML standards},
+	author       = {Leo Lahti},
+	year         = 2007,
+	url          = {https://arxiv.org/abs/1109.4919},
+	category     = {thesis},
+	note         = {Overview of machine-readable representations of biological processes.},
+	note         = {(in Finnish)},
+	howpublished = {arXiv},
+	authorship   = {first},
 	keywords     = {bioscience},
-	vol          = 95,
-	url          = {https://github.com/openresearchlabs/openresearchlabs.github.io/blob/master/content/publication_resources/papers/2019-Stolaki-FEMS.pdf}
+	arxiv        = {arXiv:1109.4919 [cs.DS]},
+	language     = {Finnish}
 }
-
-@article{tolonen2019,
-	title        = {A Quantitative Approach to Book-Printing in Sweden and Finland, 1640–1828},
-	author       = {Mikko Tolonen and Leo Lahti and Hege Roivainen and Jani Marjanen},
-	year         = 2019,
-	journal      = {Historical Methods: A Journal of Quantitative and Interdisciplinary History},
-	publisher    = {Routledge},
-	volume       = 52,
-	pages        = {57--78},
-	doi          = {10.1080/01615440.2018.1526657},
-	issue        = 1,
-	keywords     = {dh},
-	url          = {https://github.com/openresearchlabs/openresearchlabs.github.io/blob/master/content/publication_resources/papers/2019-Tolonen.pdf}
+@article{Nymark07,
+	title        = {Gene Expression Profiles in Asbestos-exposed Epithelial and Mesothelial Lung Cell Lines},
+	author       = {Penny Nymark and Pamela M. Lindholm and Mikko V. Korpela and Leo Lahti and Salla Ruosaari and Samuel Kaski and Jaakko Hollmen and Sisko Anttila and Vuokko L. Kinnula and Sakari Knuutila},
+	year         = 2007,
+	month        = 3,
+	journal      = {BMC Genomics},
+	volume       = 8,
+	number       = 62,
+	doi          = {10.1186/1471-2164-8-62},
+	keywords     = {bioscience},
+	annote       = {CCA on two asbestos-exposed cell lines.}
+}
+@article{Elo05,
+	title        = {Integrating probe-level expression changes across generations of Affymetrix arrays},
+	author       = {Elo, Laura L. and Lahti, Leo and Skottman, Heli and Kyl{\"a}niemi, Minna and Lahesmaa, Riitta and Aittokallio, Tero},
+	year         = 2005,
+	month        = 12,
+	journal      = {Nucleic Acids Research},
+	volume       = 33,
+	number       = 22,
+	pages        = {e193},
+	doi          = {10.1093/nar/gni193},
+	url          = {https://github.com/openresearchlabs/openresearchlabs.github.io/blob/master/content/publication_resources/papers/2005-Elo-NAR.pdf},
+	authorship   = {second},
+	keywords     = {bioscience}
+}
+@article{Kaski05,
+	title        = {Associative clustering for exploring dependencies between functional genomics data sets},
+	author       = {Samuel Kaski and Janne Nikkil{\"a} and Janne Sinkkonen and Leo Lahti and Juha Knuuttila and Christophe Roos},
+	year         = 2005,
+	month        = {September},
+	journal      = {IEEE/ACM Transactions on Computational Biology and Bioinformatics},
+	volume       = 2,
+	number       = 3,
+	pages        = {203--216},
+	doi          = {10.1109/TCBB.2005.32},
+	url          = {https://github.com/openresearchlabs/openresearchlabs.github.io/blob/master/content/publication_resources/papers/2005-TCBB–Kaski-AC.pdf},
+	note         = {Special Issue on Machine Learning for Bioinformatics -- Part 2},
+	keywords     = {datascience}
+}
+@techreport{Sinkkonen05tr,
+	title        = {Associative Clustering (AC): Technical Details},
+	author       = {Janne Sinkkonen and Samuel Kaski and Janne Nikkil{\"a} and Leo Lahti},
+	year         = 2005,
+	month        = {April},
+	address      = {Espoo, Finland},
+	number       = {A84},
+	url          = {https://github.com/openresearchlabs/openresearchlabs.github.io/blob/master/content/publication_resources/papers/2005-TechRep-Sinkkonen-ACtechdetails.pdf},
+	note         = {Publications in Computer and Information Science},
+	institution  = {Helsinki University of Technology},
+	keywords     = {datascience}
+}
+@incollection{Sinkkonen04ecml,
+	title        = {Associative Clustering},
+	author       = {Janne Sinkkonen and Janne Nikkil\"{a} and Leo Lahti and Samuel Kaski},
+	year         = 2004,
+	booktitle    = {Proceedings of the ECML'04, 15th European Conference on Machine Learning},
+	publisher    = {Springer},
+	address      = {Berlin},
+	pages        = {396--406},
+	url          = {http://www.cis.hut.fi/projects/mi/abstracts/ecml04.html},
+	url          = {https://github.com/openresearchlabs/openresearchlabs.github.io/blob/master/content/publication_resources/papers/2004-ECML-Sinkkonen-AC.pdf},
+	category     = {abstract},
+	editor       = {Boulicaut and Esposito and Giannotti and Pedreschi},
+	keywords     = {datascience}
+}
+@mastersthesis{Lahti03,
+	title        = {Comparative functional genome analysis using associative clustering},
+	author       = {Lahti, Leo},
+	year         = 2003,
+	month        = 12,
+	url          = {https://github.com/antagomir/thesis/tree/master/msc03},
+	url          = {https://github.com/antagomir/thesis/blob/master/msc03/dtyo.pdf},
+	category     = {thesis},
+	note         = {(in Finnish)},
+	school       = {Helsinki University of Technology},
+	language     = {Finnish},
+	keywords     = {thesis}
+}
+@techreport{Sinkkonen03tr,
+	title        = {Associative Clustering by Maximizing a {B}ayes Factor},
+	author       = {Janne Sinkkonen and Janne Nikkil\"{a} and Leo Lahti and Samuel Kaski},
+	year         = 2003,
+	month        = 6,
+	address      = {Espoo, Finland},
+	number       = {A68},
+	url          = {https://github.com/openresearchlabs/openresearchlabs.github.io/blob/master/content/publication_resources/papers/2003-TechRep-Sinkkonen-ACBayesFactor.pdf},
+	institution  = {Helsinki University of Technology and Laboratory of Computer and Information Science},
+	keywords     = {bioscience}
+}
+@misc{Lahti2002,
+	title        = {Itsesimilaaristen joukkojen Hausdorffin dimension määrittäminen},
+	author       = {Leo Lahti},
+	year         = 2002,
+	url          = {https://github.com/antagomir/thesis/tree/master/hausdorff02},
+	category     = {thesis},
+	note         = {Special assignment in Mathematics (in Finnish)},
+	keywords     = {thesis},
+	language     = {Finnish}
+}
+@misc{Lahti2001,
+	title        = {Julian joukko iteraatioden valuma-altaan reunana},
+	author       = {Leo Lahti},
+	year         = 2001,
+	url          = {https://github.com/antagomir/thesis/tree/master/julia01},
+	category     = {thesis},
+	note         = {Special assignment in Mathematics (in Finnish)},
+	keywords     = {thesis},
+	language     = {Finnish}
+}
+@misc{Lahti10blog,
+	title        = {opencomp blog},
+	author       = {Leo Lahti},
+	url          = {http://antagomir.wordpress.com/},
+	category     = {blog},
+	keywords     = {blog}
+}
+@misc{Lahti11-louhos,
+	title        = {Louhos blog},
+	author       = {Leo Lahti and Joona Lehtomäki and Juuso Parkkinen and others},
+	url          = {http://louhos.github.io/},
+	note         = {Open government data analytics blog (in Finnish)},
+	keywords     = {blog}
+}
+@misc{Lahti13-ropengov,
+	title        = {rOpenGov blog},
+	author       = {Leo Lahti and Joona Lehtomäki and Markus Kainu and Juuso Parkkinen and others},
+	url          = {http://ropengov.github.io/},
+	note         = {Open government data analytics blog},
+	keywords     = {blog}
 }
 

--- a/content/publication_resources/bibtex/lahti.bib
+++ b/content/publication_resources/bibtex/lahti.bib
@@ -1,31 +1,686 @@
-
-@Article{Aatsinki2018,
-  author =	 {Anna-Katariina Aatsinki and Henna-Maria Uusitupa and
-                  Eveliina Munukka and Henri Pesonen and Anniina
-                  Rintala and Sami Pietilä and Leo Lahti and
-                  Erkki Eerola and Linnea Karlsson and Hasse Karlsson},
-  title =	 {Gut Microbiota Composition in Mid-Pregnancy Is
-                  Associated with Gestational Weight Gain but Not
-                  Prepregnancy Body Mass Index},
-  journal =	 {Journal of Womens Health},
-  year =	 2018,
-  month =	 {May},
-  keywords =	 {bioscience},
-  doi =		 {10.1089/jwh.2017.6488},
-  pdf =
-                  {https://github.com/openresearchlabs/openresearchlabs.github.io/blob/master/content/publication_resources/papers/2018-Aatsinki.pdf},
-  note =	 {Epub ahead of print.}
+@Article{Lahti2021bioc,
+  author =	 {Leo Lahti and Felix G.M. Ernst and Sudarshan
+                  A. Shetty and others},
+  title =	 {Microbiome data science in the {\it
+                  SummarizedExperiment} universe},
+  journal =	 {F1000Research},
+  year =	 2021,
+  volume =	 10,
+  number =	 748,
+  note =	 {(slides); version 1; not peer reviewed},
+  doi =		 {10.7490/f1000research.1118712.1}
 }
 
+@InProceedings{Tiihonen2021chr,
+  author =	 {Iiro Tiihonen and Mikko Tolonen and Leo Lahti},
+  title =	 {Probabilistic Analysis of Early Modern British Book
+                  Prices},
+  booktitle =	 {{Proc. CEUR Workshop Proceedings on Computational
+                  Humanities Research}},
+  year =	 2021,
+  pages =	 {39--48},
+  keywords =	 {dh},
+  month =	 {Nov},
+  url =
+                  {https://github.com/openresearchlabs/openresearchlabs.github.io/blob/master/content/publication_resources/papers/2021-Tiihonen-CHR.pdf},
+  note =	 {In M Ehrmann, F Karsdorp et al. (eds).}
+}
 
+@article{Tolonen2021rcl,
+  author =	 {Tolonen, M and M{\"a}kel{\"a}, E and Ijaz, A and
+                  Lahti, L},
+  title =	 {Corpus Linguistics and Eighteenth Century
+                  Collections Online (ECCO)},
+  journal =	 {Research in Corpus Linguistics},
+  year =	 2021,
+  volume =	 9,
+  number =	 1,
+  pages =	 {19--34},
+  doi =		 {10.32714/ricl.09.01.03},
+  keywords =	 {dh}
+}
 
+@Article{Qin2021,
+  author =	 {Youwen Qin and Aki S. Havulinna and Yang Liu and
+                  Pekka Jousilahti and Scott C. Ritchie and Alex
+                  Tokolyi and Jon G. Sanders and Liisa Valsta and
+                  Marta Brożyńska and Qiyun Zhu and Anupriya Tripathi
+                  and Yoshiki Vazquez-Baeza and Rohit Loomba and Susan
+                  Cheng and Mohit Jain and Teemu Niiranen and Leo
+                  Lahti and Rob Knight and Veikko Salomaa and Michael
+                  Inouye and Guillaume Méric},
+  title =	 {Combined effects of host genetics and diet on human
+                  gut microbiota and incident disease in a single
+                  population cohort},
+  journal =	 {medRxiv (preprint)},
+  year =	 2021,
+  pages =	 {2020.09.12.20193045},
+  keywords =	 {preprint},
+  doi =		 {10.1101/2020.09.12.20193045}
+}
+
+@Article{Arani2021,
+  author =	 {Babak M.S. Arani, Egbert van Nes, Leo Lahti, Stephen
+                  R. Carpenter, Marten Scheffer},
+  title =	 {Exit Time as a Measure of Ecological Resilience},
+  journal =	 {Science},
+  year =	 2021,
+  volume =	 372,
+  number =	 6547,
+  pages =	 {eaay4895},
+  month =	 {June},
+  doi =		 {10.1126/science.aay4895}
+}
+
+@Article{Makela2021hs,
+  author =	 {Eetu Mäkelä and Leo Lahti and Johanna Lilja and
+                  Pekka Heikkinen},
+  title =	 {Laki estää tehokkaiden tutkimusmenetelmien käytön},
+  journal =	 {HS Mielipide},
+  year =	 2021,
+  month =	 {October},
+  url =		 {https://www.hs.fi/mielipide/art-2000008325656.html},
+  keywords =	 {opinion},
+  status =	 {general}
+}
+
+@article {Zhu2021,
+  author =	 {Zhu, Qiyun and Huang, Shi and Gonzalez, Antonio and
+                  McGrath, Imran and McDonald, Daniel and Haiminen,
+                  Niina and Armstrong, George and V{\'a}zquez-Baeza,
+                  Yoshiki and Yu, Julian and Kuczynski, Justin and
+                  Sepich-Poore, Gregory D and Swafford, Austin D and
+                  Das, Promi and Shaffer, Justin P and Lejzerowicz,
+                  Franck and Belda-Ferre, Pedro and Havulinna, Aki S
+                  and M{\'e}ric, Guillaume and Niiranen, Teemu and
+                  Lahti, Leo and Salomaa, Veikko and Kim, Ho-Cheol and
+                  Jain, Mohit and Inouye, Michael and Gilbert, Jack
+                  and Knight, Rob},
+  title =	 {OGUs enable effective, phylogeny-aware analysis of
+                  even shallow metagenome community structures},
+  elocation-id = {2021.04.04.438427},
+  year =	 2021,
+  doi =		 {10.1101/2021.04.04.438427},
+  URL =
+                  {https://www.biorxiv.org/content/early/2021/04/06/2021.04.04.438427},
+  eprint =
+                  {https://www.biorxiv.org/content/early/2021/04/06/2021.04.04.438427.full.pdf},
+  journal =	 {bioRxiv},
+  status =	 {preprint}
+}
+
+@article {Liu2021liver,
+  author =	 {Liu, Yang and Meric, Guillaume and Havulinna, Aki
+                  S. and Teo, Shu Mei and Ruuskanen, Matti and
+                  Sanders, Jon and Zhu, Qiyun and Tripathi, Anupriya
+                  and Verspoor, Karin and Cheng, Susan and Jain, Mo
+                  and Jousilahti, Pekka and Vazquez-Baeza, Yoshiki and
+                  Loomba, Rohit and Lahti, Leo and Niiranen, Teemu and
+                  Salomaa, Veikko and Knight, Rob and Inouye, Michael},
+  title =	 {Early prediction of liver disease using conventional
+                  risk factors and gut microbiome-augmented gradient
+                  boosting},
+  year =	 2020,
+  doi =		 {10.1101/2020.06.24.20138933},
+  URL =
+                  {https://www.medrxiv.org/content/early/2020/06/25/2020.06.24.20138933},
+  eprint =
+                  {https://www.medrxiv.org/content/early/2020/06/25/2020.06.24.20138933.full.pdf},
+  journal =	 {medRxiv},
+  status =	 {preprint}
+}
+
+@inBook{Tolonen2021canon,
+  author =	 {Mikko Tolonen and Mark J. Hill and Ali Zeeshan Ijaz
+                  and Ville Vaara and Leo Lahti},
+  editor =	 {Baird, I.},
+  title =	 {Data Visualization in Enlightenment Literature and
+                  Culture},
+  chapter =	 {Examining the Early Modern Canon: {The English Short
+                  Title Catalogue} and Large-Scale Patterns of
+                  Cultural Production},
+  publisher =	 {Palgrave Macmillan, Cham.},
+  booktitle =	 {Data Visualization in Enlightenment Literature and
+                  Culture},
+  maintitle =	 {Data Visualization in Enlightenment Literature and
+                  Culture},
+  year =	 2021,
+  doi =		 {10.1007/978-3-030-54913-8_3},
+  month =	 {March},
+}
+
+@Article{Ruuskanen2021,
+  author =	 {Matti Ruuskanen and Guilhem Sommeria-Klein and Aki
+                  Havulinna and Teemu Niiranen and Leo Lahti},
+  title =	 {Modeling spatial patterns in host-associated
+                  microbial communities},
+  journal =	 {Environmental Microbiology},
+  year =	 2021,
+  volume =	 23,
+  number =	 5,
+  pages =	 {2374-2388},
+  month =	 {May},
+  doi =		 {10.1111/1462-2920.15462}
+}
+
+@Article{Hintikka2021,
+  author =	 {Hintikka, J and Lensu, S and Mäkinen, E and
+                  Karvinen, S and Honkanen, M and Linden, J and
+                  Garrels, T and Pekkala, S and Lahti, L},
+  title =	 {Xylo-Oligosaccharides in Prevention of Hepatic
+                  Steatosis and Adipose Tissue Inflammation:
+                  Associating Taxonomic and Metabolomic Patterns in
+                  Fecal Microbiomes with Biclustering},
+  journal =	 {International Journal of Environmental Research and
+                  Public Health},
+  year =	 2021,
+  volume =	 18,
+  number =	 8,
+  pages =	 4049,
+  month =	 {April},
+  doi =		 {10.3390/ijerph18084049},
+  status =	 {bioscience}
+}
+
+@Article{Salosensaari2021,
+  author =	 {Aaro Salosensaari* and Ville Laitinen* and Aki S
+                  Havulinna and Guillaume Meric and Susan Cheng and
+                  Markus Perola and Liisa Valsta and Georg Alfthan and
+                  Michael Inouye and Jeramie D Watrous and Tao Long
+                  and Rodolfo Salido and Karenina Sanders and
+                  Caitriona Brennan and Gregory C Humphrey and Jon G
+                  Sanders and Mohit Jain and Pekka Jousilahti and
+                  Veikko Salomaa and Rob Knight and Leo Lahti* and
+                  Teemu Niiranen*},
+  title =	 {Taxonomic signatures of cause-specific mortality
+                  risk in human gut microbiome},
+  journal =	 {Nature Communications},
+  year =	 2021,
+  volume =	 12,
+  pages =	 2671,
+  doi =		 {10.1038/s41467-021-22962-y},
+  status =	 {bioscience},
+  annote =	 {Preprint featured in HS Tiede Jan 30, 2020. Featured
+                  in Science Magazine Jan 22, 2020
+                  https://www.sciencemag.org/news/2020/01/microbes-your-gut-could-predict-whether-you-re-likely-die-next-15-years}
+}
+
+@InProceedings{Lahti2020chr,
+  author =	 {Leo Lahti and Eetu Mäkelä and Mikko Tolonen},
+  title =	 {Quantifying bias and uncertainty in historical data
+                  collections with probabilistic programming},
+  booktitle =	 {{Proc. CEUR Workshop Proceedings on Computational
+                  Humanities Research}},
+  pages =	 {80--89},
+  year =	 2020,
+  month =	 {Nov},
+  url =		 {http://ceur-ws.org/Vol-2723/short46.pdf}
+}
+
+@Article{Keskitalo2021,
+  author =	 {Keskitalo, A and Aatsinki, A-K and Kortesluoma, S
+                  and Pelto, J and Korhonen, L and Lahti, L and
+                  Lukkarinen, M and Munukka, E and Karlsson, H and
+                  Karlsson, L},
+  title =	 {Gut microbiota diversity but not composition is
+                  related to saliva cortisol stress response at the
+                  age of 2.5 months},
+  journal =	 {Stress},
+  year =	 2021,
+  volume =	 24,
+  number =	 5,
+  pages =	 {551-560},
+  month =	 {March},
+  doi =		 {10.1080/10253890.2021.1895110},
+  note =	 {In press.},
+  status =	 {bioscience}
+}
+
+@ARTICLE{MorenoIndias2021,
+  author =	 {Isabel Moreno-Indias and Leo Lahti and Miroslava
+                  Nedyalkova and Ilze Elbere and Gennady
+                  V. Roshchupkin and Muhamed Adilovic and Onder
+                  Aydemir and Burcu Bakir-Gungor and Enrique
+                  Carrillo-de Santa Pau and Domenica D'Elia and Magesh
+                  S. Desai and Laurent Falquet and Aycan Gundogdu and
+                  Karel Hron and Thomas Klammsteiner and Marta
+                  B. Lopes and Laura J. Marcos Zambrano and Cláudia
+                  Marques and Michael Mason and Patrick May and Lejla
+                  Pašić and Gianvito Pio and Sándor Pongor and Vasilis
+                  J. Promponas and Piotr Przymus and Julio
+                  Sáez-Rodríguez and Alexia Sampri and Rajesh Shigdel
+                  and Blaz Stres and Ramona Suharoschi and Jaak Truu
+                  and Ciprian-Octavian Truică and Baiba Vilne and
+                  Dimitrios P. Vlachakis and Ercüment Yılmaz and Georg
+                  Zeller and Aldert Zomer and David Gómez-Cabrero and
+                  Marcus Claesson},
+  title =	 {Statistical and machine learning techniques in human
+                  microbiome studies: contemporary challenges and
+                  solutions},
+  journal =	 {Frontiers in Microbiology},
+  volume =	 12,
+  pages =	 277,
+  month =	 {February},
+  year =	 2021,
+  doi =		 {10.3389/fmicb.2021.635781},
+  status =	 {bioscience}
+}
+
+@ARTICLE{MarcosZambrano2021,
+  author =	 {Marcos-Zambrano, Laura Judith and
+                  Karaduzovic-Hadziabdic, Kanita and Loncar Turukalo,
+                  Tatjana and Przymus, Piotr and Trajkovik, Vladimir
+                  and Aasmets, Oliver and Berland, Magali and Gruca,
+                  Aleksandra and Hasic, Jasminka and Hron, Karel and
+                  Klammsteiner, Thomas and Kolev, Mikhail and Lahti,
+                  Leo and Lopes, Marta B and Moreno, Victor and
+                  Naskinova, Irina and Org, Elin and Paciência, Inês
+                  and Papoutsoglou, Georgios and Shigdel, Rajesh and
+                  Stres, Blaz and Vilne, Baiba and Yousef, Malik and
+                  Zdravevski, Eftim and Tsamarindos, Ioannis and
+                  Carrillo de Santa Pau, Enrique and Claesson, Marcus
+                  J. and Moreno-Indias, Isabel and Truu, Jaak},
+  title =	 {Applications of Machine Learning in Human Microbiome
+                  Studies: A Review on Feature Selection, Biomarker
+                  Identification, Disease Prediction and Treatment},
+  journal =	 {Frontiers in Microbiology},
+  volume =	 12,
+  pages =	 313,
+  year =	 2021,
+  url =
+                  {https://www.frontiersin.org/article/10.3389/fmicb.2021.634511},
+  doi =		 {10.3389/fmicb.2021.634511},
+  issn =	 {1664-302X},
+  status =	 {bioscience}
+}
+
+@Article{Ruuskanen2021gutmicrobes,
+  author =	 {Matti O. Ruuskanen and Fredrik Åberg and Ville
+                  Männistö and Aki S. Havulinna and Guillaume Méric
+                  and Yang Liu and Rohit Loomba and Yoshiki
+                  Vázquez-Baeza and Anupriya Tripathi and Liisa
+                  M. Valsta and Michael Inouye and Pekka Jousilahti
+                  and Veikko Salomaa and Mohit Jain and Rob Knight and
+                  Leo Lahti and Teemu J. Niiranen},
+  title =	 {Links between gut microbiome composition and fatty
+                  liver disease in a large population sample},
+  journal =	 {Gut Microbes},
+  volume =	 13,
+  issue =	 1,
+  month =	 {March},
+  year =	 2021,
+  doi =		 {10.1080/19490976.2021.1888673},
+  status =	 {bioscience}
+}
+
+@Article{crossys2021,
+  author =	 {Marja A. Heiskanen and Sanna M. Honkala and Ronja
+                  A. Ojala and Riikka Lautamäki and Kalle Koskensalo
+                  and Martin Lietzén and Jaakko Hentilä and Virva
+                  Saunavaara and Jani Saunavaara and Mika Helmiö and
+                  Eliisa Löyttyniemi and Lauri Nummenmaa and Maria
+                  C. Collado and Tarja Malm and Leo Lahti and Kirsi
+                  H. Pietiläinen and Jaakko Kaprio and Juha O. Rinne
+                  and Jarna C. Hannukainen},
+  title =	 {Systemic cross-talk between brain, gut, and
+                  peripheral tissues in glucose homeostasis: effects
+                  of exercise training (CROSSYS): Exercise training
+                  intervention in monozygotic twins discordant for
+                  body weight},
+  journal =	 {BMC Sports Science, Medicine and Rehabilitation},
+  year =	 2021,
+  volume =	 13,
+  status =	 {bioscience},
+  pages =	 16,
+  doi =		 {10.1186/s13102-021-00241-z}
+}
+
+@Article{Sarhadi2021,
+  author =	 {Virinder Sarhadi and Binu Mathew and Arto Kokkola A
+                  and Tiina Karla and Milja Tikkanen and Hilpi
+                  Rautelin and Leo Lahti and Pauli Puolakkainen and
+                  Sakari Knuutila},
+  title =	 {Gut microbiota of patients with different subtypes
+                  of gastric cancer and gastrointestinal stromal
+                  tumors},
+  status =	 {bioscience},
+  doi =		 {10.1186/s13099-021-00403-x},
+  volume =	 13,
+  issue =	 11,
+  pages =	 {1-9},
+  journal =	 {Gut Pathogens},
+  year =	 2021
+}
+
+@Article{Palmu2021ijerph,
+  author =	 {Joonatan Palmu and Leo Lahti and Teemu Niiranen},
+  title =	 {Targeting gut microbiota to treat hypertension: a
+                  systematic review},
+  journal =	 {International Journal of Environmental Research and
+                  Public Health},
+  year =	 2021,
+  month =	 January,
+  volume =	 18,
+  number =	 3,
+  pages =	 1248,
+  doi =		 {10.3390/ijerph18031248},
+  status =	 {bioscience},
+  tag =		 {review}
+}
+
+@Article{Khalighi2021,
+  author =	 {Moein Khalighi and Leila Eftekhari and Soleiman
+                  Hosseinpour and Leo Lahti},
+  title =	 {Three-species Lotka-Volterra model with respect to
+                  Caputo and Caputo-Fabrizio fractional operators},
+  journal =	 {Symmetry},
+  volume =	 13,
+  issue =	 3,
+  pages =	 368,
+  month =	 {January},
+  doi =		 {10.3390/sym13030368},
+  status =	 {datascience},
+  year =	 2020
+}
+
+@TechReport{openedu2020,
+  author =	 {Expert Panel in Open Education (Open Science
+                  Coordination in Finland)},
+  title =	 {National policy and executive plan by the higher
+                  education and research community for 2021-2025 -
+                  Policy component 1: Open access to educational
+                  resources.},
+  institution =	 {unknown},
+  year =	 2020,
+  publisher =	 {Committee for Public Information (TJNK) and
+                  Federation of Finnish Learned Societies (TSV).},
+  series =	 {Responsible Research Series},
+  year =	 2020,
+  volume =	 16,
+  status =	 {openscience},
+  address =	 {Helsinki, Finland}
+}
+
+@Article{Koffert2020,
+  author =	 {Jukka Koffert and Leo Lahti and Lotta Nylund and
+                  Seppo Salminen and Jarna C Hannukainen and Paulina
+                  Salminen and Willem de Vos and Pirjo Nuutila},
+  title =	 {Partial restoration of normal intestinal microbiota
+                  in morbidly obese women six months after bariatric
+                  surgery},
+  journal =	 {PeerJ – Life & Environment},
+  year =	 2020,
+  volume =	 8,
+  pages =	 {e10442},
+  doi =		 {10.7717/peerj.10442},
+  note =	 {Shared first authorship.},
+  status =	 {bioscience}
+}
+
+@Article{Pekkala2020,
+  author =	 {Sanna Lensu and Raghunath Pariyani and Elina Mäkinen
+                  and Baoru Yang and Wisam Saleem and Eveliina Munukka
+                  and Maarit Lehti and Baoru Yang and Jere Linden and
+                  Marja Tiirola and Leo Lahti and Satu Pekkala},
+  title =	 {Prebiotic Xylo-oligosaccharides Targeting
+                  Faecalibacterium prausnitzii Prevent High Fat
+                  Diet-induced Hepatic Steatosis in Rats},
+  journal =	 {Nutrients},
+  year =	 2020,
+  volume =	 12,
+  number =	 11,
+  doi =		 {10.3390/nu12113225},
+  pages =	 3225,
+  month =	 {October},
+  status =	 {bioscience}
+}
+
+@Article{Nylund2020,
+  author =	 {Lotta Nylund and Salla Hakkola and Leo Lahti and
+                  Seppo Salminen and Marko Kalliomäki and Baoru Yang
+                  and Kaisa M. Linderborg},
+  title =	 {Diet, perceived intestinal well-being, fecal
+                  microbiota and short chain fatty acids in oat-using
+                  subjects with celiac disease or gluten sensitivity.},
+  journal =	 {Nutrients},
+  year =	 2020,
+  volume =	 12,
+  issue =	 9,
+  pages =	 2570,
+  status =	 {bioscience},
+  month =	 {August},
+  note =	 {Special issue.},
+  doi =		 {10.3390/nu12092570}
+}
+
+@Article{Palmu2020JAHA,
+  author =	 {Joonatan Palmu and others},
+  title =	 {Eicosanoid Inflammatory Mediators Are Robustly
+                  Associated with Blood Pressure in the General
+                  Population},
+  journal =	 {Journal of American Heart Association},
+  year =	 2020,
+  volume =	 9,
+  issue =	 15,
+  pages =	 {e016641},
+  status =	 {bioscience},
+  doi =		 {10.1161/JAHA.120.017598}
+}
+
+@Article{Lahti2020thinkopen,
+  author =	 {Leo Lahti},
+  title =	 {Avoimuus voi vahvistaa päätöksenteon tieteellistä
+                  pohjaa},
+  journal =	 {University of Helsinki, ThinkOpen blog},
+  year =	 2020,
+  month =	 {August},
+  url =
+                  {https://blogs.helsinki.fi/thinkopen/lahdekoodin-avoimuus-paatoksenteossa/},
+  status =	 {general}
+}
+
+@Article{Lahti2020hs2,
+  author =	 {Leo Lahti},
+  title =	 {Lähdekoodin sisältämien yksityiskohtien avoimuus on
+                  keskeistä päätöksenteon läpinäkyvyydelle.},
+  journal =	 {HS Mielipide},
+  year =	 2020,
+  month =	 {June},
+  url =		 {https://www.hs.fi/mielipide/art-2000006545770.html},
+  status =	 {general}
+}
+
+@Article{Lahti2020okf2,
+  author =	 {Leo Lahti},
+  title =	 {Päätös epidemialaskelmien salaamisesta vastoin
+                  valtioneuvoston avoimuuslinjausta},
+  journal =	 {Open Knowledge Finland Blog},
+  year =	 2020,
+  month =	 {June},
+  url =
+                  {https://www.okf.fi/fi/2020/06/15/thln-paatos-epidemialaskelmien-salaamisesta-vastoin-valtioneuvoston-avoimuuslinjausta/},
+  status =	 {general}
+}
+
+@Article{Lahti2020okf1,
+  author =	 {Leo Lahti and Tarmo Toikkanen},
+  title =	 {Tietopyyntö epidemialaskelmien lähdekoodeista},
+  journal =	 {Open Knowledge Finland Blog},
+  year =	 2020,
+  month =	 {May},
+  url =
+                  {https://www.okf.fi/fi/2020/05/13/tietopyynto-thln-epidemialaskelmien-lahdekoodeista},
+  status =	 {general}
+}
+
+@Article{Lahti2020hs1,
+  author =	 {Leo Lahti and Thomas Wallgren and Markku Kulmala},
+  title =	 {Laskentamallit eivät lähtökohtaisesti ole salassa
+                  pidettävää tietoa},
+  journal =	 {HS Mielipide},
+  year =	 2020,
+  month =	 {May},
+  url =		 {https://www.hs.fi/mielipide/art-2000006494641.html},
+  status =	 {general}
+}
+
+@Article{Vaura2020jch,
+  author =	 {Felix C. Vaura and Veikko V. Salomaa and Ilkka
+                  M. Kantola and Risto Kaaja and Leo Lahti and Teemu
+                  J. Niiranen},
+  title =	 {Unsupervised hierarchical clustering identifies a
+                  metabolically challenged subgroup of hypertensive
+                  individuals},
+  journal =	 {Journal of Clinical Hypertension},
+  year =	 2020,
+  volume =	 22,
+  number =	 9,
+  pages =	 {1546--1553},
+  month =	 {August},
+  doi =		 {10.1111/jch.13984},
+  status =	 {bioscience}
+}
+
+@Article{Palmu2020,
+  author =	 {Joonatan Palmu and Aaro Salosensaari and Aki
+                  S. Havulinna and Susan Cheng and Michael Inouye and
+                  Mohit Jain and Rodolfo A. Salido and Karenina
+                  Sanders and Caitriona Brennan and Gregory
+                  C. Humphrey and Jon G. Sanders and Erkki Vartiainen
+                  and Tiina Laatikainen and Pekka Jousilahti and
+                  Veikko Salomaa and Rob Knight and Leo Lahti and
+                  Teemu J. Niiranen},
+  title =	 {Association Between the Gut Microbiota and Blood
+                  Pressure in a Population Cohort of 6953 Individuals},
+  journal =	 {Journal of the American Heart Association},
+  year =	 2020,
+  status =	 {bioscience},
+  month =	 {July},
+  doi =		 {10.1161/JAHA.120.016641}
+}
+
+@article{Aatsinki2020,
+  title =	 {Maternal prenatal psychological distress and hair
+                  cortisol levels associate with infant fecal
+                  microbiota composition at 2.5 months of age},
+  journal =	 {Psychoneuroendocrinology},
+  volume =	 119,
+  pages =	 104754,
+  year =	 2020,
+  status =	 {bioscience},
+  doi =		 {10.1016/j.psyneuen.2020.104754},
+  author =	 {Anna-Katariina Aatsinki and Anniina Keskitalo and
+                  Ville Laitinen and Eveliina Munukka and Henna-Maria
+                  Uusitupa and Leo Lahti and Susanna Kortesluoma and
+                  Paula Mustonen and Ana João Rodrigues and Bárbara
+                  Coimbra and Pentti Huovinen and Hasse Karlsson and
+                  Linnea Karlsson}
+}
+
+@Article{Sarhadi2020,
+  author =	 {Sarhadi, V and Lahti, L and Saberi, F and Youssef, O
+                  and Kokkola, A and Karla, T and Tikkanen, M and
+                  Rautelin, H and Puolakkainen, P and Salehi, R and
+                  Knuutila, S},
+  title =	 {Gut Microbiota and Host Gene Mutations in Colorectal
+                  Cancer Patients and Controls of Iranian and Finnish
+                  Origin},
+  journal =	 {Anticancer Research},
+  year =	 2020,
+  volume =	 40,
+  number =	 3,
+  pages =	 {1325-1334},
+  month =	 {March},
+  doi =		 {10.21873/anticanres.14074},
+  status =	 {bioscience},
+  pdf =		 {papers/2020-Sarhadi-Anticanc.pdf}
+}
+
+@InProceedings{Makela2020,
+  author =	 {Eetu, M and Lagus, K and Lahti, L and Säily, T and
+                  Tolonen, M and Hämäläinen, M and Kaislaniemi, S and
+                  Nevalainen T},
+  title =	 {Wrangling with Non-Standard Data},
+  booktitle =	 {Proc. Digital Humanities in the Nordic Countries},
+  year =	 2020,
+  month =	 {March},
+  series =	 {CEUR Workshop Proceedings},
+  pages =	 {81--96},
+  volume =	 2612,
+  editor =	 {Sanita Reinsone and Inguna Skadiņa and Anda Baklāne
+                  and Jānis Daugavietis},
+  pdf =		 {papers/2020-Makela-DHN.pdf},
+  status =	 {dh}
+}
+
+@Article{Shetty2019,
+  author =	 {Sudarshan Shetty and Leo Lahti},
+  title =	 {Microbiome data science},
+  journal =	 {Journal of Biosciences},
+  year =	 2019,
+  volume =	 44,
+  pages =	 115,
+  month =	 {October},
+  doi =		 {10.1007/s12038-019-9930-2},
+  note =	 {Preprint openly available at:
+                  https://openresearchlabs.github.io/publications/papers/2019-Shetty-MDS.pdf},
+  status =	 {bioscience},
+  keywords =	 {review}
+}
+
+@Article{Marjanen2019,
+  author =	 {Jani Marjanen and Ville Vaara and Antti Kanner and
+                  Hege Roivainen and Eetu Mäkelä and Leo Lahti and
+                  Mikko Tolonen},
+  title =	 {A National Public Sphere? Analyzing the Language,
+                  Location, and Form of Newspapers in Finland,
+                  1771–1917},
+  journal =	 {Journal of European Periodical Studies},
+  year =	 2019,
+  volume =	 4,
+  number =	 1,
+  month =	 {June},
+  doi =		 {10.21825/jeps.v4i1.10483},
+  url =		 {https://ojs.ugent.be/jeps/article/view/10483},
+  note =	 {Special issue: Digital Approaches Towards Serial
+                  Publications},
+  pdf =		 {papers/2019-Marjanen-JEPS.pdf},
+  status =	 {dh},
+  keywords =	 {dh}
+}
+
+@InProceedings{Ijaz2019rdhum,
+  author =	 {Ali Ijaz and Mikko Tolonen and Leo Lahti},
+  title =	 {Analytical determination of editions from
+                  bibliographic metadata},
+  booktitle =	 {Proceedings of the Research Data in the Humanities
+                  Conference},
+  year =	 2019,
+  address =	 {Oulu},
+  month =	 {August},
+  pdf =		 {papers/2019-Ijaz-RDHum.pdf}
+}
+
+@InProceedings{Lahti2019rdhum,
+  author =	 {Leo Lahti and Ville Vaara and Jani Marjanen and
+                  Mikko Tolonen},
+  title =	 {Best practices in bibliographic data science},
+  booktitle =	 {Proceedings of the Research Data in the Humanities
+                  Conference},
+  year =	 2019,
+  address =	 {Oulu},
+  month =	 {August},
+  pdf =		 {papers/2019-Lahti-RDHUM.pdf},
+  status =	 {dh},
+  keywords =	 {dh}
+}
 
 @Article{Aatsinki2019,
   author =	 {Anna Aatsinki and Leo Lahti and Henna Uusitupa and
                   Eveliina Munukka and Anniina Keskitalo, Saara Nolvi
-                  and Siobhain O'Mahony and Sami Pietilä and
-                  Laura Elo and Erkki Eerola and Hasse Karlsson and
-                  Linnea Karlsson},
+                  and Siobhain O'Mahony and Sami Pietilä and Laura Elo
+                  and Erkki Eerola and Hasse Karlsson and Linnea
+                  Karlsson},
   title =	 {Gut microbiota composition is associated with
                   temperament traits in infants},
   pdf =		 {papers/2019-Aatsinki.pdf},
@@ -34,604 +689,86 @@
   pages =	 {849--858},
   year =	 2019,
   month =	 {May},
-  keywords =	 {bioscience},
+  status =	 {bioscience},
   doi =		 {10.1016/j.bbi.2019.05.035}
 }
 
-@article{Aatsinki2020,
-  title =	 {Maternal prenatal psychological distress and hair
-                  cortisol levels associate with infant fecal
-                  microbiota composition at 2.5 months of age},
-  author =	 {Anna-Katariina Aatsinki and Anniina Keskitalo and
-                  Ville Laitinen and Eveliina Munukka and Henna-Maria
-                  Uusitupa and Leo Lahti and Susanna Kortesluoma and
-                  Paula Mustonen and Ana João Rodrigues and
-                  Bárbara Coimbra and Pentti Huovinen and Hasse
-                  Karlsson and Linnea Karlsson},
-  year =	 2020,
-  journal =	 {Psychoneuroendocrinology},
-  volume =	 119,
-  pages =	 104754,
-  doi =		 {10.1016/j.psyneuen.2020.104754},
-  keywords =	 {bioscience}
+@Article{Timmis2019,
+  author =	 {K Timmis K and F Jebok F and M Rohde M and L Lahti L
+                  and G Molinari},
+  title =	 {Microbiome yarns: The Global Phenotype-Genotype
+                  Survey. Episode III: importance of microbiota
+                  diversification for microbiome function and biome
+                  health},
+  journal =	 {Microbial Biotechnology},
+  year =	 2019,
+  month =	 {April},
+  doi =		 {10.1111/1751-7915.13406},
+  status =	 {misc},
+  keywords =	 {misc},
+  annote =	 {Comics piece for the popularization of microbiome
+                  research.}
 }
 
-
-@Article{Aleksic14,
-  author =	 {Jelena Aleksic and Adrian Alexa and Teresa K Attwood
-                  and Neil Chue Hong and Martin Dahl{\"o} and Robert
-                  Davey and Holger Dinkel and Konrad U F{\"o}rstner
-                  and Ivo Grigorov and Jean-Karim
-                  Hériché and Leo Lahti and Dan MacLean
-                  and Michael L Markie and Jenny Molloy and Maria
-                  Victoria Schneider and Camille Scott and Richard
-                  Smith-Unna and Bruno Miguel Vieira},
-  keywords =	 {openscience},
-  status =	 {openscience},
-  category =	 {perspective},
-  title =	 {The Open Science Peer Review Oath},
-  journal =	 {F1000Research},
-  year =	 2015,
-  volume =	 3,
-  month =	 1,
-  pages =	 271,
-  note =	 {AllBio: Open Science & Reproducibility Best Practice
-                  Workshop},
-  pdf =
-                  {https://github.com/openresearchlabs/openresearchlabs.github.io/blob/master/content/publication_resources/papers/2014-Aleksic.pdf},
-  doi =		 {10.12688/f1000research.5686.2}
+@Article{stolaki2019,
+  author =	 {Stolaki, Maria and Minekus, Mans and Venema, Koen
+                  and Lahti, Leo and Smid, Eddy J. and Kleerebezem,
+                  Michiel and Zoetendal, Erwin G},
+  title =	 {Microbial communities in a dynamic {it in vitro}
+                  model for the human ileum resemble the human ileal
+                  microbiota},
+  journal =	 {FEMS Microbiology Ecology},
+  year =	 2019,
+  status =	 {bioscience},
+  vol =		 95,
+  number =	 8,
+  pages =	 {fiz096},
+  month =	 {August},
+  doi =		 {10.1093/femsec/fiz096},
+  pdf =		 {papers/2019-Stolaki-FEMS.pdf}
 }
 
-
-@Article{Alneberg14,
-  author =	 {Johannes Alneberg and Brynjar Smári Bjarnason
-                  and Ino de Bruijn and Melanie Schirmer and Joshua
-                  Quick and Umer Z Ijaz and Leo Lahti and Nicholas J
-                  Loman and Anders F Andersson and Christopher Quince},
-  title =	 {Binning metagenomic contigs by coverage and
-                  composition},
-  journal =	 {Nature Methods},
-  year =	 2014,
-  keywords =	 {bioscience},
-  keywords =	 {highlight},
-  volume =	 11,
-  number =	 {1144--1146},
-  pdf =		 {papers/2014-Alneberg-NatMeth.pdf},
-  note =	 {CONCOCT algorithm},
-  doi =		 {10.1038/nmeth.3103}
-}
-
-@article{Arani2018,
-  title =	 {Stability estimation of autoregulated genes under
-                  Michaelis-Menten type kinetics},
-  author =	 {Arani, Babak M. S. and Mahmoudi, Mahdi and Lahti,
-                  Leo and Gonz\'alez, Javier and Wit, Ernst C.},
-  year =	 2018,
-  month =	 {Jun},
-  journal =	 {Physical Review E},
-  publisher =	 {American Physical Society},
-  volume =	 97,
-  number =	 6,
-  pages =	 062407,
-  doi =		 {10.1103/PhysRevE.97.062407},
-  issn =	 {2470-0045},
-  url =		 {https://link.aps.org/doi/10.1103/PhysRevE.97.062407},
-  numpages =	 10,
-  keywords =	 {datascience},
-  url =
-                  {https://github.com/openresearchlabs/openresearchlabs.github.io/blob/master/content/publication_resources/papers/2018-Arani-PhysRevE.pdf}
-}
-
-
-
-@article{Arani2021,
-  title =	 {Exit Time as a Measure of Ecological Resilience},
-  author =	 {Babak M.S. Arani and Egbert van Nes and Leo Lahti
-                  and Stephen R. Carpenter and Marten Scheffer},
-  year =	 2021,
-  month =	 {June},
-  journal =	 {Science},
-  volume =	 372,
-  number =	 6547,
-  pages =	 {eaay4895},
-  doi =		 {10.1126/science.aay4895},
-  keywords =	 {datascience}
-}
-
-
-
-
-@TechReport{Bjork2018,
-  author =	 {Anna Björk and Juho-Matti Paavolainen and
-                  Teemu Ropponen and Mikael Laakso and Leo Lahti},
-  title =	 {Opening academic publishing: development and
-                  application of systematic evaluation criteria},
-  institution =	 {unknown},
-  year =	 2018,
-  publisher =	 {Open Science and Research Initiative (ATT)},
-  month =	 {January},
-  note =	 {Report on the openness of major scientific
-                  publishers commissioned by Finnish Ministry of
-                  Education and Culture},
-  authorship =	 {corresponding},
-  category =	 {report},
-  status =	 {openscience},
-  keywords =	 {openscience},
-  url =		 {http://urn.fi/URN:NBN:fi-fe201802123334},
-  pdf =		 {papers/2018-Bjork-ATT.pdf}
-}
-
-
-
-@Article{Borze11,
-  author =	 {Ioana Borze and Mohamed Guled and Suad Musse and
-                  Anna Raunio and Erkki Elonen and Ulla
-                  Saarinen-Pihkala and Marja-Liisa
-                  Karjalainen-Lindsberg and Leo Lahti and Sakari
-                  Knuutila.},
-  title =	 {MicroRNA microarrays on archive bone marrow core
-                  biopsies of leukemias - method validation},
-  journal =	 {Leukemia Research},
-  year =	 2011,
-  volume =	 35,
-  month =	 2,
-  issue =	 2,
-  pages =	 {188--195},
-  doi =		 {10.1016/j.leukres.2010.08.005}
-}
-
-
-@Article{Buelow2017,
-  author =	 {Elena Buelow and Teresita {d.J.} Bello
-                  González and Susana Fuentes and Wouter
-                  A.A. {de Steenhuijsen Piters} and Leo Lahti and
-                  Jumamurat R. Bayjanov and Eline A.M. Majoor and
-                  Johanna C. Braat and Maaike S. van Mourik and
-                  Evelien A.N. Oostdijk and Rob J.L. Willems and Marc
-                  J.M. Bonten and Mark W.J. van Passel and Hauke Smidt
-                  and Willem van Schaik},
-  title =	 {Comparative gut microbiota and resistome profiling
-                  of intensive care patients receiving selective
-                  digestive tract decontamination and healthy
-                  subjects},
-  journal =	 {Microbiome},
-  year =	 2017,
-  volume =	 5,
-  number =	 1,
-  keywords =	 {bioscience},
-  pages =	 88,
-  month =	 {Aug},
-  pdf =
-                  {https://github.com/openresearchlabs/openresearchlabs.github.io/blob/master/content/publication_resources/papers/2017-Buelow-Microbiome.pdf},
-  doi =		 {10.1186/s40168-017-0309-z}
-}
-
-@Article{Buelow2017,
-  author =	 {Elena Buelow and Teresita {d.J.} Bello
-                  González and Susana Fuentes and Wouter
-                  A.A. {de Steenhuijsen Piters} and Leo Lahti and
-                  Jumamurat R. Bayjanov and Eline A.M. Majoor and
-                  Johanna C. Braat and Maaike S. van Mourik and
-                  Evelien A.N. Oostdijk and Rob J.L. Willems and Marc
-                  J.M. Bonten and Mark W.J. van Passel and Hauke Smidt
-                  and Willem van Schaik},
-  title =	 {Comparative gut microbiota and resistome profiling
-                  of intensive care patients receiving selective
-                  digestive tract decontamination and healthy
-                  subjects},
-  journal =	 {Microbiome},
-  year =	 2017,
-  volume =	 5,
-  number =	 1,
-  keywords =	 {bioscience},
-  pages =	 88,
-  month =	 {Aug},
-  pdf =		 {papers/2017-Buelow-Microbiome.pdf},
-  doi =		 {10.1186/s40168-017-0309-z}
-}
-
-@article{Elo05,
-  title =	 {Integrating probe-level expression changes across
-                  generations of Affymetrix arrays},
-  author =	 {Elo, Laura L. and Lahti, Leo and Skottman, Heli and
-                  Kyl{\"a}niemi, Minna and Lahesmaa, Riitta and
-                  Aittokallio, Tero},
-  year =	 2005,
-  month =	 12,
-  journal =	 {Nucleic Acids Research},
-  volume =	 33,
-  number =	 22,
-  pages =	 {e193},
-  doi =		 {10.1093/nar/gni193},
-  authorship =	 {second},
-  keywords =	 {bioscience},
-  url =
-                  {https://github.com/openresearchlabs/openresearchlabs.github.io/blob/master/content/publication_resources/papers/2005-Elo-NAR.pdf}
-}
-
-@article{Elo05,
-  author =	 {Elo, Laura L. and Lahti, Leo and Skottman, Heli and
-                  Kyl{\"a}niemi, Minna and Lahesmaa, Riitta and
-                  Aittokallio, Tero},
-  title =	 {Integrating probe-level expression changes across
-                  generations of Affymetrix arrays},
-  journal =	 {Nucleic Acids Research},
-  volume =	 33,
-  number =	 22,
-  pages =	 {e193},
-  month =	 12,
-  authorship =	 {second},
-  keywords =	 {bioscience},
-  doi =		 {10.1093/nar/gni193},
-  pdf =
-                  {https://github.com/openresearchlabs/openresearchlabs.github.io/blob/master/content/publication_resources/papers/2005-Elo-NAR.pdf},
-  year =	 2005
-}
-
-@article{Elo05,
-  author =	 {Elo, Laura L. and Lahti, Leo and Skottman, Heli and
-                  Kyl{\"a}niemi, Minna and Lahesmaa, Riitta and
-                  Aittokallio, Tero},
-  title =	 {Integrating probe-level expression changes across
-                  generations of Affymetrix arrays},
-  journal =	 {Nucleic Acids Research},
-  volume =	 33,
-  number =	 22,
-  pages =	 {e193},
-  month =	 12,
-  authorship =	 {second},
-  keywords =	 {bioscience},
-  doi =		 {10.1093/nar/gni193},
-  pdf =		 {papers/2005-Elo-NAR.pdf},
-  year =	 2005
-}
-
-@inproceedings{Faisal2011,
-  title =	 {Biomarker discovery via dependency analysis of
-                  multi-view functional genomics data},
-  author =	 {Ali Faisal and Riku Louhimo and Leo Lahti and Sampsa
-                  Hautaniemi and Samuel Kaski},
-  year =	 2011,
-  booktitle =	 {NIPS 2011 workshop From Statistical Genetics to
-                  Predictive Models in Personalized Medicine},
+@InProceedings{Tolonen16dh,
+  author =	 {Mikko Tolonen and Niko Ilom{\"a}ki and Hege
+                  Roivainen and Leo Lahti},
+  title =	 {Printing in a Periphery: a Quantitative Study of
+                  Finnish Knowledge Production, 1640-1828},
+  booktitle =	 {Digital Humanities 2016: Conference Abstracts},
+  year =	 2016,
   category =	 {abstract},
-  keywords =	 {bioscience},
-  url =
-                  {https://github.com/openresearchlabs/openresearchlabs.github.io/blob/master/content/publication_resources/papers/2011-Faisal-NIPS.pdf}
-}
-
-@InProceedings{Faisal2011,
-  author =	 {Ali Faisal and Riku Louhimo and Leo Lahti and Sampsa
-                  Hautaniemi and Samuel Kaski},
-  title =	 {Biomarker discovery via dependency analysis of
-                  multi-view functional genomics data},
-  booktitle =	 {NIPS 2011 workshop From Statistical Genetics to
-                  Predictive Models in Personalized Medicine},
-  category =	 {abstract},
-  keywords =	 {bioscience},
-  pdf =
-                  {https://github.com/openresearchlabs/openresearchlabs.github.io/blob/master/content/publication_resources/papers/2011-Faisal-NIPS.pdf},
-  year =	 2011,
-  doi =		 {10.1093/nar/gkt229},
-  note =	 {Implementation available through Bioconductor RPA
-                  package.}
-}
-
-@InProceedings{Faisal2011,
-  author =	 {Ali Faisal and Riku Louhimo and Leo Lahti and Sampsa
-                  Hautaniemi and Samuel Kaski},
-  title =	 {Biomarker discovery via dependency analysis of
-                  multi-view functional genomics data},
-  booktitle =	 {NIPS 2011 workshop From Statistical Genetics to
-                  Predictive Models in Personalized Medicine},
-  category =	 {abstract},
-  keywords =	 {bioscience},
-  pdf =		 {papers/2011-Faisal-NIPS.pdf},
-  year =	 2011,
-  keywords =	 {datascience}
-}
-
-@article{Faust15,
-  title =	 {Metagenomics meets time series analysis: unraveling
-                  microbial community dynamics},
-  author =	 {Karoline Faust and Leo Lahti and Didier Gonze and
-                  Willem M de Vos and Jeroen Raes},
-  year =	 2015,
-  month =	 6,
-  journal =	 {Current Opinion in Microbiology},
-  volume =	 25,
-  pages =	 {56--66},
-  doi =		 {10.1016/j.mib.2015.04.004},
-  category =	 {review},
-  keywords =	 {bioscience},
-  authorship =	 {shared first},
-  url =
-                  {https://github.com/openresearchlabs/openresearchlabs.github.io/blob/master/content/publication_resources/papers/2015-Faust-CurrOpMicrob.pdf}
-}
-
-@Article{Faust15,
-  author =	 {Karoline Faust and Leo Lahti and Didier Gonze and
-                  Willem M de Vos and Jeroen Raes},
-  title =	 {Metagenomics meets time series analysis: unraveling
-                  microbial community dynamics},
-  journal =	 {Current Opinion in Microbiology},
-  year =	 2015,
-  volume =	 25,
-  category =	 {review},
-  keywords =	 {bioscience},
-  keywords =	 {highlight},
-  pages =	 {56--66},
-  month =	 6,
-  authorship =	 {shared first},
-  doi =		 {10.1016/j.mib.2015.04.004},
-  pdf =
-                  {https://github.com/openresearchlabs/openresearchlabs.github.io/blob/master/content/publication_resources/papers/2015-Faust-CurrOpMicrob.pdf}
-}
-
-@Article{Faust15,
-  author =	 {Karoline Faust and Leo Lahti and Didier Gonze and
-                  Willem M de Vos and Jeroen Raes},
-  title =	 {Metagenomics meets time series analysis: unraveling
-                  microbial community dynamics},
-  journal =	 {Current Opinion in Microbiology},
-  year =	 2015,
-  volume =	 25,
-  category =	 {review},
-  keywords =	 {bioscience},
-  keywords =	 {highlight},
-  pages =	 {56--66},
-  month =	 6,
-  authorship =	 {shared first},
-  doi =		 {10.1016/j.mib.2015.04.004},
-  pdf =		 {papers/2015-Faust-CurrOpMicrob.pdf}
-}
-
-@Article{Faust2017,
-  author =	 {Didier Gonze and Leo Lahti and Jeroen Raes and
-                  Karoline Faust},
-  title =	 {Multi-stability and the origin of microbial
-                  community types},
-  journal =	 {ISME Journal},
-  year =	 2017,
-  keywords =	 {bioscience},
-  keywords =	 {highlight},
-  volume =	 11,
-  pages =	 {2159--2166},
-  pdf =		 {papers/2017-Faust-ISME.pdf},
-  month =	 {may},
-  doi =		 {10.1038/ismej.2017.60}
-}
-
-@article{Faust2017,
-  title =	 {Multi-stability and the origin of microbial
-                  community types},
-  author =	 {Didier Gonze and Leo Lahti and Jeroen Raes and
-                  Karoline Faust},
-  year =	 2017,
-  month =	 {may},
-  journal =	 {ISME Journal},
-  volume =	 11,
-  pages =	 {2159--2166},
-  doi =		 {10.1038/ismej.2017.60},
-  keywords =	 {bioscience},
-  url =
-                  {https://github.com/openresearchlabs/openresearchlabs.github.io/blob/master/content/publication_resources/papers/2017-Faust-ISME.pdf}
-}
-
-@Article{Faust2017,
-  author =	 {Didier Gonze and Leo Lahti and Jeroen Raes and
-                  Karoline Faust},
-  title =	 {Multi-stability and the origin of microbial
-                  community types},
-  journal =	 {ISME Journal},
-  year =	 2017,
-  keywords =	 {bioscience},
-  keywords =	 {highlight},
-  volume =	 11,
-  pages =	 {2159--2166},
-  pdf =
-                  {https://github.com/openresearchlabs/openresearchlabs.github.io/blob/master/content/publication_resources/papers/2017-Faust-ISME.pdf},
-  month =	 {may},
-  doi =		 {10.1038/ismej.2017.60}
-}
-
-@Article{Faust2018,
-  author =	 {Karoline Faust and Franziska Bauchinger and Beatrice
-                  Laroche and Sophie de Buyl and Leo Lahti and Alex D
-                  Washburne and Didier Gonze and Stefanie Widder},
-  title =	 {Signatures of ecological processes in microbial
-                  community time series},
-  journal =	 {Microbiome},
-  keywords =	 {highlight},
-  keywords =	 {bioscience},
-  year =	 2018,
-  volume =	 6,
-  number =	 120,
-  month =	 {June},
-  pdf =
-                  {https://github.com/openresearchlabs/openresearchlabs.github.io/blob/master/content/publication_resources/papers/2018-Faust-Microbiome.pdf},
-  doi =		 {10.1186/s40168-018-0496-2}
-}
-
-@Article{Faust2018,
-  author =	 {Karoline Faust and Franziska Bauchinger and Beatrice
-                  Laroche and Sophie de Buyl and Leo Lahti and Alex D
-                  Washburne and Didier Gonze and Stefanie Widder},
-  title =	 {Signatures of ecological processes in microbial
-                  community time series},
-  journal =	 {Microbiome},
-  keywords =	 {highlight},
-  keywords =	 {bioscience},
-  year =	 2018,
-  volume =	 6,
-  number =	 120,
-  month =	 {June},
-  pdf =		 {papers/2018-Faust-Microbiome.pdf},
-  doi =		 {10.1186/s40168-018-0496-2}
-}
-
-@article{Faust2018,
-  title =	 {Signatures of ecological processes in microbial
-                  community time series},
-  author =	 {Karoline Faust and Franziska Bauchinger and Beatrice
-                  Laroche and Sophie de Buyl and Leo Lahti and Alex D
-                  Washburne and Didier Gonze and Stefanie Widder},
-  year =	 2018,
-  month =	 {June},
-  journal =	 {Microbiome},
-  volume =	 6,
-  number =	 120,
-  doi =		 {10.1186/s40168-018-0496-2},
-  keywords =	 {bioscience},
-  url =
-                  {https://github.com/openresearchlabs/openresearchlabs.github.io/blob/master/content/publication_resources/papers/2018-Faust-Microbiome.pdf}
-}
-
-@Article{Gonze2018,
-  author =	 {Didier Gonze and Katharine Z Coyte and Leo Lahti and
-                  Karoline Faust},
-  title =	 {Microbial communities as dynamical systems},
-  journal =	 {Current Opinion in Microbiology},
-  keywords =	 {review},
-  keywords =	 {bioscience},
-  year =	 2018,
-  volume =	 44,
-  pages =	 {41-49},
-  month =	 {July},
-  doi =		 {10.1016/j.mib.2018.07.004},
-  pdf =
-                  {https://github.com/openresearchlabs/openresearchlabs.github.io/blob/master/content/publication_resources/papers/2018-Gonze.pdf}
-}
-
-@Article{Gonze2018,
-  author =	 {Didier Gonze and Katharine Z Coyte and Leo Lahti and
-                  Karoline Faust},
-  title =	 {Microbial communities as dynamical systems},
-  journal =	 {Current Opinion in Microbiology},
-  keywords =	 {review},
-  keywords =	 {bioscience},
-  year =	 2018,
-  volume =	 44,
-  pages =	 {41-49},
-  month =	 {July},
-  doi =		 {10.1016/j.mib.2018.07.004},
-  pdf =		 {papers/2018-Gonze.pdf}
-}
-
-@article{Gonze2018,
-  title =	 {Microbial communities as dynamical systems},
-  author =	 {Didier Gonze and Katharine Z Coyte and Leo Lahti and
-                  Karoline Faust},
-  year =	 2018,
-  month =	 {July},
-  journal =	 {Current Opinion in Microbiology},
-  volume =	 44,
-  pages =	 {41--49},
-  doi =		 {10.1016/j.mib.2018.07.004},
-  keywords =	 {bioscience},
-  url =
-                  {https://github.com/openresearchlabs/openresearchlabs.github.io/blob/master/content/publication_resources/papers/2018-Gonze.pdf}
-}
-
-@article{Guled09,
-  title =	 {CDKN2A, NF2 and JUN Are Dysregulated Among Other
-                  Genes by miRNAs in Malignant Mesothelioma - a miRNA
-                  Microarray Analysis},
-  author =	 {Mohamed Guled and Leo Lahti and Pamela M. Lindholm
-                  and Kaisa Salmenkivi and Izhar Bagwan and Andrew
-                  G. Nicholson and Sakari Knuutila},
-  year =	 2009,
-  month =	 7,
-  journal =	 {Genes, Chromosomes and Cancer},
-  volume =	 48,
-  number =	 7,
-  pages =	 {615--623},
-  doi =		 {10.1002/gcc.20669},
-  url =
-                  {https://github.com/openresearchlabs/openresearchlabs.github.io/blob/master/content/publication_resources/papers/2009-GCC-Guled-miRNA.pdf},
-  keywords =	 {bioscience}
-}
-
-@Article{Guled09,
-  author =	 {Mohamed Guled and Leo Lahti and Pamela M. Lindholm
-                  and Kaisa Salmenkivi and Izhar Bagwan and Andrew
-                  G. Nicholson and Sakari Knuutila},
-  title =	 {CDKN2A, NF2 and JUN Are Dysregulated Among Other
-                  Genes by miRNAs in Malignant Mesothelioma - a miRNA
-                  Microarray Analysis},
-  journal =	 {Genes, Chromosomes and Cancer},
-  year =	 2009,
-  volume =	 48,
-  number =	 7,
-  month =	 7,
-  pdf =		 {papers/2009-GCC-Guled-miRNA.pdf},
-  authorship =	 {second},
-  pages =	 {615--623},
-  doi =		 {10.1002/gcc.20669}
-}
-
-@article{Harris17,
-  author =	 {Keith Harris and Todd L Parsons and Umer Z Ijaz and
-                  Leo Lahti and Ian Holmes and Christopher Quince},
-  title =	 {Linking statistical and ecological theory: Hubbell's
-                  unified neutral theory of biodiversity as a
-                  hierarchical Dirichlet process},
-  journal =	 {Proceedings of the IEEE},
-  keywords =	 {bioscience},
-  keywords =	 {highlight},
-  year =	 2017,
-  volume =	 105,
-  number =	 3,
-  pages =	 {516--529},
-  pdf =
-                  {https://github.com/openresearchlabs/openresearchlabs.github.io/blob/master/content/publication_resources/papers/2017-Harris-IEEE.pdf},
-  month =	 {March},
-  doi =		 {10.1109/JPROC.2015.2428213}
-}
-
-@InProceedings{Hill2018,
-  author =	 {Mark J Hill and Antti Kanner and Jani Marjanen and
-                  Ville Vaara and Eetu Mäkelä and Leo
-                  Lahti and Mikko Tolonen},
-  title =	 {Spheres of “public” in
-                  eighteenth-century Britain},
-  booktitle =	 {Proceedings of the Digital Humanities in the Nordics
-                  Conference},
   status =	 {dh},
-  category =	 {abstract},
-  year =	 2018,
-  address =	 {Helsinki, Finland},
-  month =	 3
-}
-
-@InProceedings{Hill2018,
-  author =	 {Mark J Hill and Antti Kanner and Jani Marjanen and
-                  Ville Vaara and Eetu Mäkelä and Leo
-                  Lahti and Mikko Tolonen},
-  title =	 {Spheres of “public” in
-                  eighteenth-century Britain},
-  booktitle =	 {Proceedings of the Digital Humanities in the Nordics
-                  Conference},
-  status =	 {dh},
-  category =	 {abstract},
-  year =	 2018,
-  address =	 {Helsinki, Finland},
-  month =	 3
-}
-
-@inproceedings{Hill2018,
-  title =	 {Spheres of “public” in
-                  eighteenth-century Britain},
-  author =	 {Mark J Hill and Antti Kanner and Jani Marjanen and
-                  Ville Vaara and Eetu Mäkelä and Leo
-                  Lahti and Mikko Tolonen},
-  year =	 2018,
-  month =	 3,
-  booktitle =	 {Proceedings of the Digital Humanities in the Nordics
-                  Conference},
-  address =	 {Helsinki, Finland},
-  category =	 {abstract},
+  publisher =	 {Jagiellonian University & Pedagogical University,
+                  Kraków},
+  address =	 {Krakow, Poland},
+  url =		 {http://dh2016.adho.org/abstracts/9},
+  pages =	 {383--385},
+  month =	 7,
   keywords =	 {dh}
+}
+
+@InProceedings{Vaara2019dh,
+  author =	 {Ville Vaara and Ali Ijaz and Iiro Tiihonen and Simon
+                  Hengchen and Antti Kanner and Tanja S{\"a}ily and
+                  Leo Lahti},
+  title =	 {The Emerging Paradigm of Bibliographic Data Science},
+  booktitle =	 {Proceedings of the Digital Humanities (DH2019)},
+  year =	 2019,
+  month =	 {July},
+  status =	 {dh},
+  keywords =	 {dh},
+  note =	 {In press.}
+}
+
+@InProceedings{Ijaz2019dh,
+  author =	 {Ali Ijaz and Hege Roivainen and Leo Lahti},
+  title =	 {Analytical Edition Detection In Bibliographic
+                  Metadata},
+  booktitle =	 {Proceedings of the Digital Humanities (DH2019)},
+  year =	 2019,
+  month =	 {July},
+  status =	 {dh},
+  keywords =	 {dh},
+  note =	 {In press.}
 }
 
 @InProceedings{Hill2019dhn,
@@ -656,112 +793,850 @@
   keywords =	 {dh}
 }
 
-@inproceedings{Hill2019dhn,
-  title =	 {Reconstructing intellectual networks: from the
-                  {ESTC}'s bibliographic metadata to historical
-                  material},
-  author =	 {Mark J Hill and Ville Vaara and Tanja S{\"a}ily and
-                  Leo Lahti and Mikko Tolonen},
+@InProceedings{Makela2019dhn,
+  author =	 {Eetu M{\"a}kel{\"a} and Mikko Tolonen and Jani
+                  Marjanen and Antti Kanner and Ville Vaara and Leo
+                  Lahti},
+  title =	 {Interdisciplinary collaboration in studying
+                  newspaper materiality},
+  pages =	 {55-66},
+  booktitle =	 {Proc. Twin Talks workshop. Digital Humanities in the
+                  Nordic Countries},
+  series =	 {CEUR Workshop Proceedings},
   year =	 2019,
   month =	 {March},
-  booktitle =	 {Proc. Digital Humanities in the Nordic Countries},
   address =	 {Copenhagen},
-  series =	 {CEUR Workshop Proceedings},
-  volume =	 2364,
-  pages =	 {201--219},
-  note =	 {Best paper award.},
-  editor =	 {Costanza Navarretta and Manex Agirrezabal and Bente
-                  Maegaard},
-  url =
-                  {https://github.com/openresearchlabs/openresearchlabs.github.io/blob/master/content/publication_resources/papers/2019-Hill-DHN.pdf},
-  keywords =	 {dh}
-}
-
-@article{Hintikka2021,
-  title =	 {Xylo-Oligosaccharides in Prevention of Hepatic
-                  Steatosis and Adipose Tissue Inflammation:
-                  Associating Taxonomic and Metabolomic Patterns in
-                  Fecal Microbiomes with Biclustering},
-  author =	 {Hintikka, J and Lensu, S and Mäkinen, E and
-                  Karvinen, S and Honkanen, M and Linden, J and
-                  Garrels, T and Pekkala, S and Lahti, L},
-  year =	 2021,
-  month =	 {April},
-  journal =	 {International Journal of Environmental Research and
-                  Public Health},
-  volume =	 18,
-  number =	 8,
-  pages =	 4049,
-  doi =		 {10.3390/ijerph18084049},
-  keywords =	 {bioscience}
-}
-
-@InProceedings{Ijaz2019dh,
-  author =	 {Ali Ijaz and Hege Roivainen and Leo Lahti},
-  title =	 {Analytical Edition Detection In Bibliographic
-                  Metadata},
-  booktitle =	 {Proceedings of the Digital Humanities (DH2019)},
-  year =	 2019,
-  month =	 {July},
+  volume =	 2365,
+  editor =	 {Steven Krauwer and Darja Fišer},
   status =	 {dh},
   keywords =	 {dh},
-  note =	 {In press.}
-}
-
-@inproceedings{Ijaz2019dh,
-  title =	 {Analytical Edition Detection In Bibliographic
-                  Metadata},
-  author =	 {Ali Ijaz and Hege Roivainen and Leo Lahti},
-  year =	 2019,
-  month =	 {July},
-  booktitle =	 {Proceedings of the Digital Humanities (DH2019)},
-  note =	 {In press.},
-  keywords =	 {dh}
-}
-
-@InProceedings{Ijaz2019rdhum,
-  author =	 {Ali Ijaz and Mikko Tolonen and Leo Lahti},
-  title =	 {Analytical determination of editions from
-                  bibliographic metadata},
-  booktitle =	 {Proceedings of the Research Data in the Humanities
-                  Conference},
-  year =	 2019,
-  address =	 {Oulu},
-  month =	 {August},
-  pdf =		 {papers/2019-Ijaz-RDHum.pdf}
-}
-
-@inproceedings{Ijaz2019rdhum,
-  title =	 {Analytical determination of editions from
-                  bibliographic metadata},
-  author =	 {Ali Ijaz and Mikko Tolonen and Leo Lahti},
-  year =	 2019,
-  month =	 {August},
-  booktitle =	 {Proceedings of the Research Data in the Humanities
-                  Conference},
-  address =	 {Oulu},
+  pdf =		 {papers/2019-Makela-DHN.pdf},
   url =
-                  {https://github.com/openresearchlabs/openresearchlabs.github.io/blob/master/content/publication_resources/papers/2019-Ijaz-RDHum.pdf},
+                  {http://ceur-ws.org/Vol-2365/07-TwinTalks-DHN2019_paper_7.pdf}
+}
+
+@InProceedings{Tolonen2019dhn,
+  author =	 {Mikko Tolonen and Jani Marjanen and Hege Roivainen
+                  and Leo Lahti},
+  title =	 {Scaling up bibliographic data science},
+  booktitle =	 {Proceedings of the Digital Humanities in the Nordics
+                  (DHN2019)},
+  year =	 2019,
+  month =	 {March},
+  address =	 {Copenhagen},
+  editor =	 {Costanza Navarretta and Manex Agirrezabal and Bente
+                  Maegaard},
+  pdf =		 {papers/2019-Tolonen-DHN.pdf},
+  status =	 {dh},
   keywords =	 {dh}
 }
 
-@Article{Jalanka-Tuovinen11,
-  author =	 {Jonna Jalanka-Tuovinen and Anne Salonen and Janne
-                  Nikkil{\"a} and Outi Immonen and Riina Kekkonen and
-                  Leo Lahti and Airi Palva and Willem M. de Vos},
-  title =	 {Intestinal microbiota in healthy adults: Temporal
-                  analysis reveals individual and common core and
-                  relation to intestinal symptoms},
-  journal =	 {PLoS One},
-  year =	 2011,
-  volume =	 6,
-  keywords =	 {bioscience},
-  number =	 7,
-  month =	 7,
-  pages =	 {e23035},
-  url =		 {10.1371/journal.pone.0023035},
+@Article{Lahti2019bds,
+  author =	 {Leo Lahti and Jani Marjanen and Hege Roivainen and
+                  Mikko Tolonen},
+  title =	 {Bibliographic Data Science and the History of the
+                  Book (c. 1500–1800)},
+  journal =	 {Cataloging \& Classification Quarterly},
+  year =	 2019,
+  volume =	 57,
+  number =	 1,
+  pages =	 {5--23},
+  month =	 {January},
+  doi =		 {10.1080/01639374.2018.1543747},
+  pdf =		 {papers/2019-Lahti-CCQ.pdf},
+  publisher =	 {Routledge},
+  status =	 {dh},
+  note =	 {Special issue.}
+}
+
+@Article{tolonen2019,
+  author =	 {Mikko Tolonen and Leo Lahti and Hege Roivainen and
+                  Jani Marjanen},
+  title =	 {A Quantitative Approach to Book-Printing in Sweden
+                  and Finland, 1640–1828},
+  journal =	 {Historical Methods: A Journal of Quantitative and
+                  Interdisciplinary History},
+  year =	 2019,
+  volume =	 52,
+  issue =	 1,
+  publisher =	 {Routledge},
+  pages =	 {57--78},
+  doi =		 {10.1080/01615440.2018.1526657},
+  status =	 {dh},
+  keywords =	 {dh},
+  pdf =		 {papers/2019-Tolonen.pdf}
+}
+
+@InProceedings{Lahti2018IDA,
+  author =	 {Lahti, Leo},
+  title =	 {Open Data Science},
+  booktitle =	 {Advances in Intelligent Data Analysis XVII. Lecture
+                  Notes in Computer Science 11191.},
+  year =	 2018,
+  volume =	 11191,
+  address =	 {India},
+  publisher =	 {Springer},
+  month =	 {October},
+  publisher =	 {Springer Nature},
+  keywords =	 {openscience},
+  category =	 {perspective},
+  status =	 {openscience},
+  authorship =	 {first},
   pdf =
-                  {https://github.com/openresearchlabs/openresearchlabs.github.io/blob/master/content/publication_resources/papers/2011-JalankaTuovinen-PLoS.pdf},
+                  {https://github.com/openresearchlabs/openresearchlabs.github.io/blob/devel/publications/papers/2018-Lahti-IDA.pdf},
+  note =	 {Conference proceedings.}
+}
+
+@InProceedings{Laitinen2018IDA,
+  author =	 {Laitinen, Ville and Lahti, Leo},
+  title =	 {A hierarchical Ornstein-Uhlenbeck model for
+                  stochastic time series analysis},
+  booktitle =	 {Advances in Intelligent Data Analysis XVII. Lecture
+                  Notes in Computer Science 11191.},
+  year =	 2018,
+  url =		 {https://github.com/velait/OUP},
+  address =	 {India},
+  month =	 {October},
+  publisher =	 {Springer},
+  status =	 {datascience},
+  authorship =	 {pi},
+  pdf =		 {papers/2018-Laitinen-IDA.pdf},
+  note =	 {Conference proceedings.}
+}
+
+@Article{gonze2018,
+  author =	 {Didier Gonze and Katharine Z Coyte and Leo Lahti and
+                  Karoline Faust},
+  title =	 {Microbial communities as dynamical systems},
+  journal =	 {Current Opinion in Microbiology},
+  keywords =	 {review},
+  status =	 {bioscience},
+  year =	 2018,
+  volume =	 44,
+  pages =	 {41-49},
+  month =	 {July},
+  doi =		 {10.1016/j.mib.2018.07.004},
+  pdf =		 {papers/2018-Gonze.pdf}
+}
+
+@Article{Youssef2018,
+  author =	 {Omar Youssef and Leo Lahti and Arto Kokkola and
+                  Tiina Karla and Milja Tikkanen and Homa Ehsan and
+                  Monika Carpelan‑Holmström and Selja Koskensalo and
+                  Tom Böhling and Hilpi Rautelin and Pauli
+                  Puolakkainen and Sakari Knuutila and Virinder
+                  Sarhadi},
+  title =	 {Stool Microbiota Composition Differs in Patients
+                  with Stomach, Colon, and Rectal Neoplasms},
+  journal =	 {Digestive Diseases and Sciences},
+  year =	 2018,
+  volume =	 63,
+  number =	 11,
+  pages =	 {2950--2958},
+  authorship =	 {shared first},
+  month =	 {July},
+  status =	 {bioscience},
+  pdf =		 {papers/2018-Youssef.pdf},
+  doi =		 {10.1007/s10620-018-5190-5}
+}
+
+@Article{openutu2018,
+  key =		 {report},
+  author =	 {University of Turku},
+  title =	 {Turun yliopiston avoimen tutkimuksen politiikka /
+                  Open Research Policy},
+  howpublished = {Report},
+  journal =	 {unknwown},
+  journaltitle = {unknown},
+  status =	 {openscience},
+  category =	 {report},
+  month =	 {May},
+  year =	 2018,
+  pdf =		 {papers/2018-avoimen-tutkimuksen-politiikka-fi.pdf},
+  url =
+                  {https://www.utu.fi/sites/default/files/public\%3A//media/file/ty-avoimen-tutkimuksen-politiikka-fi.pdf},
+  note =	 {(in Finnish)},
+  annote =	 {Member in the work group that developed the report.}
+}
+
+@Article{Faust2018,
+  author =	 {Karoline Faust and Franziska Bauchinger and Beatrice
+                  Laroche and Sophie de Buyl and Leo Lahti and Alex D
+                  Washburne and Didier Gonze and Stefanie Widder},
+  title =	 {Signatures of ecological processes in microbial
+                  community time series},
+  journal =	 {Microbiome},
+  keywords =	 {highlight},
+  status =	 {bioscience},
+  year =	 2018,
+  volume =	 6,
+  number =	 120,
+  month =	 {June},
+  pdf =		 {papers/2018-Faust-Microbiome.pdf},
+  doi =		 {10.1186/s40168-018-0496-2}
+}
+
+@Article{Aatsinki2018,
+  author =	 {Anna-Katariina Aatsinki and Henna-Maria Uusitupa and
+                  Eveliina Munukka and Henri Pesonen and Anniina
+                  Rintala and Sami Pietilä and Leo Lahti and Erkki
+                  Eerola and Linnea Karlsson and Hasse Karlsson},
+  title =	 {Gut Microbiota Composition in Mid-Pregnancy Is
+                  Associated with Gestational Weight Gain but Not
+                  Prepregnancy Body Mass Index},
+  journal =	 {Journal of Womens Health},
+  year =	 2018,
+  month =	 {May},
+  status =	 {bioscience},
+  doi =		 {10.1089/jwh.2017.6488},
+  pdf =		 {papers/2018-Aatsinki.pdf},
+  note =	 {Epub ahead of print.}
+}
+
+@Article{Arani2018,
+  author =	 {Arani, Babak M. S. and Mahmoudi, Mahdi and Lahti,
+                  Leo and Gonz\'alez, Javier and Wit, Ernst C.},
+  title =	 {Stability estimation of autoregulated genes under
+                  Michaelis-Menten type kinetics},
+  journal =	 {Physical Review E},
+  year =	 2018,
+  volume =	 97,
+  number =	 6,
+  pages =	 062407,
+  numpages =	 10,
+  issn =	 {2470-0045},
+  month =	 {Jun},
+  publisher =	 {American Physical Society},
+  status =	 {datascience},
+  pdf =		 {papers/2018-Arani-PhysRevE.pdf},
+  doi =		 {10.1103/PhysRevE.97.062407},
+  url =		 {https://link.aps.org/doi/10.1103/PhysRevE.97.062407}
+}
+
+@article{Tolonen2018gaudeamus,
+  author =	 {Mikko Tolonen and Leo Lahti},
+  title =	 {Digitaaliset ihmistieteet ja historiantutkimus},
+  publisher =	 {Gaudeamus},
+  authorship =	 {second},
+  year =	 {2018},  
+  language =	 {Finnish},
+  note =	 {(in Finnish). In: Hannikainen, MO and Danielsbacka, M and Tepora, T (eds.). Menneisyyden rakentajat. Gaudeamus, Helsinki, 2018.},
+  %editor =	 {Hannikainen, MO and Danielsbacka, M and Tepora, T},
+  %booktitle = {Menneisyyden rakentajat},
+  journaltitle =	 {Menneisyyden rakentajat},
+  status =	 {dh},
+  journal = {Menneisyyden rakentajat},
+  url =		 {https://www.gaudeamus.fi/menneisyyden-rakentajat/},
+  annote = {This is a book chapter but classified as article as could not find a way to include this to CSL automatically generated bibliography yet.}
+}
+
+@Misc{Lahti2006biopax,
+  author =	 {Leo Lahti},
+  title =	 {A brief overview on the BioPAX and SBML standards},
+  howpublished = {arXiv},
+  authorship =	 {first},
+  status =	 {bioscience},
+  category =	 {thesis},
+  year =	 2007,
+  url =		 {https://arxiv.org/abs/1109.4919},
+  arxiv =	 {arXiv:1109.4919 [cs.DS]},
+  note =	 {Overview of machine-readable representations of
+                  biological processes.},
+  language =	 {Finnish},
+  note =	 {(in Finnish)}
+}
+
+@Misc{Lahti2001,
+  author =	 {Leo Lahti},
+  title =	 {Julian joukko iteraatioden valuma-altaan reunana},
+  category =	 {thesis},
+  status =	 {thesis},
+  year =	 2001,
+  url =
+                  {https://github.com/antagomir/thesis/tree/master/julia01},
+  language =	 {Finnish},
+  note =	 {Special assignment in Mathematics (in Finnish)}
+}
+
+@Misc{Lahti2002,
+  author =	 {Leo Lahti},
+  title =	 {Itsesimilaaristen joukkojen Hausdorffin dimension
+                  määrittäminen},
+  category =	 {thesis},
+  year =	 2002,
+  url =
+                  {https://github.com/antagomir/thesis/tree/master/hausdorff02},
+  language =	 {Finnish},
+  note =	 {Special assignment in Mathematics (in Finnish)}
+}
+
+@InProceedings{Hill2018,
+  author =	 {Mark J Hill and Antti Kanner and Jani Marjanen and
+                  Ville Vaara and Eetu Mäkelä and Leo Lahti and Mikko
+                  Tolonen},
+  title =	 {Spheres of “public” in eighteenth-century Britain},
+  booktitle =	 {Proceedings of the Digital Humanities in the Nordics
+                  Conference},
+  status =	 {dh},
+  category =	 {abstract},
+  year =	 2018,
+  address =	 {Helsinki, Finland},
+  month =	 3
+}
+
+@TechReport{Bjork2018,
+  author =	 {Anna Björk and Juho-Matti Paavolainen and Teemu
+                  Ropponen and Mikael Laakso and Leo Lahti},
+  title =	 {Opening academic publishing: development and
+                  application of systematic evaluation criteria},
+  institution =	 {unknown},
+  year =	 2018,
+  publisher =	 {Open Science and Research Initiative (ATT)},
+  month =	 {January},
+  note =	 {Report on the openness of major scientific
+                  publishers commissioned by Finnish Ministry of
+                  Education and Culture},
+  authorship =	 {corresponding},
+  category =	 {report},
+  status =	 {openscience},
+  keywords =	 {openscience},
+  url =		 {http://urn.fi/URN:NBN:fi-fe201802123334},
+  pdf =		 {papers/2018-Bjork-ATT.pdf}
+}
+
+@Article{Buelow2017,
+  author =	 {Elena Buelow and Teresita {d.J.} Bello González and
+                  Susana Fuentes and Wouter A.A. {de Steenhuijsen
+                  Piters} and Leo Lahti and Jumamurat R. Bayjanov and
+                  Eline A.M. Majoor and Johanna C. Braat and Maaike
+                  S. van Mourik and Evelien A.N. Oostdijk and Rob
+                  J.L. Willems and Marc J.M. Bonten and Mark W.J. van
+                  Passel and Hauke Smidt and Willem van Schaik},
+  title =	 {Comparative gut microbiota and resistome profiling
+                  of intensive care patients receiving selective
+                  digestive tract decontamination and healthy
+                  subjects},
+  journal =	 {Microbiome},
+  year =	 2017,
+  volume =	 5,
+  number =	 1,
+  status =	 {bioscience},
+  pages =	 88,
+  month =	 {Aug},
+  pdf =		 {papers/2017-Buelow-Microbiome.pdf},
+  doi =		 {10.1186/s40168-017-0309-z}
+}
+
+@Article{Lahti17phos,
+  author =	 {Leo Lahti and Filipe da Silva and Markus Petteri
+                  Laine and Viivi Lähteenoja and Mikko Tolonen},
+  title =	 {Alchemy & algorithms: perspectives on the philosophy
+                  and history of open science},
+  journal =	 {RIO Journal},
+  year =	 2017,
+  volume =	 3,
+  pages =	 {e13593},
+  month =	 {May},
+  authorship =	 {first, corresponding},
+  category =	 {perspective},
+  keywords =	 {highlight},
+  status =	 {openscience},
+  doi =		 {10.3897/rio.3.e13593},
+  pdf =		 {papers/2017-Lahti-PHOS.pdf},
+  keywords =	 {dh},
+  note =	 {Review of the international conference, including
+                  electronic material (video interviews, lectures and
+                  podcasts.}
+}
+
+@Article{Faust2017,
+  author =	 {Didier Gonze and Leo Lahti and Jeroen Raes and
+                  Karoline Faust},
+  title =	 {Multi-stability and the origin of microbial
+                  community types},
+  journal =	 {ISME Journal},
+  year =	 2017,
+  status =	 {bioscience},
+  keywords =	 {highlight},
+  volume =	 11,
+  pages =	 {2159--2166},
+  pdf =		 {papers/2017-Faust-ISME.pdf},
+  month =	 {may},
+  doi =		 {10.1038/ismej.2017.60}
+}
+
+@Article{Tolonen15EnnenNyt,
+  author =	 {Mikko Tolonen and Leo Lahti},
+  title =	 {Aatehistoria ja digitaalisten aineistojen
+                  mahdollisuudet},
+  journal =	 {Ennen \& Nyt 2},
+  authorship =	 {shared first},
+  year =	 2015,
+  volume =	 2,
+  category =	 {review},
+  language =	 {Finnish},
+  month =	 8,
+  pdf =		 {papers/2015-EnnenNyt-Tolonen.pdf},
+  status =	 {dh},
+  url =
+                  {http://www.ennenjanyt.net/2015/08/aatehistoria-ja-digitaalisten-aineistojen-mahdollisuudet}
+}
+
+@Article{Lahti15LIBER,
+  author =	 {Leo Lahti and Niko Ilom{\"a}ki and Mikko Tolonen},
+  title =	 {A quantitative study of history in the English
+                  short-title catalogue (ESTC) 1470-1800},
+  journal =	 {LIBER Quarterly},
+  year =	 2015,
+  status =	 {dh},
+  volume =	 25,
+  number =	 2,
+  pages =	 {87-116},
+  month =	 12,
+  authorship =	 {first},
+  pdf =		 {papers/2015-Lahti-LIBERQuarterly.pdf},
+  issn =	 {2213-056X},
+  keywords =	 {dh},
+  doi =		 {10.18352/lq.10112}
+}
+
+@Article{Ritari15,
+  author =	 {Jarmo Ritari and Jarkko Salojärvi and Leo Lahti and
+                  Willem M. de Vos},
+  title =	 {Improved taxonomic assignment of human intestinal
+                  16S rRNA sequences by a dedicated reference
+                  database},
+  journal =	 {BMC Genomics},
+  pdf =		 {papers/2015-Ritari-BMCGenomics.pdf},
+  year =	 2015,
+  volume =	 16,
+  status =	 {bioscience},
+  pages =	 1056,
+  month =	 12,
+  doi =		 {10.1186/s12864-015-2265-y}
+}
+
+@InProceedings{Laine15,
+  author =	 {Heidi Laine and Leo Lahti and Anne Lehto and Samuli
+                  Ollila and Markus Miettinen},
+  title =	 {Beyond Open Access - The Changing Culture of
+                  Producing and Disseminating Scientific Knowledge},
+  booktitle =	 {Proceedings of the 19th International Academic
+                  Mindtrek Conference in Tampere, Finland, September
+                  22-24},
+  year =	 2015,
+  address =	 {ACM New York, NY, USA},
+  organization = {AcademicMindTrek'15: Proceedings of the 19th
+                  International Academic Mindtrek Conference},
+  publisher =	 {ACM},
+  authorship =	 {second},
+  address =	 {New York, NY, USA},
+  status =	 {openscience},
+  location =	 {Tampere, Finland},
+  isbn =	 {978-1-4503-3948-3},
+  keywords =	 {openscience},
+  pdf =		 {papers/2015-Laine-Mindtrek.pdf},
+  url =		 {http://dl.acm.org/citation.cfm?id=2818187}
+}
+
+@Article{Su2015,
+  author =	 {Jing Su and Carl Ekman and Nikolay Oskolkov and Leo
+                  Lahti and Kristoffer Ström and Alvis Brazma and Leif
+                  Groop and Johan Rung and and Ola Hansson},
+  title =	 {A novel atlas of gene expression in human skeletal
+                  muscle reveals molecular changes associated with
+                  aging},
+  journal =	 {Skeletal Muscle},
+  status =	 {bioscience},
+  year =	 2015,
+  volume =	 5,
+  number =	 35,
+  doi =		 {10.1186/s13395-015-0059-1},
+  month =	 10,
+  pdf =		 {papers/2015-Su-SkeletalMuscle.pdf}
+}
+
+@Misc{Lahti13icml,
+  author =	 {Leo Lahti, Juuso Parkkinen, Joona Lehtomäki and
+                  Markus Kainu},
+  title =	 {rOpenGov: open source ecosystem for computational
+                  social sciences and digital humanities},
+  keywords =	 {dh, openscience},
+  howpublished = {software},
+  category =	 {abstract},
+  status =	 {datascience},
+  month =	 12,
+  year =	 2013,
+  url =		 {http://ropengov.github.io},
+  note =	 {ICML/MLOSS workshop (Int'l Conf. on Machine Learning
+                  - Open Source Software workshop).}
+}
+
+@Article{Siavash15,
+  author =	 {Siavash Atashgahi and Rozelin Aydin and Mauricio
+                  R. Dimitrov and Detmer Sipkema and Kelly Hamonts and
+                  Leo Lahti and Farai Maphosa and Thomas Kruse and
+                  Edoardo Saccenti and Dirk Springael, Winnie Dejonghe
+                  and Hauke Smidt},
+  title =	 {Impact of a wastewater treatment plant on microbial
+                  community composition and function in a hyporheic
+                  zone of a eutrophic river},
+  journal =	 {Scientific Reports},
+  status =	 {bioscience},
+  year =	 2015,
+  volume =	 5,
+  number =	 17284,
+  month =	 11,
+  doi =		 {10.1038/srep17284},
+  pdf =		 {papers/2015-Atagashi.pdf}
+}
+
+@Article{Faust15,
+  author =	 {Karoline Faust and Leo Lahti and Didier Gonze and
+                  Willem M de Vos and Jeroen Raes},
+  title =	 {Metagenomics meets time series analysis: unraveling
+                  microbial community dynamics},
+  journal =	 {Current Opinion in Microbiology},
+  year =	 2015,
+  volume =	 25,
+  category =	 {review},
+  status =	 {bioscience},
+  keywords =	 {highlight},
+  pages =	 {56--66},
+  month =	 6,
+  authorship =	 {shared first},
+  doi =		 {10.1016/j.mib.2015.04.004},
+  pdf =		 {papers/2015-Faust-CurrOpMicrob.pdf}
+}
+
+@Article{OKeefe15,
+  author =	 {SJD O'Keefe and JV Li and L Lahti and J Ou and F
+                  Carbonero and K Mohammed and JM Posma and J Kinross
+                  and E Wahl and E Ruder and K Vipperla and V Naidoo
+                  and L Mtshali and S Tims and PGB Puylaert, J DeLany
+                  and A Krasinskas and AC Benefiel and HO Kaseb and K
+                  Newton and JK Nicholson and WM de Vos and HR Gaskins
+                  and EG Zoetendal},
+  title =	 {Fat, Fiber and Cancer Risk in African, Americans and
+                  Rural Africans},
+  journal =	 {Nature Communications},
+  year =	 2015,
+  volume =	 6,
+  pages =	 6342,
+  keywords =	 {gut},
+  status =	 {bioscience},
+  keywords =	 {highlight},
+  month =	 {Apr},
+  doi =		 {10.1038/ncomms7342},
+  note =	 {Top science article in Guardian on the release day.},
+  pdf =		 {papers/2015-OKeefe-NComms.pdf},
+  annote =	 {Guardian:
+                  http://www.theguardian.com/science/2015/apr/28/bowel-cancer-risk-may-be-reduced-by-rural-african-diet-study-finds}
+}
+
+@Article{Aleksic14,
+  author =	 {Jelena Aleksic and Adrian Alexa and Teresa K Attwood
+                  and Neil Chue Hong and Martin Dahl{\"o} and Robert
+                  Davey and Holger Dinkel and Konrad U F{\"o}rstner
+                  and Ivo Grigorov and Jean-Karim Hériché and Leo
+                  Lahti and Dan MacLean and Michael L Markie and Jenny
+                  Molloy and Maria Victoria Schneider and Camille
+                  Scott and Richard Smith-Unna and Bruno Miguel
+                  Vieira},
+  keywords =	 {openscience},
+  status =	 {openscience},
+  category =	 {perspective},
+  title =	 {The Open Science Peer Review Oath},
+  journal =	 {F1000Research},
+  year =	 2015,
+  volume =	 3,
+  month =	 1,
+  pages =	 271,
+  note =	 {AllBio: Open Science & Reproducibility Best Practice
+                  Workshop},
+  pdf =		 {papers/2014-Aleksic.pdf},
+  doi =		 {10.12688/f1000research.5686.2}
+}
+
+@Article{Niini12,
+  author =	 {Tarja Niini and Ilari Scheinin and Leo Lahti and
+                  Suvi Savola and Fredrik Mertens and Jaakko Hollmén
+                  and Tom Böhling and Aarne Kivioja and Karolin H Nord
+                  and Sakari Knuutila},
+  title =	 {Homozygous Deletions of Cadherin Genes in
+                  Chondrosarcoma – an Array CGH Study},
+  journal =	 {Cancer Genetics},
+  year =	 2012,
+  volume =	 205,
+  number =	 11,
+  pages =	 {588-93},
+  status =	 {bioscience},
+  month =	 11,
+  doi =		 {10.1016/j.cancergen.2012.09.007},
+  pmid =	 23146407
+}
+
+@Article{Lahti12cmi,
+  author =	 {Anne Salonen and Jarkko Saloj{\"a}rvi and Leo Lahti
+                  and and Willem M. de Vos},
+  title =	 {The adult intestinal core microbiota is determined
+                  by analysis depth and health status},
+  journal =	 {Clinical Microbiology and Infection},
+  year =	 2012,
+  volume =	 18,
+  number =	 {Suppl. 4},
+  status =	 {bioscience},
+  pages =	 {16–20},
+  pdf =		 {papers/2012-Salonen-CMI.pdf},
+  doi =		 {10.1111/j.1469-0691.2012.03855.x},
+}
+
+@Article{Mosakhani12,
+  author =	 {Neda Mosakhani and Leo Lahti and Ioana Borze and
+                  Marja-Liisa Karjalainen-Lindsberg and Jari Sundstrom
+                  and Raija Ristamaki and Pia Osterlund and Sakari
+                  Knuutila and and Virinder Kaur Sarhadi},
+  title =	 {MicroRNA profiling predicts survival in anti-EGFR
+                  treated chemorefractory metastatic colorectal cancer
+                  patients with wild-type KRAS and BRAF},
+  journal =	 {Cancer Genetics},
+  year =	 2012,
+  volume =	 205,
+  number =	 11,
+  pages =	 {545-51},
+  status =	 {bioscience},
+  pdf =		 {papers/2012-Mosakhani-CG.pdf},
+  authorship =	 {second},
+  month =	 11,
+  doi =		 {10.1016/j.cancergen.2012.08.003}
+}
+
+@Article{Lahti2012intcomp,
+  author =	 {Leo Lahti and Martin Sch{\"a}fer and Hans-Ulrich
+                  Klein and Silvio Bicciato and Martin Dugas},
+  title =	 {Cancer gene prioritization by integrative analysis
+                  of mRNA expression and DNA copy number data: a
+                  comparative review},
+  journal =	 {Briefings in Bioinformatics},
+  year =	 2013,
+  volume =	 14,
+  number =	 1,
+  month =	 6,
+  status =	 {bioscience},
+  authorship =	 {first, corresponding},
+  pdf =		 {papers/2013-Lahti-BriefBioinf.pdf},
+  category =	 {review},
+  pages =	 {27--35},
+  doi =		 {10.1093/bib/bbs005}
+}
+
+@Article{Lahti13provasI,
+  author =	 {Leo Lahti and Anne Salonen and Riina A. Kekkonen and
+                  Jarkko Salojärvi and Jonna Jalanka-Tuovinen and Airi
+                  Palva and Matej Orešič and Willem M. de Vos},
+  title =	 {Associations between the human intestinal
+                  microbiota, Lactobacillus rhamnosus GG and serum
+                  lipids indicated by integrated analysis of
+                  high-throughput profiling data},
+  journal =	 {PeerJ},
+  year =	 2013,
+  volume =	 1,
+  pages =	 {e32},
+  status =	 {bioscience},
+  authorship =	 {corresponding, shared first},
+  pdf =		 {papers/2013-Lahti-PeerJ.pdf},
+  doi =		 {10.7717/peerj.32},
+  note =	 {Highly accessed, featured in PeerJ journal blog and
+                  Top-10 Microbiology collection.},
+  pmid =	 23638368
+}
+
+@Article{Sarhadi13,
+  author =	 {Virinder Kaur Sarhadi and Leo Lahti and Ilari
+                  Scheinin and Anne Tyyb{\"a}kinoja and Suvi Savola
+                  and Anu Usvasalo and Riikka R{\"a}ty and Erkki
+                  Elonen and Pekka Ellonen and Ulla M Saarinen-Pihkala
+                  and Sakari Knuutila},
+  status =	 {bioscience},
+  title =	 {Targeted Resequencing of 9p in Acute Lymphoblastic
+                  Leukemia Yields Concordant Results with Array CGH
+                  and Reveals Novel Genomic Alterations},
+  journal =	 {Genomics},
+  pdf =		 {papers/2013-Sarhadi-Genomics.pdf},
+  year =	 2013,
+  volume =	 102,
+  month =	 9,
+  authorship =	 {shared first},
+  number =	 3,
+  pages =	 {182--188},
+  doi =		 {10.1016/j.ygeno.2013.01.001}
+}
+
+@Article{Mosakhani12LL,
+  author =	 {N Mosakhani and VK Sarhadi and A Usvasalo and ML
+                  Karjalainen-Lindsberg and L Lahti and K Tuononen and
+                  UM Saarinen-Pihkala and S Knuutila},
+  title =	 {MicroRNA profiling in pediatric acute lymphoblastic
+                  leukemia: novel prognostic tools},
+  journal =	 {Leukemia \& Lymphoma},
+  year =	 2012,
+  pdf =		 {papers/2012-Mosakhani-LL.pdf},
+  volume =	 53,
+  number =	 12,
+  pages =	 {2517-2520},
+  status =	 {bioscience},
+  month =	 {Dec},
+  doi =		 {10.3109/10428194.2012.685731}
+}
+
+@Article{Harris17,
+  author =	 {Keith Harris and Todd L Parsons and Umer Z Ijaz and
+                  Leo Lahti and Ian Holmes and Christopher Quince},
+  title =	 {Linking statistical and ecological theory: Hubbell's
+                  unified neutral theory of biodiversity as a
+                  hierarchical Dirichlet process},
+  journal =	 {Proceedings of the IEEE},
+  status =	 {bioscience},
+  keywords =	 {highlight},
+  year =	 2017,
+  volume =	 105,
+  number =	 3,
+  pages =	 {516--529},
+  pdf =		 {papers/2017-Harris-IEEE.pdf},
+  month =	 {March},
+  doi =		 {10.1109/JPROC.2015.2428213}
+}
+
+@Article{Alneberg14,
+  author =	 {Johannes Alneberg and Brynjar Smári Bjarnason and
+                  Ino de Bruijn and Melanie Schirmer and Joshua Quick
+                  and Umer Z Ijaz and Leo Lahti and Nicholas J Loman
+                  and Anders F Andersson and Christopher Quince},
+  title =	 {Binning metagenomic contigs by coverage and
+                  composition},
+  journal =	 {Nature Methods},
+  year =	 2014,
+  status =	 {bioscience},
+  keywords =	 {highlight},
+  volume =	 11,
+  number =	 {1144--1146},
+  pdf =		 {papers/2014-Alneberg-NatMeth.pdf},
+  note =	 {CONCOCT algorithm},
+  doi =		 {10.1038/nmeth.3103}
+}
+
+@Article{lahti14natcomm,
+  author =	 {Leo Lahti and Jarkko Saloj{\"a}rvi and Anne Salonen
+                  and Marten Scheffer and Willem M. de Vos},
+  title =	 {Tipping elements in the human intestinal ecosystem},
+  journal =	 {Nature Communications},
+  year =	 2014,
+  volume =	 5,
+  pages =	 4344,
+  pdf =		 {papers/2014-Lahti-NatComm.pdf},
+  month =	 7,
+  authorship =	 {first},
+  status =	 {bioscience},
+  keywords =	 {highlight},
+  doi =		 {10.1038/ncomms5344}
+}
+
+@Article{salonen14,
+  author =	 {Anne Salonen and Leo Lahti and Jarkko Saloj{\"a}rvi
+                  and Grietje Holtrop and Katri Korpela and Sylvia
+                  Duncan and Priya Date and Alexandra Johnstone and
+                  Gerald Lobley and Petra Louis and Harry Flint and
+                  Willem M. de Vos},
+  title =	 {Impact of diet and individual variation on
+                  intestinal microbiota composition and fermentation
+                  products in obese men},
+  journal =	 {ISME Journal},
+  year =	 2014,
+  status =	 {bioscience},
+  volume =	 8,
+  pdf =		 {papers/2014-Salonen-ISME.pdf},
+  authorship =	 {second},
+  pages =	 {2218--2230},
+  doi =		 {10.1038/ismej.2014.63}
+}
+
+@Article{bender13,
+  author =	 {Leo Lahti},
+  title =	 {Intestinal microbiota, individuality and health. In:
+                  Computational Methods Aiding Early-Stage Drug Design
+                  (Dagstuhl Seminar 13212)},
+  pages =	 {78--94},
+  journal =	 {Dagstuhl Reports},
+  ISSN =	 {2192-5283},
+  year =	 2013,
+  volume =	 3,
+  number =	 5,
+  category =	 {abstract},
+  status =	 {bioscience},
+  editor =	 {Andreas Bender and Hinrich G{\"o}hlmann and Sepp
+                  Hochreiter and Ziv Shkedy},
+  publisher =	 {Schloss Dagstuhl--Leibniz-Zentrum fuer Informatik},
+  address =	 {Dagstuhl, Germany},
+  URL =		 {http://drops.dagstuhl.de/opus/volltexte/2013/4179},
+  URN =		 {urn:nbn:de:0030-drops-41791},
+  doi =		 {10.4230/DagRep.3.5.78},
+  annote =	 {Keywords: Bioinformatics, Chemoinformatics, Machine
+                  learning, Statistics, Interdisciplinary
+                  applications. Short abstract for the Dagstuhl
+                  seminar.}
+}
+
+@article{Lahti11rpa,
+  author =	 {Leo Lahti and Laura L. Elo and Tero Aittokallio and
+                  Samuel Kaski},
+  title =	 {Probabilistic Analysis of Probe Reliability in
+                  Differential Gene Expression Studies with Short
+                  Oligonucleotide Arrays},
+  journal =	 {IEEE/ACM Transactions on Computational Biology and
+                  Bioinformatics},
+  year =	 2011,
+  volume =	 8,
+  number =	 1,
+  pages =	 {217--225},
+  month =	 {Jan.-Mar.},
+  status =	 {bioscience},
+  authorship =	 {first, corresponding},
+  doi =		 {10.1109/TCBB.2009.38},
+  pdf =		 {papers/2011-Lahti-TCBB.pdf},
+  publisher =	 {IEEE Computer Society},
+  address =	 {Los Alamitos, CA, USA},
+  annote =	 {R/Bioconductor: RPA}
+}
+
+@Misc{Lahti11-louhos,
+  author =	 {Leo Lahti and Joona Lehtomäki and Juuso Parkkinen
+                  and others},
+  title =	 {Louhos blog},
+  status =	 {blog},
+  url =		 {http://louhos.github.io/},
+  note =	 {Open government data analytics blog (in Finnish)}
+}
+
+@Misc{Lahti13-ropengov,
+  author =	 {Leo Lahti and Joona Lehtomäki and Markus Kainu and
+                  Juuso Parkkinen and others},
+  title =	 {rOpenGov blog},
+  status =	 {blog},
+  url =		 {http://ropengov.github.io/},
+  note =	 {Open government data analytics blog}
+}
+
+@Misc{Lahti11intcomp,
+  author =	 {Leo Lahti and Martin Schäfer and Hans-Ulrich Klein
+                  and Silvio Bicciato and Martin Dugas},
+  title =	 {intcomp: a benchmarking pipeline for integrative
+                  cancer gene detection algorithms},
+  howpublished = {software},
+  status =	 {bioscience},
+  month =	 2,
+  year =	 2011,
+  url =		 {http://intcomp.r-forge.r-project.org/},
+  note =	 {R-forge}
 }
 
 @Article{Jalanka-Tuovinen11,
@@ -774,7 +1649,7 @@
   journal =	 {PLoS One},
   year =	 2011,
   volume =	 6,
-  keywords =	 {bioscience},
+  status =	 {bioscience},
   number =	 7,
   month =	 7,
   pages =	 {e23035},
@@ -782,44 +1657,95 @@
   pdf =		 {papers/2011-JalankaTuovinen-PLoS.pdf},
 }
 
-@article{Jalanka-Tuovinen11,
-  title =	 {Intestinal microbiota in healthy adults: Temporal
-                  analysis reveals individual and common core and
-                  relation to intestinal symptoms},
-  author =	 {Jonna Jalanka-Tuovinen and Anne Salonen and Janne
-                  Nikkil{\"a} and Outi Immonen and Riina Kekkonen and
-                  Leo Lahti and Airi Palva and Willem M. de Vos},
-  year =	 2011,
-  month =	 7,
-  journal =	 {PLoS One},
-  volume =	 6,
-  number =	 7,
-  pages =	 {e23035},
-  url =		 {10.1371/journal.pone.0023035},
-  keywords =	 {bioscience},
-  url =
-                  {https://github.com/openresearchlabs/openresearchlabs.github.io/blob/master/content/publication_resources/papers/2011-JalankaTuovinen-PLoS.pdf}
+@article{Louhimo14,
+  author =	 {Riku Louhimo and Viljami Aittom{\"a}ki and Ali
+                  Faisal and Marko Laakso and Ping Chen and Kristian
+                  Ovaska and Erkka Valo and Leo Lahti and Vladimir
+                  Rogojin and Samuel Kaski and Sampsa Hautaniemi.},
+  journal =	 {Systems Biomedicine (special issue)},
+  volume =	 1,
+  issue =	 2,
+  pages =	 {130--136},
+  status =	 {bioscience},
+  title =	 {Systematic Use of Computational Methods Allows
+                  Stratifying Treatment Responders in Glioblastoma
+                  Multiforme},
+  note =	 {Critical Assessment of Massive Data Analysis (CAMDA)
+                  workshop},
+  year =	 2014,
+  month =	 4,
+  pdf =		 {papers/2014-Louhimo.pdf},
+  doi =		 {10.4161/sysb.28904}
 }
 
-@Article{Kaski05,
-  author =	 {Samuel Kaski and Janne Nikkil{\"a} and Janne
-                  Sinkkonen and Leo Lahti and Juha Knuuttila and
-                  Christophe Roos},
-  title =	 {Associative clustering for exploring dependencies
-                  between functional genomics data sets},
-  journal =	 {IEEE/ACM Transactions on Computational Biology and
-                  Bioinformatics},
-  year =	 2005,
-  volume =	 2,
-  number =	 3,
-  pages =	 {203--216},
-  month =	 {September},
-  status =	 {datascience},
-  note =	 {Special Issue on Machine Learning for Bioinformatics
-                  -- Part 2},
-  doi =		 {10.1109/TCBB.2005.32},
-  pdf =
-                  {https://github.com/openresearchlabs/openresearchlabs.github.io/blob/master/content/publication_resources/papers/2005-TCBB–Kaski-AC.pdf}
+@misc{Lahti11ismb,
+  author =	 {Leo Lahti and Samuel Kaski},
+  title =	 {Probabilistic dependency models for data integration
+                  in functional genomics},
+  category =	 {abstract},
+  authorship =	 {first, corresponding},
+  status =	 {bioscience},
+  pdf =		 {papers/2011-MLSB-Lahti.pdf},
+  month =	 {July},
+  year =	 2011,
+  note =	 {Machine Learning for Systems Biology workshop, ISMB,
+                  Vienna, Austria}
+}
+
+@Article{Nymark11,
+  author =	 {Penny Nymark and Mohamed Guled and Ioana Borze and
+                  Ali Faisal and Leo Lahti and Kaisa Salmenkivi and
+                  Eeva Kettunen and Sisko Anttila and Sakari Knuutila},
+  title =	 {Integrative Analysis of microRNA, mRNA and aCGH Data
+                  Reveals Asbestos- and Histology-Related Changes in
+                  Lung Cancer},
+  journal =	 {Genes, Chromosomes and Cancer},
+  pdf =		 {papers/2011-Nymark-GCC.pdf},
+  year =	 2011,
+  volume =	 50,
+  number =	 8,
+  pages =	 {585--597},
+  month =	 8,
+  status =	 {bioscience},
+  doi =		 {10.1002/gcc.20880}
+}
+
+@Article{Niini11mfh,
+  author =	 {Tarja Niini and Leo Lahti and Francesca Michelacci
+                  and Shinsuke Ninomiya and Claudia Maria Hattinger
+                  and Mohamed Guled and Tom B{\"o}hling and Piero
+                  Picci and Massimo Serra and Sakari Knuutila},
+  title =	 {Array Comparative Genomic Hybridization Reveals
+                  Frequent Alterations of G1/S Checkpoint Genes in
+                  Undifferentiated Pleomorphic Sarcoma of Bone},
+  journal =	 {Genes, Chromosomes and Cancer},
+  year =	 2011,
+  authorship =	 {second},
+  pdf =		 {papers/2011-Niini-GCC.pdf},
+  volume =	 50,
+  number =	 5,
+  month =	 5,
+  pages =	 {291--306},
+  status =	 {bioscience},
+  doi =		 {10.1002/gcc.20851}
+}
+
+@article{Elo05,
+  author =	 {Elo, Laura L. and Lahti, Leo and Skottman, Heli and
+                  Kyl{\"a}niemi, Minna and Lahesmaa, Riitta and
+                  Aittokallio, Tero},
+  title =	 {Integrating probe-level expression changes across
+                  generations of Affymetrix arrays},
+  journal =	 {Nucleic Acids Research},
+  volume =	 33,
+  number =	 22,
+  pages =	 {e193},
+  month =	 12,
+  authorship =	 {second},
+  status =	 {bioscience},
+  doi =		 {10.1093/nar/gni193},
+  pdf =		 {papers/2005-Elo-NAR.pdf},
+  year =	 2005
 }
 
 @Article{Kaski05,
@@ -842,231 +1768,188 @@
   pdf =		 {papers/2005-TCBB–Kaski-AC.pdf}
 }
 
-@article{Kaski05,
-  title =	 {Associative clustering for exploring dependencies
-                  between functional genomics data sets},
-  author =	 {Samuel Kaski and Janne Nikkil{\"a} and Janne
-                  Sinkkonen and Leo Lahti and Juha Knuuttila and
-                  Christophe Roos},
-  year =	 2005,
-  month =	 {September},
-  journal =	 {IEEE/ACM Transactions on Computational Biology and
-                  Bioinformatics},
-  volume =	 2,
-  number =	 3,
-  pages =	 {203--216},
-  doi =		 {10.1109/TCBB.2005.32},
-  note =	 {Special Issue on Machine Learning for Bioinformatics
-                  -- Part 2},
-  keywords =	 {datascience},
+@MastersThesis{Lahti03,
+  author =	 {Lahti, Leo},
+  title =	 {Comparative functional genome analysis using
+                  associative clustering},
+  school =	 {Helsinki University of Technology},
+  year =	 2003,
+  month =	 12,
+  language =	 {Finnish},
   url =
-                  {https://github.com/openresearchlabs/openresearchlabs.github.io/blob/master/content/publication_resources/papers/2005-TCBB–Kaski-AC.pdf}
+                  {https://github.com/antagomir/thesis/tree/master/msc03},
+  pdf =
+                  {https://github.com/antagomir/thesis/blob/master/msc03/dtyo.pdf},
+  category =	 {thesis},
+  note =	 {(in Finnish)}
 }
 
-@Article{Keskitalo2021,
-  author =	 {Keskitalo, A and Aatsinki, A-K and Kortesluoma, S
-                  and Pelto, J and Korhonen, L and Lahti, L and
-                  Lukkarinen, M and Munukka, E and Karlsson, H and
-                  Karlsson, L},
-  title =	 {Gut microbiota diversity but not composition is
-                  related to saliva cortisol stress response at the
-                  age of 2.5 months},
-  journal =	 {Stress},
-  year =	 2021,
-  volume =	 24,
-  number =	 5,
-  pages =	 {551-560},
-  month =	 {March},
-  doi =		 {10.1080/10253890.2021.1895110},
-  note =	 {In press.},
-  keywords =	 {bioscience}
+@Misc{Lahti09bsc,
+  author =	 {Leo Lahti},
+  title =	 {Concerning Blackburn's quasi-realism in securing
+                  moral discussion},
+  howpublished = {B.Sc. thesis. University of Helsinki, Faculty of
+                  Political Sciences},
+  month =	 7,
+  year =	 2009,
+  language =	 {Finnish},
+  category =	 {thesis},
+  pdf =		 {theses/LeoLahti-BSc-2008.pdf},
+  note =	 {(In Finnish)}
 }
 
-@article{Keskitalo2021,
-  title =	 {Gut microbiota diversity but not composition is
-                  related to saliva cortisol stress response at the
-                  age of 2.5 months},
-  author =	 {Keskitalo, A and Aatsinki, A-K and Kortesluoma, S
-                  and Pelto, J and Korhonen, L and Lahti, L and
-                  Lukkarinen, M and Munukka, E and Karlsson, H and
-                  Karlsson, L},
-  year =	 2021,
-  month =	 {March},
-  journal =	 {Stress},
-  volume =	 24,
-  number =	 5,
-  pages =	 {551--560},
-  doi =		 {10.1080/10253890.2021.1895110},
-  note =	 {In press.},
-  keywords =	 {bioscience}
-}
-
-@article{Khalighi2021,
-  title =	 {Three-species Lotka-Volterra model with respect to
-                  Caputo and Caputo-Fabrizio fractional operators},
-  author =	 {Moein Khalighi and Leila Eftekhari and Soleiman
-                  Hosseinpour and Leo Lahti},
-  year =	 2020,
-  month =	 {January},
-  journal =	 {Symmetry},
-  volume =	 13,
-  pages =	 368,
-  doi =		 {10.3390/sym13030368},
-  issue =	 3,
-  keywords =	 {datascience}
-}
-
-@article{Koffert2020,
-  title =	 {Partial restoration of normal intestinal microbiota
-                  in morbidly obese women six months after bariatric
-                  surgery},
-  author =	 {Jukka Koffert and Leo Lahti and Lotta Nylund and
-                  Seppo Salminen and Jarna C Hannukainen and Paulina
-                  Salminen and Willem de Vos and Pirjo Nuutila},
-  year =	 2020,
-  journal =	 {PeerJ – Life & Environment},
+@Article{Nymark07,
+  author =	 {Penny Nymark and Pamela M. Lindholm and Mikko
+                  V. Korpela and Leo Lahti and Salla Ruosaari and
+                  Samuel Kaski and Jaakko Hollmen and Sisko Anttila
+                  and Vuokko L. Kinnula and Sakari Knuutila},
+  title =	 {Gene Expression Profiles in Asbestos-exposed
+                  Epithelial and Mesothelial Lung Cell Lines},
+  journal =	 {BMC Genomics},
+  year =	 2007,
+  month =	 3,
   volume =	 8,
-  pages =	 {e10442},
-  doi =		 {10.7717/peerj.10442},
-  note =	 {Shared first authorship.},
-  keywords =	 {bioscience}
+  number =	 62,
+  status =	 {bioscience},
+  doi =		 {10.1186/1471-2164-8-62},
+  annote =	 {CCA on two asbestos-exposed cell lines.}
 }
 
-@MastersThesis{Lahti03,
-  author =	 {Lahti, Leo},
-  title =	 {Comparative functional genome analysis using
-                  associative clustering},
-  school =	 {Helsinki University of Technology},
-  year =	 2003,
-  month =	 12,
-  language =	 {Finnish},
-  url =
-                  {https://github.com/antagomir/thesis/tree/master/msc03},
-  pdf =
-                  {https://github.com/antagomir/thesis/blob/master/msc03/dtyo.pdf},
-  category =	 {thesis},
-  note =	 {(in Finnish)}
+@TechReport{Sinkkonen05tr,
+  author =	 {Janne Sinkkonen and Samuel Kaski and Janne
+                  Nikkil{\"a} and Leo Lahti},
+  title =	 {Associative Clustering (AC): Technical Details},
+  institution =	 {Helsinki University of Technology},
+  year =	 2005,
+  number =	 {A84},
+  address =	 {Espoo, Finland},
+  month =	 {April},
+  status =	 {datascience},
+  pdf =		 {papers/2005-TechRep-Sinkkonen-ACtechdetails.pdf},
+  note =	 {Publications in Computer and Information Science}
 }
 
-@MastersThesis{Lahti03,
-  author =	 {Lahti, Leo},
-  title =	 {Comparative functional genome analysis using
-                  associative clustering},
-  school =	 {Helsinki University of Technology},
-  year =	 2003,
-  month =	 12,
-  language =	 {Finnish},
-  url =
-                  {https://github.com/antagomir/thesis/tree/master/msc03},
-  pdf =
-                  {https://github.com/antagomir/thesis/blob/master/msc03/dtyo.pdf},
-  category =	 {thesis},
-  note =	 {(in Finnish)}
-}
-
-@mastersthesis{Lahti03,
-  title =	 {Comparative functional genome analysis using
-                  associative clustering},
-  author =	 {Lahti, Leo},
-  year =	 2003,
-  month =	 12,
-  url =
-                  {https://github.com/antagomir/thesis/tree/master/msc03},
-  category =	 {thesis},
-  note =	 {(in Finnish)},
-  school =	 {Helsinki University of Technology},
-  language =	 {Finnish},
-  url =
-                  {https://github.com/antagomir/thesis/blob/master/msc03/dtyo.pdf},
-  keywords =	 {thesis}
-}
-
-@Misc{Lahti09bsc,
-  author =	 {Leo Lahti},
-  title =	 {Concerning Blackburn's quasi-realism in securing
-                  moral discussion},
-  howpublished = {B.Sc. thesis. University of Helsinki, Faculty of
-                  Political Sciences},
-  month =	 7,
-  year =	 2009,
-  language =	 {Finnish},
-  category =	 {thesis},
-  pdf =		 {theses/LeoLahti-BSc-2008.pdf},
-  note =	 {(In Finnish)}
-}
-
-@Misc{Lahti09bsc,
-  author =	 {Leo Lahti},
-  title =	 {Concerning Blackburn's quasi-realism in securing
-                  moral discussion},
-  howpublished = {B.Sc. thesis. University of Helsinki, Faculty of
-                  Political Sciences},
-  month =	 7,
-  year =	 2009,
-  language =	 {Finnish},
-  category =	 {thesis},
-  pdf =		 {theses/LeoLahti-BSc-2008.pdf},
-  note =	 {(In Finnish)}
-}
-
-@misc{Lahti09bsc,
-  title =	 {Concerning Blackburn's quasi-realism in securing
-                  moral discussion},
-  author =	 {Leo Lahti},
-  year =	 2009,
-  month =	 7,
-  category =	 {thesis},
-  keywords =	 {thesis},
-  note =	 {(In Finnish)},
-  howpublished = {B.Sc. thesis. University of Helsinki, Faculty of
-                  Political Sciences},
-  language =	 {Finnish},
-  url =
-                  {https://github.com/openresearchlabs/openresearchlabs.github.io/blob/master/content/publication_resources/theses/LeoLahti-BSc-2008.pdf}
-}
-
-@inproceedings{Lahti09mlsp,
-  title =	 {Dependency detection with similarity constraints},
-  author =	 {Leo Lahti and Samuel Myllykangas and Sakari Knuutila
+@InCollection{Sinkkonen04ecml,
+  author =	 {Janne Sinkkonen and Janne Nikkil\"{a} and Leo Lahti
                   and Samuel Kaski},
-  year =	 2009,
-  booktitle =	 {Proc. MLSP'09 IEEE International Workshop on Machine
-                  Learning for Signal Processing XIX},
-  address =	 {Piscataway, NJ},
-  pages =	 {198--203},
-  url =		 {http://arxiv.org/abs/1101.5919},
-  note =	 {R/Bioconductor: pint},
-  editor =	 {Adali T, Chanussot J, Jutten C, and Larsen J},
-  howpublished = {software},
+  title =	 {Associative Clustering},
+  booktitle =	 {Proceedings of the ECML'04, 15th European Conference
+                  on Machine Learning},
+  editor =	 {Boulicaut and Esposito and Giannotti and Pedreschi},
+  pages =	 {396--406},
+  publisher =	 {Springer},
+  address =	 {Berlin},
+  category =	 {abstract},
+  status =	 {datascience},
+  year =	 2004,
   url =
-                  {https://github.com/openresearchlabs/openresearchlabs.github.io/blob/master/content/publication_resources/papers/2009-MLSP-Lahti-SimCCA.pdf},
+                  {http://www.cis.hut.fi/projects/mi/abstracts/ecml04.html},
+  pdf =		 {papers/2004-ECML-Sinkkonen-AC.pdf}
+}
+
+@TechReport{Sinkkonen03tr,
+  author =	 {Janne Sinkkonen and Janne Nikkil\"{a} and Leo Lahti
+                  and Samuel Kaski},
+  title =	 {Associative Clustering by Maximizing a {B}ayes
+                  Factor},
+  institution =	 {Helsinki University of Technology and Laboratory of
+                  Computer and Information Science},
+  year =	 2003,
+  month =	 6,
+  number =	 {A68},
+  pdf =		 {papers/2003-TechRep-Sinkkonen-ACBayesFactor.pdf},
+  address =	 {Espoo, Finland}
+}
+
+@article{Lahti17eurostat,
+  author =	 {Leo Lahti and Janne Huovari and Markus Kainu and
+                  Przemysław Biecek},
+  title =	 {Retrieval and Analysis of Eurostat Open Data with
+                  the eurostat Package},
+  year =	 2017,
+  journal =	 {The R Journal},
+  url =
+                  {https://journal.r-project.org/archive/2017/RJ-2017-019/index.html},
+  pages =	 {385--392},
+  keywords =	 {dh},
+  software =	 {yes},
+  volume =	 9,
+  number =	 1,
+  status =	 {dh},
+  pdf =		 {papers/2017-Lahti-RJournal.pdf},
+  authorship =	 {first, corresponding},
+  annote =	 {R package homepage URL:
+                  http://ropengov.github.io/eurostat/}
+}
+
+@Article{Shetty2017,
+  author =	 {Shetty, SA and Hugenholtz, F and Lahti, L and Smidt,
+                  H and de Vos, WM and Danchin, A},
+  title =	 {Intestinal microbiome landscaping: Insight in
+                  community assemblage and implications for microbial
+                  modulation strategies},
+  journal =	 {FEMS Microbiology Reviews},
+  volume =	 41,
+  issue =	 2,
+  month =	 {March},
+  status =	 {bioscience},
+  keywords =	 {review},
+  pages =	 {182--199},
+  year =	 2017,
+  pdf =		 {papers/2017-Shetty-FEMS.pdf},
+  pages =	 {fuw045},
+  doi =		 {10.1093/femsre/fuw045}
+}
+
+@Article{sarhadi14,
+  author =	 {Virinder Sarhadi and Leo Lahti and Ilari Scheinin
+                  and Pekka Ellonen and Eeva Kettunen and Massimo
+                  Serra and Katia Scotlandi and Pierro Picci and
+                  Sakari Knuutila},
+  title =	 {Copy Number Alterations and Neoplasia Specific
+                  Mutations in MELK, PDCD1LG2, TLN1, and PAX5 at 9p in
+                  Different Neoplasias},
+  journal =	 {Genes, Chromosomes and Cancer},
+  year =	 2014,
+  volume =	 53,
+  number =	 7,
+  pages =	 {579--588},
+  month =	 7,
+  authorship =	 {second},
+  doi =		 {10.1002/gcc.22168}
+}
+
+@Article{Lahti13nar,
+  author =	 {Leo Lahti and Aurora Torrente and Laura L Elo and
+                  Alvis Brazma and Johan Rung},
+  title =	 {A fully scalable online pre-processing algorithm for
+                  short oligonucleotide microarray atlases},
+  journal =	 {Nucleic Acids Research},
+  volume =	 41,
+  number =	 10,
+  year =	 2013,
+  pages =	 {e110},
+  pdf =		 {papers/2013-Lahti-NAR.pdf},
   authorship =	 {first, corresponding},
   doi =		 {10.1093/nar/gkt229},
   note =	 {Implementation available through Bioconductor RPA
                   package.}
 }
 
-@InProceedings{Lahti09mlsp,
-  author =	 {Leo Lahti and Samuel Myllykangas and Sakari Knuutila
-                  and Samuel Kaski},
-  title =	 {Dependency detection with similarity constraints},
-  editor =	 {Adali T, Chanussot J, Jutten C, and Larsen J},
-  booktitle =	 {Proc. MLSP'09 IEEE International Workshop on Machine
-                  Learning for Signal Processing XIX},
-  year =	 2009,
-  howpublished = {software},
-  pages =	 {198--203},
-  address =	 {Piscataway, NJ},
-  pdf =		 {papers/2009-MLSP-Lahti-SimCCA.pdf},
-  note =	 {R/Bioconductor: pint},
-  authorship =	 {first, corresponding},
-  url =		 {http://arxiv.org/abs/1101.5919},
-  arxiv =	 {1101.5919}
+@InProceedings{Faisal2011,
+  author =	 {Ali Faisal and Riku Louhimo and Leo Lahti and Sampsa
+                  Hautaniemi and Samuel Kaski},
+  title =	 {Biomarker discovery via dependency analysis of
+                  multi-view functional genomics data},
+  booktitle =	 {NIPS 2011 workshop From Statistical Genetics to
+                  Predictive Models in Personalized Medicine},
+  category =	 {abstract},
+  status =	 {bioscience},
+  pdf =		 {papers/2011-Faisal-NIPS.pdf},
+  year =	 2011
 }
 
-@misc{Lahti09rpa,
-  title =	 {RPA: probe reliability and differential gene
-                  expression analysis},
+@PhdThesis{Lahti10thesis,
   author =	 {Leo Lahti},
   title =	 {Probabilistic analysis of the human transcriptome
                   with side information},
@@ -1092,8 +1975,7 @@
                   learning, computational biology, open source, open
                   access, creative commons},
   url =		 {http://lib.tkk.fi/Diss/2010/isbn9789526033686/},
-  pdf =
-                  {https://github.com/openresearchlabs/openresearchlabs.github.io/blob/master/content/publication_resources/papers/2010-Lahti-thesis.pdf},
+  pdf =		 {papers/2010-Lahti-thesis.pdf},
   issn =	 {1797-5069},
   abstract =	 {Recent advances in high-throughput measurement
                   technologies and efficient sharing of biomedical
@@ -1159,1691 +2041,16 @@
   pages =	 {2713--2720},
   volume =	 26,
   issue =	 21,
-  keywords =	 {bioscience},
+  status =	 {bioscience},
   authorship =	 {first},
   month =	 11,
   note =	 {R/Matlab implementations available at
                   http://netpro.r-forge.r-project.org/},
-  year =	 2009,
-  month =	 {October},
-  doi =		 {10.18129/B9.BIOC.RPA},
   url =
                   {http://bioinformatics.oxfordjournals.org/content/early/2010/09/02/bioinformatics.btq500.abstract.html?ijkey=N1zzjtUBRng3wCM&keytype=ref},
-  pdf =
-                  {https://github.com/openresearchlabs/openresearchlabs.github.io/blob/master/content/publication_resources/papers/2010-Bioinformatics-Lahti-NetResponse.pdf},
+  pdf =		 {papers/2010-Bioinformatics-Lahti-NetResponse.pdf},
   annote =	 {ArXiv: http://arxiv.org/abs/1202.0501; R/Matlab
                   source code http://netpro.r-forge.r-project.org}
-}
-
-@article{Lahti10bioinf,
-  title =	 {Global modeling of transcriptional responses in
-                  interaction networks},
-  author =	 {Leo Lahti and Juha E.A. Knuuttila and Samuel Kaski},
-  year =	 2010,
-  month =	 11,
-  journal =	 {Bioinformatics},
-  volume =	 26,
-  pages =	 {2713--2720},
-  doi =		 {10.1093/bioinformatics/btq500},
-  url =
-                  {http://bioinformatics.oxfordjournals.org/content/early/2010/09/02/bioinformatics.btq500.abstract.html?ijkey=N1zzjtUBRng3wCM&keytype=ref},
-  note =	 {R/Matlab implementations available at
-                  http://netpro.r-forge.r-project.org/},
-  issue =	 21,
-  keywords =	 {bioscience},
-  authorship =	 {first},
-  url =
-                  {https://github.com/openresearchlabs/openresearchlabs.github.io/blob/master/content/publication_resources/papers/2010-Bioinformatics-Lahti-NetResponse.pdf},
-  annote =	 {ArXiv: http://arxiv.org/abs/1202.0501; R/Matlab
-                  source code http://netpro.r-forge.r-project.org}
-}
-
-@Article{Lahti10bioinf,
-  author =	 {Leo Lahti and Juha E.A. Knuuttila and Samuel Kaski},
-  title =	 {Global modeling of transcriptional responses in
-                  interaction networks},
-  journal =	 {Bioinformatics},
-  year =	 2010,
-  doi =		 {10.1093/bioinformatics/btq500},
-  pages =	 {2713--2720},
-  volume =	 26,
-  issue =	 21,
-  keywords =	 {bioscience},
-  authorship =	 {first},
-  month =	 11,
-  note =	 {R/Matlab implementations available at
-                  http://netpro.r-forge.r-project.org/}
-}
-
-@misc{Lahti10blog,
-  title =	 {opencomp blog},
-  author =	 {Leo Lahti},
-  url =		 {http://antagomir.wordpress.com/},
-  category =	 {blog},
-  keywords =	 {blog}
-}
-
-@Misc{Lahti10blog,
-  author =	 {Leo Lahti},
-  title =	 {opencomp blog},
-  category =	 {blog},
-  url =		 {http://antagomir.wordpress.com/}
-}
-
-@misc{Lahti10dmt,
-  title =	 {Dependency modeling toolkit},
-  author =	 {Leo Lahti and Abhishek Tripathi and Olli-Pekka
-                  Huovilainen},
-  year =	 2010,
-  month =	 6,
-  publisher =	 {ICML workshop},
-  url =		 {http://dmt.r-forge.r-project.org/},
-  note =	 {CRAN: dmt},
-  howpublished = {software},
-  keywords =	 {datascience}
-}
-
-@misc{Lahti10netresponse,
-  title =	 {NetResponse (functional network analysis)},
-  author =	 {Leo Lahti and Antonio Gusmao and Olli-Pekka
-                  Huovilainen},
-  year =	 2010,
-  month =	 {October},
-  doi =		 {10.18129/B9.BIOC.NETRESPONSE},
-  url =
-                  {http://www.bioconductor.org/help/bioc-views/devel/bioc/html/netresponse.html},
-  note =	 {R/Bioconductor: netresponse},
-  keywords =	 {datascience},
-  howpublished = {software}
-}
-
-@misc{Lahti10pint,
-  title =	 {Pairwise integration of functional genomics data},
-  author =	 {Olli-Pekka Huovilainen and Leo Lahti},
-  year =	 2010,
-  month =	 {April},
-  url =
-                  {http://bioconductor.org/packages/devel/bioc/html/pint.html},
-  note =	 {R/BioConductor: pint},
-  keywords =	 {datascience},
-  howpublished = {software}
-}
-
-@phdthesis{Lahti10thesis,
-  title =	 {Probabilistic analysis of the human transcriptome
-                  with side information},
-  author =	 {Leo Lahti},
-  year =	 2010,
-  month =	 12,
-  address =	 {Espoo},
-  series =	 {TKK Dissertations in Information and Computer
-                  Science},
-  number =	 {TKK-ICS-D19},
-  issn =	 {1797-5069},
-  url =		 {http://lib.tkk.fi/Diss/2010/isbn9789526033686/},
-  category =	 {thesis},
-  note =	 {LaTeX sources and the pdf version are openly
-                  available:
-                  https://github.com/antagomir/thesis/tree/master/phd10;
-                  Press release:
-                  https://github.com/antagomir/thesis/blob/master/phd10/Vaitostiedote-LeoLahti-20101207.pdf},
-  school =	 {Aalto University School of Science and Technology,
-                  Faculty of Information and Natural Sciences,
-                  Department of Information and Computer Science},
-  language =	 {Finnish},
-  keywords =	 {thesis, probabilistic models, Bayesian analysis,
-                  data integration, gene expression, microarrays,
-                  computational science, data analysis, machine
-                  learning, computational biology, open source, open
-                  access, creative commons},
-  url =
-                  {https://github.com/openresearchlabs/openresearchlabs.github.io/blob/master/content/publication_resources/papers/2010-Lahti-thesis.pdf},
-  abstract =	 {Recent advances in high-throughput measurement
-                  technologies and efficient sharing of biomedical
-                  data through community databases have made it
-                  possible to investigate the complete collection of
-                  genetic material, the genome, which encodes the
-                  heritable genetic program of an organism. This has
-                  opened up new views to the study of living organisms
-                  with a profound impact on biological
-                  research. Functional genomics is a subdiscipline of
-                  molecular biology that investigates the functional
-                  organization of genetic information.  This thesis
-                  develops computational strategies to investigate a
-                  key functional layer of the genome, the
-                  transcriptome. The time- and context-specific
-                  transcriptional activity of the genes regulates the
-                  function of living cells through protein
-                  synthesis. Efficient computational techniques are
-                  needed in order to extract useful information from
-                  high-dimensional genomic observations that are
-                  associated with high levels of complex
-                  variation. Statistical learning and probabilistic
-                  models provide the theoretical framework for
-                  combining statistical evidence across multiple
-                  observations and the wealth of background
-                  information in genomic data repositories.  This
-                  thesis addresses three key challenges in
-                  transcriptome analysis. First, new preprocessing
-                  techniques that utilize side information in genomic
-                  sequence databases and microarray collections are
-                  developed to improve the accuracy of high-throughput
-                  microarray measurements.  Second, a novel
-                  exploratory approach is proposed in order to
-                  construct a global view of cell-biological network
-                  activation patterns and functional relatedness
-                  between tissues across normal human
-                  body. Information in genomic interaction databases
-                  is used to derive constraints that help to focus the
-                  modeling in those parts of the data that are
-                  supported by known or potential interactions between
-                  the genes, and to scale up the analysis. The third
-                  contribution is to develop novel approaches to model
-                  dependency between co-occurring measurement
-                  sources. The methods are used to study cancer
-                  mechanisms and transcriptome evolution; integrative
-                  analysis of the human transcriptome and other layers
-                  of genomic information allows the identification of
-                  functional mechanisms and interactions that could
-                  not be detected based on the individual measurement
-                  sources. Open source implementations of the key
-                  methodological contributions have been released to
-                  facilitat e their further adoption by the research
-                  community.}
-}
-
-@Misc{Lahti11-louhos,
-  author =	 {Leo Lahti and Joona Lehtomäki and Juuso
-                  Parkkinen and others},
-  title =	 {Louhos blog},
-  status =	 {blog},
-  url =		 {http://louhos.github.io/},
-  note =	 {Open government data analytics blog (in Finnish)}
-}
-
-@Misc{Lahti11-louhos,
-  author =	 {Leo Lahti and Joona Lehtomäki and Juuso
-                  Parkkinen and others},
-  title =	 {Louhos blog},
-  status =	 {blog},
-  url =		 {http://louhos.github.io/},
-  note =	 {Open government data analytics blog (in Finnish)}
-}
-
-@misc{Lahti11-louhos,
-  title =	 {Louhos blog},
-  author =	 {Leo Lahti and Joona Lehtomäki and Juuso
-                  Parkkinen and others},
-  url =		 {http://louhos.github.io/},
-  note =	 {Open government data analytics blog (in Finnish)},
-  keywords =	 {blog}
-}
-
-@Misc{Lahti11intcomp,
-  author =	 {Leo Lahti and Martin Schäfer and Hans-Ulrich
-                  Klein and Silvio Bicciato and Martin Dugas},
-  title =	 {intcomp: a benchmarking pipeline for integrative
-                  cancer gene detection algorithms},
-  howpublished = {software},
-  keywords =	 {bioscience},
-  month =	 2,
-  year =	 2011,
-  url =		 {http://intcomp.r-forge.r-project.org/},
-  note =	 {R-forge}
-}
-
-@Misc{Lahti11intcomp,
-  author =	 {Leo Lahti and Martin Schäfer and Hans-Ulrich
-                  Klein and Silvio Bicciato and Martin Dugas},
-  title =	 {intcomp: a benchmarking pipeline for integrative
-                  cancer gene detection algorithms},
-  howpublished = {software},
-  keywords =	 {bioscience},
-  month =	 2,
-  year =	 2011,
-  url =		 {http://intcomp.r-forge.r-project.org/},
-  note =	 {R-forge}
-}
-
-@misc{Lahti11intcomp,
-  title =	 {intcomp: a benchmarking pipeline for integrative
-                  cancer gene detection algorithms},
-  author =	 {Leo Lahti and Martin Schäfer and Hans-Ulrich
-                  Klein and Silvio Bicciato and Martin Dugas},
-  year =	 2011,
-  month =	 2,
-  url =		 {http://intcomp.r-forge.r-project.org/},
-  note =	 {R-forge},
-  howpublished = {software},
-  keywords =	 {bioscience}
-}
-
-@misc{Lahti11ismb,
-  author =	 {Leo Lahti and Samuel Kaski},
-  title =	 {Probabilistic dependency models for data integration
-                  in functional genomics},
-  category =	 {abstract},
-  authorship =	 {first, corresponding},
-  keywords =	 {bioscience},
-  pdf =
-                  {https://github.com/openresearchlabs/openresearchlabs.github.io/blob/master/content/publication_resources/papers/2011-MLSB-Lahti.pdf},
-  month =	 {July},
-  year =	 2011,
-  note =	 {Machine Learning for Systems Biology workshop, ISMB,
-                  Vienna, Austria}
-}
-
-@misc{Lahti11ismb,
-  author =	 {Leo Lahti and Samuel Kaski},
-  title =	 {Probabilistic dependency models for data integration
-                  in functional genomics},
-  category =	 {abstract},
-  authorship =	 {first, corresponding},
-  keywords =	 {bioscience},
-  pdf =		 {papers/2011-MLSB-Lahti.pdf},
-  month =	 {July},
-  year =	 2011,
-  note =	 {Machine Learning for Systems Biology workshop, ISMB,
-                  Vienna, Austria}
-}
-
-@misc{Lahti11ismb,
-  title =	 {Probabilistic dependency models for data integration
-                  in functional genomics},
-  author =	 {Leo Lahti and Samuel Kaski},
-  year =	 2011,
-  month =	 {July},
-  category =	 {abstract},
-  note =	 {Machine Learning for Systems Biology workshop, ISMB,
-                  Vienna, Austria},
-  authorship =	 {first, corresponding},
-  keywords =	 {bioscience},
-  url =
-                  {https://github.com/openresearchlabs/openresearchlabs.github.io/blob/master/content/publication_resources/papers/2011-MLSB-Lahti.pdf}
-}
-
-@article{Lahti11rpa,
-  author =	 {Leo Lahti and Laura L. Elo and Tero Aittokallio and
-                  Samuel Kaski},
-  title =	 {Probabilistic Analysis of Probe Reliability in
-                  Differential Gene Expression Studies with Short
-                  Oligonucleotide Arrays},
-  journal =	 {IEEE/ACM Transactions on Computational Biology and
-                  Bioinformatics},
-  year =	 2011,
-  volume =	 8,
-  number =	 1,
-  pages =	 {217--225},
-  month =	 {Jan.-Mar.},
-  keywords =	 {bioscience},
-  authorship =	 {first, corresponding},
-  doi =		 {10.1109/TCBB.2009.38},
-  pdf =
-                  {https://github.com/openresearchlabs/openresearchlabs.github.io/blob/master/content/publication_resources/papers/2011-Lahti-TCBB.pdf},
-  publisher =	 {IEEE Computer Society},
-  address =	 {Los Alamitos, CA, USA},
-  annote =	 {R/Bioconductor: RPA}
-}
-
-@article{Lahti11rpa,
-  author =	 {Leo Lahti and Laura L. Elo and Tero Aittokallio and
-                  Samuel Kaski},
-  title =	 {Probabilistic Analysis of Probe Reliability in
-                  Differential Gene Expression Studies with Short
-                  Oligonucleotide Arrays},
-  journal =	 {IEEE/ACM Transactions on Computational Biology and
-                  Bioinformatics},
-  year =	 2011,
-  volume =	 8,
-  number =	 1,
-  pages =	 {217--225},
-  month =	 {Jan.-Mar.},
-  keywords =	 {bioscience},
-  authorship =	 {first, corresponding},
-  doi =		 {10.1109/TCBB.2009.38},
-  pdf =		 {papers/2011-Lahti-TCBB.pdf},
-  publisher =	 {IEEE Computer Society},
-  address =	 {Los Alamitos, CA, USA},
-  annote =	 {R/Bioconductor: RPA}
-}
-
-@article{Lahti11rpa,
-  title =	 {Probabilistic Analysis of Probe Reliability in
-                  Differential Gene Expression Studies with Short
-                  Oligonucleotide Arrays},
-  author =	 {Leo Lahti and Laura L. Elo and Tero Aittokallio and
-                  Samuel Kaski},
-  year =	 2011,
-  month =	 {Jan.-Mar.},
-  journal =	 {IEEE/ACM Transactions on Computational Biology and
-                  Bioinformatics},
-  publisher =	 {IEEE Computer Society},
-  address =	 {Los Alamitos, CA, USA},
-  volume =	 8,
-  number =	 1,
-  pages =	 {217--225},
-  doi =		 {10.1109/TCBB.2009.38},
-  keywords =	 {bioscience},
-  authorship =	 {first, corresponding},
-  url =
-                  {https://github.com/openresearchlabs/openresearchlabs.github.io/blob/master/content/publication_resources/papers/2011-Lahti-TCBB.pdf},
-  annote =	 {R/Bioconductor: RPA}
-}
-
-@Article{Lahti12cmi,
-  author =	 {Anne Salonen and Jarkko Saloj{\"a}rvi and Leo Lahti
-                  and and Willem M. de Vos},
-  title =	 {The adult intestinal core microbiota is determined
-                  by analysis depth and health status},
-  journal =	 {Clinical Microbiology and Infection},
-  year =	 2012,
-  volume =	 18,
-  number =	 {Suppl. 4},
-  keywords =	 {bioscience},
-  pages =	 {16–20},
-  pdf =
-                  {https://github.com/openresearchlabs/openresearchlabs.github.io/blob/master/content/publication_resources/papers/2012-Salonen-CMI.pdf},
-  doi =		 {10.1111/j.1469-0691.2012.03855.x},
-}
-
-@Article{Lahti12cmi,
-  author =	 {Anne Salonen and Jarkko Saloj{\"a}rvi and Leo Lahti
-                  and and Willem M. de Vos},
-  title =	 {The adult intestinal core microbiota is determined
-                  by analysis depth and health status},
-  journal =	 {Clinical Microbiology and Infection},
-  year =	 2012,
-  volume =	 18,
-  number =	 {Suppl. 4},
-  keywords =	 {bioscience},
-  pages =	 {16–20},
-  pdf =		 {papers/2012-Salonen-CMI.pdf},
-  doi =		 {10.1111/j.1469-0691.2012.03855.x},
-}
-
-@article{Lahti12cmi,
-  title =	 {The adult intestinal core microbiota is determined
-                  by analysis depth and health status},
-  author =	 {Anne Salonen and Jarkko Saloj{\"a}rvi and Leo Lahti
-                  and and Willem M. de Vos},
-  year =	 2012,
-  journal =	 {Clinical Microbiology and Infection},
-  volume =	 18,
-  number =	 {Suppl. 4},
-  pages =	 {16–20},
-  doi =		 {10.1111/j.1469-0691.2012.03855.x},
-  keywords =	 {bioscience},
-  url =
-                  {https://github.com/openresearchlabs/openresearchlabs.github.io/blob/master/content/publication_resources/papers/2012-Salonen-CMI.pdf}
-}
-
-@Misc{Lahti13-ropengov,
-  author =	 {Leo Lahti and Joona Lehtomäki and Markus
-                  Kainu and Juuso Parkkinen and others},
-  title =	 {rOpenGov blog},
-  status =	 {blog},
-  url =		 {http://ropengov.github.io/},
-  note =	 {Open government data analytics blog}
-}
-
-@Misc{Lahti13-ropengov,
-  author =	 {Leo Lahti and Joona Lehtomäki and Markus
-                  Kainu and Juuso Parkkinen and others},
-  title =	 {rOpenGov blog},
-  status =	 {blog},
-  url =		 {http://ropengov.github.io/},
-  note =	 {Open government data analytics blog}
-}
-
-@misc{Lahti13-ropengov,
-  title =	 {rOpenGov blog},
-  author =	 {Leo Lahti and Joona Lehtomäki and Markus
-                  Kainu and Juuso Parkkinen and others},
-  url =		 {http://ropengov.github.io/},
-  note =	 {Open government data analytics blog},
-  keywords =	 {blog}
-}
-
-@Misc{Lahti13icml,
-  author =	 {Leo Lahti, Juuso Parkkinen, Joona Lehtomäki
-                  and Markus Kainu},
-  title =	 {rOpenGov: open source ecosystem for computational
-                  social sciences and digital humanities},
-  keywords =	 {dh, openscience},
-  howpublished = {software},
-  category =	 {abstract},
-  status =	 {datascience},
-  month =	 12,
-  year =	 2013,
-  url =		 {http://ropengov.github.io},
-  note =	 {ICML/MLOSS workshop (Int'l Conf. on Machine Learning
-                  - Open Source Software workshop).}
-}
-
-@Misc{Lahti13icml,
-  author =	 {Leo Lahti, Juuso Parkkinen, Joona Lehtomäki
-                  and Markus Kainu},
-  title =	 {rOpenGov: open source ecosystem for computational
-                  social sciences and digital humanities},
-  keywords =	 {dh, openscience},
-  howpublished = {software},
-  category =	 {abstract},
-  status =	 {datascience},
-  month =	 12,
-  year =	 2013,
-  url =		 {http://ropengov.github.io},
-  note =	 {ICML/MLOSS workshop (Int'l Conf. on Machine Learning
-                  - Open Source Software workshop).}
-}
-
-@misc{Lahti13icml,
-  title =	 {rOpenGov: open source ecosystem for computational
-                  social sciences and digital humanities},
-  author =	 {Leo Lahti, Juuso Parkkinen, Joona Lehtomäki
-                  and Markus Kainu},
-  year =	 2013,
-  month =	 12,
-  url =		 {http://ropengov.github.io},
-  category =	 {abstract},
-  note =	 {ICML/MLOSS workshop (Int'l Conf. on Machine Learning
-                  - Open Source Software workshop).},
-  keywords =	 {dh},
-  howpublished = {software},
-  keywords =	 {datascience}
-}
-
-@Article{Lahti13nar,
-  author =	 {Leo Lahti and Aurora Torrente and Laura L Elo and
-                  Alvis Brazma and Johan Rung},
-  title =	 {A fully scalable online pre-processing algorithm for
-                  short oligonucleotide microarray atlases},
-  journal =	 {Nucleic Acids Research},
-  volume =	 41,
-  number =	 10,
-  year =	 2013,
-  pages =	 {e110},
-  pdf =
-                  {https://github.com/openresearchlabs/openresearchlabs.github.io/blob/master/content/publication_resources/papers/2013-Lahti-NAR.pdf},
-}
-
-@Article{Lahti13nar,
-  author =	 {Leo Lahti and Aurora Torrente and Laura L Elo and
-                  Alvis Brazma and Johan Rung},
-  title =	 {A fully scalable online pre-processing algorithm for
-                  short oligonucleotide microarray atlases},
-  journal =	 {Nucleic Acids Research},
-  volume =	 41,
-  number =	 10,
-  year =	 2013,
-  pages =	 {e110},
-  pdf =		 {papers/2013-Lahti-NAR.pdf}
-}
-
-@article{Lahti13nar,
-  title =	 {A fully scalable online pre-processing algorithm for
-                  short oligonucleotide microarray atlases},
-  author =	 {Leo Lahti and Aurora Torrente and Laura L Elo and
-                  Alvis Brazma and Johan Rung},
-  year =	 2013,
-  journal =	 {Nucleic Acids Research},
-  volume =	 41,
-  number =	 10,
-  pages =	 {e110},
-  doi =		 {10.1093/nar/gkt229},
-  note =	 {Implementation available through Bioconductor RPA
-                  package.},
-  url =
-                  {https://github.com/openresearchlabs/openresearchlabs.github.io/blob/master/content/publication_resources/papers/2013-Lahti-NAR.pdf},
-  authorship =	 {first, corresponding},
-  keywords =	 {bioscience}
-}
-
-@Article{Lahti13provasI,
-  author =	 {Leo Lahti and Anne Salonen and Riina A. Kekkonen and
-                  Jarkko Salojärvi and Jonna Jalanka-Tuovinen
-                  and Airi Palva and Matej Orešič and
-                  Willem M. de Vos},
-  title =	 {Associations between the human intestinal
-                  microbiota, Lactobacillus rhamnosus GG and serum
-                  lipids indicated by integrated analysis of
-                  high-throughput profiling data},
-  journal =	 {PeerJ},
-  year =	 2013,
-  volume =	 1,
-  pages =	 {e32},
-  keywords =	 {bioscience},
-  authorship =	 {corresponding, shared first},
-  pdf =
-                  {https://github.com/openresearchlabs/openresearchlabs.github.io/blob/master/content/publication_resources/papers/2013-Lahti-PeerJ.pdf},
-  doi =		 {10.7717/peerj.32},
-  note =	 {Highly accessed, featured in PeerJ journal blog and
-                  Top-10 Microbiology collection.},
-  pmid =	 23638368
-}
-
-@Article{Lahti13provasI,
-  author =	 {Leo Lahti and Anne Salonen and Riina A. Kekkonen and
-                  Jarkko Salojärvi and Jonna Jalanka-Tuovinen
-                  and Airi Palva and Matej Orešič and
-                  Willem M. de Vos},
-  title =	 {Associations between the human intestinal
-                  microbiota, Lactobacillus rhamnosus GG and serum
-                  lipids indicated by integrated analysis of
-                  high-throughput profiling data},
-  journal =	 {PeerJ},
-  year =	 2013,
-  volume =	 1,
-  pages =	 {e32},
-  keywords =	 {bioscience},
-  authorship =	 {corresponding, shared first},
-  pdf =		 {papers/2013-Lahti-PeerJ.pdf},
-  doi =		 {10.7717/peerj.32},
-  note =	 {Highly accessed, featured in PeerJ journal blog and
-                  Top-10 Microbiology collection.},
-  pmid =	 23638368
-}
-
-@article{Lahti13provasI,
-  title =	 {Associations between the human intestinal
-                  microbiota, Lactobacillus rhamnosus GG and serum
-                  lipids indicated by integrated analysis of
-                  high-throughput profiling data},
-  author =	 {Leo Lahti and Anne Salonen and Riina A. Kekkonen and
-                  Jarkko Salojärvi and Jonna Jalanka-Tuovinen
-                  and Airi Palva and Matej Orešič and
-                  Willem M. de Vos},
-  year =	 2013,
-  journal =	 {PeerJ},
-  volume =	 1,
-  pages =	 {e32},
-  doi =		 {10.7717/peerj.32},
-  note =	 {Highly accessed, featured in PeerJ journal blog and
-                  Top-10 Microbiology collection.},
-  keywords =	 {bioscience},
-  authorship =	 {corresponding, shared first},
-  url =
-                  {https://github.com/openresearchlabs/openresearchlabs.github.io/blob/master/content/publication_resources/papers/2013-Lahti-PeerJ.pdf},
-  pmid =	 23638368
-}
-
-@Article{Lahti15LIBER,
-  author =	 {Leo Lahti and Niko Ilom{\"a}ki and Mikko Tolonen},
-  title =	 {A quantitative study of history in the English
-                  short-title catalogue (ESTC) 1470-1800},
-  journal =	 {LIBER Quarterly},
-  year =	 2015,
-  status =	 {dh},
-  volume =	 25,
-  number =	 2,
-  pages =	 {87-116},
-  month =	 12,
-  authorship =	 {first},
-  pdf =
-                  {https://github.com/openresearchlabs/openresearchlabs.github.io/blob/master/content/publication_resources/papers/2015-Lahti-LIBERQuarterly.pdf},
-  issn =	 {2213-056X},
-  keywords =	 {dh},
-  doi =		 {10.18352/lq.10112}
-}
-
-@Article{Lahti15LIBER,
-  author =	 {Leo Lahti and Niko Ilom{\"a}ki and Mikko Tolonen},
-  title =	 {A quantitative study of history in the English
-                  short-title catalogue (ESTC) 1470-1800},
-  journal =	 {LIBER Quarterly},
-  year =	 2015,
-  status =	 {dh},
-  volume =	 25,
-  number =	 2,
-  pages =	 {87-116},
-  month =	 12,
-  authorship =	 {first},
-  pdf =		 {papers/2015-Lahti-LIBERQuarterly.pdf},
-  issn =	 {2213-056X},
-  keywords =	 {dh},
-  doi =		 {10.18352/lq.10112}
-}
-
-@article{Lahti15LIBER,
-  title =	 {A quantitative study of history in the English
-                  short-title catalogue (ESTC) 1470-1800},
-  author =	 {Leo Lahti and Niko Ilom{\"a}ki and Mikko Tolonen},
-  year =	 2015,
-  month =	 12,
-  journal =	 {LIBER Quarterly},
-  volume =	 25,
-  number =	 2,
-  pages =	 {87--116},
-  doi =		 {10.18352/lq.10112},
-  issn =	 {2213-056X},
-  status =	 {dh},
-  authorship =	 {first},
-  url =
-                  {https://github.com/openresearchlabs/openresearchlabs.github.io/blob/master/content/publication_resources/papers/2015-Lahti-LIBERQuarterly.pdf},
-  keywords =	 {dh}
-}
-
-@article{Lahti17eurostat,
-  author =	 {Leo Lahti and Janne Huovari and Markus Kainu and
-                  Przemysław Biecek},
-  title =	 {Retrieval and Analysis of Eurostat Open Data with
-                  the eurostat Package},
-  year =	 2017,
-  journal =	 {The R Journal},
-  url =
-                  {https://journal.r-project.org/archive/2017/RJ-2017-019/index.html},
-  pages =	 {385--392},
-  keywords =	 {dh},
-  software =	 {yes},
-  volume =	 9,
-  number =	 1,
-  pdf =
-                  {https://github.com/openresearchlabs/openresearchlabs.github.io/blob/master/content/publication_resources/papers/2017-Lahti-RJournal.pdf},
-  authorship =	 {first, corresponding},
-  annote =	 {R package homepage URL:
-                  http://ropengov.github.io/eurostat/}
-}
-
-@article{Lahti17eurostat,
-  author =	 {Leo Lahti and Janne Huovari and Markus Kainu and
-                  Przemysław Biecek},
-  title =	 {Retrieval and Analysis of Eurostat Open Data with
-                  the eurostat Package},
-  year =	 2017,
-  journal =	 {The R Journal},
-  url =
-                  {https://journal.r-project.org/archive/2017/RJ-2017-019/index.html},
-  pages =	 {385--392},
-  keywords =	 {dh},
-  software =	 {yes},
-  volume =	 9,
-  number =	 1,
-  pdf =		 {papers/2017-Lahti-RJournal.pdf},
-  authorship =	 {first, corresponding},
-  annote =	 {R package homepage URL:
-                  http://ropengov.github.io/eurostat/}
-}
-
-@article{Lahti17eurostat,
-  title =	 {Retrieval and Analysis of Eurostat Open Data with
-                  the eurostat Package},
-  author =	 {Leo Lahti and Janne Huovari and Markus Kainu and
-                  Przemysław Biecek},
-  year =	 2017,
-  journal =	 {The R Journal},
-  volume =	 9,
-  number =	 1,
-  pages =	 {385--392},
-  url =
-                  {https://journal.r-project.org/archive/2017/RJ-2017-019/index.html},
-  keywords =	 {dh},
-  software =	 {yes},
-  url =
-                  {https://github.com/openresearchlabs/openresearchlabs.github.io/blob/master/content/publication_resources/papers/2017-Lahti-RJournal.pdf},
-  authorship =	 {first, corresponding},
-  annote =	 {R package homepage URL:
-                  http://ropengov.github.io/eurostat/}
-}
-
-@Article{Lahti17phos,
-  author =	 {Leo Lahti and Filipe da Silva and Markus Petteri
-                  Laine and Viivi Lähteenoja and Mikko Tolonen},
-  title =	 {Alchemy & algorithms: perspectives on the philosophy
-                  and history of open science},
-  journal =	 {RIO Journal},
-  year =	 2017,
-  volume =	 3,
-  pages =	 {e13593},
-  month =	 {May},
-  authorship =	 {first, corresponding},
-  category =	 {perspective},
-  keywords =	 {highlight},
-  status =	 {openscience},
-  doi =		 {10.3897/rio.3.e13593},
-  pdf =
-                  {https://github.com/openresearchlabs/openresearchlabs.github.io/blob/master/content/publication_resources/papers/2017-Lahti-PHOS.pdf},
-  keywords =	 {dh},
-  note =	 {Review of the international conference, including
-                  electronic material (video interviews, lectures and
-                  podcasts.}
-}
-
-@Article{Lahti17phos,
-  author =	 {Leo Lahti and Filipe da Silva and Markus Petteri
-                  Laine and Viivi Lähteenoja and Mikko Tolonen},
-  title =	 {Alchemy & algorithms: perspectives on the philosophy
-                  and history of open science},
-  journal =	 {RIO Journal},
-  year =	 2017,
-  volume =	 3,
-  pages =	 {e13593},
-  month =	 {May},
-  authorship =	 {first, corresponding},
-  category =	 {perspective},
-  keywords =	 {highlight},
-  status =	 {openscience},
-  doi =		 {10.3897/rio.3.e13593},
-  pdf =		 {papers/2017-Lahti-PHOS.pdf},
-  keywords =	 {dh},
-  note =	 {Review of the international conference, including
-                  electronic material (video interviews, lectures and
-                  podcasts.}
-}
-
-@article{Lahti17phos,
-  title =	 {Alchemy & algorithms: perspectives on the philosophy
-                  and history of open science},
-  author =	 {Leo Lahti and Filipe da Silva and Markus Petteri
-                  Laine and Viivi Lähteenoja and Mikko Tolonen},
-  year =	 2017,
-  month =	 {May},
-  journal =	 {RIO Journal},
-  volume =	 3,
-  pages =	 {e13593},
-  doi =		 {10.3897/rio.3.e13593},
-  category =	 {perspective},
-  note =	 {Review of the international conference, including
-                  electronic material (video interviews, lectures and
-                  podcasts.},
-  authorship =	 {first, corresponding},
-  keywords =	 {openscience},
-  status =	 {openscience},
-  url =
-                  {https://github.com/openresearchlabs/openresearchlabs.github.io/blob/master/content/publication_resources/papers/2017-Lahti-PHOS.pdf},
-  keywords =	 {dh}
-}
-
-@misc{Lahti2001,
-  title =	 {Julian joukko iteraatioden valuma-altaan reunana},
-  author =	 {Leo Lahti},
-  year =	 2001,
-  url =
-                  {https://github.com/antagomir/thesis/tree/master/julia01},
-  category =	 {thesis},
-  note =	 {Special assignment in Mathematics (in Finnish)},
-  keywords =	 {thesis},
-  language =	 {Finnish}
-}
-
-@Misc{Lahti2002,
-  author =	 {Leo Lahti},
-  title =	 {Itsesimilaaristen joukkojen Hausdorffin dimension
-                  määrittäminen},
-  category =	 {thesis},
-  year =	 2002,
-  url =
-                  {https://github.com/antagomir/thesis/tree/master/hausdorff02},
-  language =	 {Finnish},
-  note =	 {Special assignment in Mathematics (in Finnish)}
-}
-
-@Misc{Lahti2002,
-  author =	 {Leo Lahti},
-  title =	 {Itsesimilaaristen joukkojen Hausdorffin dimension
-                  määrittäminen},
-  category =	 {thesis},
-  year =	 2002,
-  url =
-                  {https://github.com/antagomir/thesis/tree/master/hausdorff02},
-  language =	 {Finnish},
-  note =	 {Special assignment in Mathematics (in Finnish)}
-}
-
-@misc{Lahti2002,
-  title =	 {Itsesimilaaristen joukkojen Hausdorffin dimension
-                  määrittäminen},
-  author =	 {Leo Lahti},
-  year =	 2002,
-  url =
-                  {https://github.com/antagomir/thesis/tree/master/hausdorff02},
-  category =	 {thesis},
-  keywords =	 {thesis},
-  note =	 {Special assignment in Mathematics (in Finnish)},
-  language =	 {Finnish}
-}
-
-@misc{Lahti2006biopax,
-  title =	 {A brief overview on the BioPAX and SBML standards},
-  author =	 {Leo Lahti},
-  year =	 2007,
-  url =		 {https://arxiv.org/abs/1109.4919},
-  category =	 {thesis},
-  note =	 {Overview of machine-readable representations of
-                  biological processes.},
-  note =	 {(in Finnish)},
-  howpublished = {arXiv},
-  authorship =	 {first},
-  keywords =	 {bioscience},
-  arxiv =	 {arXiv:1109.4919 [cs.DS]},
-  language =	 {Finnish}
-}
-
-@Article{Lahti2012intcomp,
-  author =	 {Leo Lahti and Martin Sch{\"a}fer and Hans-Ulrich
-                  Klein and Silvio Bicciato and Martin Dugas},
-  title =	 {Cancer gene prioritization by integrative analysis
-                  of mRNA expression and DNA copy number data: a
-                  comparative review},
-  journal =	 {Briefings in Bioinformatics},
-  year =	 2013,
-  volume =	 14,
-  number =	 1,
-  month =	 6,
-  keywords =	 {bioscience},
-  authorship =	 {first, corresponding},
-  pdf =
-                  {https://github.com/openresearchlabs/openresearchlabs.github.io/blob/master/content/publication_resources/papers/2013-Lahti-BriefBioinf.pdf},
-  category =	 {review},
-  pages =	 {27--35},
-  doi =		 {10.1093/bib/bbs005}
-}
-
-@Article{Lahti2012intcomp,
-  author =	 {Leo Lahti and Martin Sch{\"a}fer and Hans-Ulrich
-                  Klein and Silvio Bicciato and Martin Dugas},
-  title =	 {Cancer gene prioritization by integrative analysis
-                  of mRNA expression and DNA copy number data: a
-                  comparative review},
-  journal =	 {Briefings in Bioinformatics},
-  year =	 2013,
-  volume =	 14,
-  number =	 1,
-  month =	 6,
-  keywords =	 {bioscience},
-  authorship =	 {first, corresponding},
-  pdf =		 {papers/2013-Lahti-BriefBioinf.pdf},
-  category =	 {review},
-  pages =	 {27--35},
-  doi =		 {10.1093/bib/bbs005}
-}
-
-@article{Lahti2012intcomp,
-  title =	 {Cancer gene prioritization by integrative analysis
-                  of mRNA expression and DNA copy number data: a
-                  comparative review},
-  author =	 {Leo Lahti and Martin Sch{\"a}fer and Hans-Ulrich
-                  Klein and Silvio Bicciato and Martin Dugas},
-  year =	 2013,
-  month =	 6,
-  journal =	 {Briefings in Bioinformatics},
-  volume =	 14,
-  number =	 1,
-  pages =	 {27--35},
-  doi =		 {10.1093/bib/bbs005},
-  category =	 {review},
-  keywords =	 {bioscience},
-  authorship =	 {first, corresponding},
-  url =
-                  {https://github.com/openresearchlabs/openresearchlabs.github.io/blob/master/content/publication_resources/papers/2013-Lahti-BriefBioinf.pdf}
-}
-
-@InProceedings{Lahti2018IDA,
-  author =	 {Lahti, Leo},
-  title =	 {Open Data Science},
-  booktitle =	 {Advances in Intelligent Data Analysis XVII. Lecture
-                  Notes in Computer Science 11191.},
-  year =	 2018,
-  volume =	 11191,
-  address =	 {India},
-  publisher =	 {Springer},
-  month =	 {October},
-  publisher =	 {Springer Nature},
-  keywords =	 {openscience},
-  category =	 {perspective},
-  status =	 {openscience},
-  authorship =	 {first},
-  pdf =
-                  {https://github.com/openresearchlabs/openresearchlabs.github.io/blob/devel/publications/papers/2018-Lahti-IDA.pdf},
-  note =	 {Conference proceedings.}
-}
-
-@InProceedings{Lahti2018IDA,
-  author =	 {Lahti, Leo},
-  title =	 {Open Data Science},
-  booktitle =	 {Advances in Intelligent Data Analysis XVII. Lecture
-                  Notes in Computer Science 11191.},
-  year =	 2018,
-  volume =	 11191,
-  address =	 {India},
-  publisher =	 {Springer},
-  month =	 {October},
-  publisher =	 {Springer Nature},
-  keywords =	 {openscience},
-  category =	 {perspective},
-  status =	 {openscience},
-  authorship =	 {first},
-  pdf =
-                  {https://github.com/openresearchlabs/openresearchlabs.github.io/blob/devel/publications/papers/2018-Lahti-IDA.pdf},
-  note =	 {Conference proceedings.}
-}
-
-@inproceedings{Lahti2018IDA,
-  title =	 {Open Data Science},
-  author =	 {Lahti, Leo},
-  year =	 2018,
-  month =	 {October},
-  booktitle =	 {Advances in Intelligent Data Analysis XVII. Lecture
-                  Notes in Computer Science 11191.},
-  publisher =	 {Springer},
-  publisher =	 {Springer Nature},
-  address =	 {India},
-  volume =	 11191,
-  category =	 {perspective},
-  note =	 {Conference proceedings.},
-  keywords =	 {openscience},
-  authorship =	 {first},
-  url =
-                  {https://github.com/openresearchlabs/openresearchlabs.github.io/blob/devel/publications/https://github.com/openresearchlabs/openresearchlabs.github.io/blob/master/content/publication_resources/papers/2018-Lahti-IDA.pdf}
-}
-
-@Article{Lahti2019bds,
-  author =	 {Leo Lahti and Jani Marjanen and Hege Roivainen and
-                  Mikko Tolonen},
-  title =	 {Bibliographic Data Science and the History of the
-                  Book (c. 1500–1800)},
-  journal =	 {Cataloging \& Classification Quarterly},
-  year =	 2019,
-  volume =	 57,
-  number =	 1,
-  pages =	 {5--23},
-  month =	 {January},
-  doi =		 {10.1080/01639374.2018.1543747},
-  pdf =
-                  {https://github.com/openresearchlabs/openresearchlabs.github.io/blob/master/content/publication_resources/papers/2019-Lahti-CCQ.pdf},
-  publisher =	 {Routledge},
-  status =	 {dh},
-  note =	 {Special issue.}
-}
-
-@Article{Lahti2019bds,
-  author =	 {Leo Lahti and Jani Marjanen and Hege Roivainen and
-                  Mikko Tolonen},
-  title =	 {Bibliographic Data Science and the History of the
-                  Book (c. 1500–1800)},
-  journal =	 {Cataloging \& Classification Quarterly},
-  year =	 2019,
-  volume =	 57,
-  number =	 1,
-  pages =	 {5--23},
-  month =	 {January},
-  doi =		 {10.1080/01639374.2018.1543747},
-  pdf =		 {papers/2019-Lahti-CCQ.pdf},
-  publisher =	 {Routledge},
-  status =	 {dh},
-  note =	 {Special issue.}
-}
-
-@article{Lahti2019bds,
-  title =	 {Bibliographic Data Science and the History of the
-                  Book (c. 1500–1800)},
-  author =	 {Leo Lahti and Jani Marjanen and Hege Roivainen and
-                  Mikko Tolonen},
-  year =	 2019,
-  month =	 {January},
-  journal =	 {Cataloging \& Classification Quarterly},
-  publisher =	 {Routledge},
-  volume =	 57,
-  number =	 1,
-  pages =	 {5--23},
-  doi =		 {10.1080/01639374.2018.1543747},
-  note =	 {Special issue.},
-  url =
-                  {https://github.com/openresearchlabs/openresearchlabs.github.io/blob/master/content/publication_resources/papers/2019-Lahti-CCQ.pdf},
-  keywords =	 {dh}
-}
-
-@InProceedings{Lahti2019rdhum,
-  author =	 {Leo Lahti and Ville Vaara and Jani Marjanen and
-                  Mikko Tolonen},
-  title =	 {Best practices in bibliographic data science},
-  booktitle =	 {Proceedings of the Research Data in the Humanities
-                  Conference},
-  year =	 2019,
-  address =	 {Oulu},
-  month =	 {August},
-  pdf =		 {papers/2019-Lahti-RDHUM.pdf},
-  status =	 {dh},
-  keywords =	 {dh}
-}
-
-@inproceedings{Lahti2019rdhum,
-  title =	 {Best practices in bibliographic data science},
-  author =	 {Leo Lahti and Ville Vaara and Jani Marjanen and
-                  Mikko Tolonen},
-  year =	 2019,
-  month =	 {August},
-  booktitle =	 {Proceedings of the Research Data in the Humanities
-                  Conference},
-  address =	 {Oulu},
-  url =
-                  {https://github.com/openresearchlabs/openresearchlabs.github.io/blob/master/content/publication_resources/papers/2019-Lahti-RDHUM.pdf},
-  keywords =	 {dh}
-}
-
-@InProceedings{Lahti2020chr,
-  author =	 {Leo Lahti and Eetu Mäkelä and Mikko
-                  Tolonen},
-  title =	 {Quantifying bias and uncertainty in historical data
-                  collections with probabilistic programming},
-  booktitle =	 {{Proc. CEUR Workshop Proceedings on Computational
-                  Humanities Research}},
-  pages =	 {80--89},
-  year =	 2020,
-  number =	 2723,
-  month =	 {Nov},
-  keywords =	 {dh},
-  url =
-                  {https://github.com/openresearchlabs/openresearchlabs.github.io/blob/master/content/publication_resources/papers/2020-Lahti-CHR.pdf},
-  note =	 {In F Karsdorp, B McGillivray, A Nerghes & M Wevers
-                  (eds).}
-}
-
-@inproceedings{Lahti2020chr,
-  title =	 {Quantifying bias and uncertainty in historical data
-                  collections with probabilistic programming},
-  author =	 {Leo Lahti and Eetu Mäkelä and Mikko
-                  Tolonen},
-  year =	 2020,
-  month =	 {Nov},
-  booktitle =	 {{Proc. CEUR Workshop Proceedings on Computational
-                  Humanities Research}},
-  pages =	 {80--89},
-  keywords =	 {dh},
-  url =		 {http://ceur-ws.org/Vol-2723/short46.pdf}
-}
-
-@article{Lahti2020hs1,
-  title =	 {Laskentamallit eivät
-                  lähtökohtaisesti ole salassa
-                  pidettävää tietoa},
-  author =	 {Leo Lahti and Thomas Wallgren and Markku Kulmala},
-  year =	 2020,
-  month =	 {May},
-  journal =	 {HS Mielipide},
-  url =		 {https://www.hs.fi/mielipide/art-2000006494641.html},
-  keywords =	 {opinion}
-}
-
-@article{Lahti2020hs2,
-  title =	 {Lähdekoodin sisältämien
-                  yksityiskohtien avoimuus on keskeistä
-                  päätöksenteon
-                  läpinäkyvyydelle.},
-  author =	 {Leo Lahti},
-  year =	 2020,
-  month =	 {June},
-  journal =	 {HS Mielipide},
-  url =		 {https://www.hs.fi/mielipide/art-2000006545770.html},
-  keywords =	 {opinion}
-}
-
-@article{Lahti2020okf1,
-  title =	 {Tietopyyntö epidemialaskelmien
-                  lähdekoodeista},
-  author =	 {Leo Lahti and Tarmo Toikkanen},
-  year =	 2020,
-  month =	 {May},
-  journal =	 {Open Knowledge Finland Blog},
-  url =
-                  {https://www.okf.fi/fi/2020/05/13/tietopyynto-thln-epidemialaskelmien-lahdekoodeista},
-  keywords =	 {opinion}
-}
-
-@article{Lahti2020okf2,
-  title =	 {Päätös epidemialaskelmien
-                  salaamisesta vastoin valtioneuvoston
-                  avoimuuslinjausta},
-  author =	 {Leo Lahti},
-  year =	 2020,
-  month =	 {June},
-  journal =	 {Open Knowledge Finland Blog},
-  url =
-                  {https://www.okf.fi/fi/2020/06/15/thln-paatos-epidemialaskelmien-salaamisesta-vastoin-valtioneuvoston-avoimuuslinjausta/},
-  keywords =	 {opinion}
-}
-
-@article{Lahti2020thinkopen,
-  title =	 {Avoimuus voi vahvistaa
-                  päätöksenteon
-                  tieteellistä pohjaa},
-  author =	 {Leo Lahti},
-  year =	 2020,
-  month =	 {August},
-  journal =	 {University of Helsinki, ThinkOpen blog},
-  keywords =	 {opinion},
-  url =
-                  {https://blogs.helsinki.fi/thinkopen/lahdekoodin-avoimuus-paatoksenteossa/}
-}
-
-@Article{Lahti2021bioc,
-  author =	 {Leo Lahti and Felix G.M. Ernst and Sudarshan
-                  A. Shetty and others},
-  title =	 {Microbiome data science in the {\it
-                  SummarizedExperiment} universe},
-  journal =	 {F1000Research},
-  year =	 2021,
-  volume =	 10,
-  number =	 748,
-  note =	 {(slides); version 1; not peer reviewed},
-  doi =		 {10.7490/f1000research.1118712.1}
-}
-
-@article{Lahti2021bioc,
-  title =	 {Microbiome data science in the {\it
-                  SummarizedExperiment} universe},
-  author =	 {Leo Lahti and Felix G.M. Ernst and Sudarshan
-                  A. Shetty and others},
-  year =	 2021,
-  journal =	 {F1000Research},
-  volume =	 10,
-  number =	 748,
-  doi =		 {10.7490/f1000research.1118712.1},
-  note =	 {(slides); version 1; not peer reviewed},
-  keywords =	 {bioscience}
-}
-
-@Article{Lahti2021hs,
-  author =	 {Eetu Mäkelä and Leo Lahti and Johanna
-                  Lilja and Pekka Heikkinen},
-  title =	 {Laki estää tehokkaiden
-                  tutkimusmenetelmien käytön},
-  journal =	 {HS Mielipide},
-  year =	 2021,
-  month =	 {October},
-  url =		 {https://www.hs.fi/mielipide/art-2000008325656.html},
-  keywords =	 {opinion},
-  status =	 {general}
-}
-
-@InProceedings{Laine15,
-  author =	 {Heidi Laine and Leo Lahti and Anne Lehto and Samuli
-                  Ollila and Markus Miettinen},
-  title =	 {Beyond Open Access - The Changing Culture of
-                  Producing and Disseminating Scientific Knowledge},
-  booktitle =	 {Proceedings of the 19th International Academic
-                  Mindtrek Conference in Tampere, Finland, September
-                  22-24},
-  year =	 2015,
-  address =	 {ACM New York, NY, USA},
-  organization = {AcademicMindTrek'15: Proceedings of the 19th
-                  International Academic Mindtrek Conference},
-  publisher =	 {ACM},
-  authorship =	 {second},
-  address =	 {New York, NY, USA},
-  status =	 {openscience},
-  location =	 {Tampere, Finland},
-  isbn =	 {978-1-4503-3948-3},
-  keywords =	 {openscience},
-  pdf =
-                  {https://github.com/openresearchlabs/openresearchlabs.github.io/blob/master/content/publication_resources/papers/2015-Laine-Mindtrek.pdf},
-  url =		 {http://dl.acm.org/citation.cfm?id=2818187}
-}
-
-@InProceedings{Laine15,
-  author =	 {Heidi Laine and Leo Lahti and Anne Lehto and Samuli
-                  Ollila and Markus Miettinen},
-  title =	 {Beyond Open Access - The Changing Culture of
-                  Producing and Disseminating Scientific Knowledge},
-  booktitle =	 {Proceedings of the 19th International Academic
-                  Mindtrek Conference in Tampere, Finland, September
-                  22-24},
-  year =	 2015,
-  address =	 {ACM New York, NY, USA},
-  organization = {AcademicMindTrek'15: Proceedings of the 19th
-                  International Academic Mindtrek Conference},
-  publisher =	 {ACM},
-  authorship =	 {second},
-  address =	 {New York, NY, USA},
-  status =	 {openscience},
-  location =	 {Tampere, Finland},
-  isbn =	 {978-1-4503-3948-3},
-  keywords =	 {openscience},
-  pdf =		 {papers/2015-Laine-Mindtrek.pdf},
-  url =		 {http://dl.acm.org/citation.cfm?id=2818187}
-}
-
-@inproceedings{Laine15,
-  title =	 {Beyond Open Access - The Changing Culture of
-                  Producing and Disseminating Scientific Knowledge},
-  author =	 {Heidi Laine and Leo Lahti and Anne Lehto and Samuli
-                  Ollila and Markus Miettinen},
-  year =	 2015,
-  booktitle =	 {Proceedings of the 19th International Academic
-                  Mindtrek Conference in Tampere, Finland, September
-                  22-24},
-  location =	 {Tampere, Finland},
-  publisher =	 {ACM},
-  address =	 {ACM New York, NY, USA},
-  address =	 {New York, NY, USA},
-  isbn =	 {978-1-4503-3948-3},
-  url =		 {http://dl.acm.org/citation.cfm?id=2818187},
-  organization = {AcademicMindTrek'15: Proceedings of the 19th
-                  International Academic Mindtrek Conference},
-  authorship =	 {second},
-  keywords =	 {openscience},
-  url =
-                  {https://github.com/openresearchlabs/openresearchlabs.github.io/blob/master/content/publication_resources/papers/2015-Laine-Mindtrek.pdf}
-}
-
-@InProceedings{Laitinen2018IDA,
-  author =	 {Laitinen, Ville and Lahti, Leo},
-  title =	 {A hierarchical Ornstein-Uhlenbeck model for
-                  stochastic time series analysis},
-  booktitle =	 {Advances in Intelligent Data Analysis XVII. Lecture
-                  Notes in Computer Science 11191.},
-  year =	 2018,
-  url =		 {https://github.com/velait/OUP},
-  address =	 {India},
-  month =	 {October},
-  publisher =	 {Springer},
-  status =	 {datascience},
-  authorship =	 {pi},
-  pdf =
-                  {https://github.com/openresearchlabs/openresearchlabs.github.io/blob/master/content/publication_resources/papers/2018-Laitinen-IDA.pdf},
-  note =	 {Conference proceedings.}
-}
-
-@InProceedings{Laitinen2018IDA,
-  author =	 {Laitinen, Ville and Lahti, Leo},
-  title =	 {A hierarchical Ornstein-Uhlenbeck model for
-                  stochastic time series analysis},
-  booktitle =	 {Advances in Intelligent Data Analysis XVII. Lecture
-                  Notes in Computer Science 11191.},
-  year =	 2018,
-  url =		 {https://github.com/velait/OUP},
-  address =	 {India},
-  month =	 {October},
-  publisher =	 {Springer},
-  status =	 {datascience},
-  authorship =	 {pi},
-  pdf =		 {papers/2018-Laitinen-IDA.pdf},
-  note =	 {Conference proceedings.}
-}
-
-@inproceedings{Laitinen2018IDA,
-  title =	 {A hierarchical Ornstein-Uhlenbeck model for
-                  stochastic time series analysis},
-  author =	 {Laitinen, Ville and Lahti, Leo},
-  year =	 2018,
-  month =	 {October},
-  booktitle =	 {Advances in Intelligent Data Analysis XVII. Lecture
-                  Notes in Computer Science 11191.},
-  publisher =	 {Springer},
-  address =	 {India},
-  url =		 {https://github.com/velait/OUP},
-  note =	 {Conference proceedings.},
-  keywords =	 {datascience},
-  authorship =	 {pi},
-  url =
-                  {https://github.com/openresearchlabs/openresearchlabs.github.io/blob/master/content/publication_resources/papers/2018-Laitinen-IDA.pdf}
-}
-
-@Article{Laitinen2021ews,
-  author =	 {Ville Laitinen and Vasilis Dakos and Leo Lahti},
-  title =	 {Probabilistic early warning signals},
-  journal =	 {Ecology & Evolution},
-  year =	 2021,
-  volume =	 11,
-  number =	 20,
-  pages =	 {14101-14114},
-  month =	 {September},
-  keywords =	 {bioscience},
-  doi =		 {10.1002/ece3.8123}
-}
-
-@article{Liu2021liver,
-  title =	 {Early prediction of liver disease using conventional
-                  risk factors and gut microbiome-augmented gradient
-                  boosting},
-  author =	 {Liu, Yang and Meric, Guillaume and Havulinna, Aki
-                  S. and Teo, Shu Mei and Ruuskanen, Matti and
-                  Sanders, Jon and Zhu, Qiyun and Tripathi, Anupriya
-                  and Verspoor, Karin and Cheng, Susan and Jain, Mo
-                  and Jousilahti, Pekka and Vazquez-Baeza, Yoshiki and
-                  Loomba, Rohit and Lahti, Leo and Niiranen, Teemu and
-                  Salomaa, Veikko and Knight, Rob and Inouye, Michael},
-  year =	 2020,
-  journal =	 {medRxiv},
-  doi =		 {10.1101/2020.06.24.20138933},
-  url =
-                  {https://www.medrxiv.org/content/early/2020/06/25/2020.06.24.20138933},
-  eprint =
-                  {https://www.medrxiv.org/content/early/2020/06/25/2020.06.24.20138933.full.pdf},
-  keywords =	 {preprint}
-}
-
-@article {Liu2021liver,
-  author =	 {Liu, Yang and Meric, Guillaume and Havulinna, Aki
-                  S. and Teo, Shu Mei and Ruuskanen, Matti and
-                  Sanders, Jon and Zhu, Qiyun and Tripathi, Anupriya
-                  and Verspoor, Karin and Cheng, Susan and Jain, Mo
-                  and Jousilahti, Pekka and Vazquez-Baeza, Yoshiki and
-                  Loomba, Rohit and Lahti, Leo and Niiranen, Teemu and
-                  Salomaa, Veikko and Knight, Rob and Inouye, Michael},
-  title =	 {Early prediction of liver disease using conventional
-                  risk factors and gut microbiome-augmented gradient
-                  boosting},
-  year =	 2020,
-  doi =		 {10.1101/2020.06.24.20138933},
-  URL =
-                  {https://www.medrxiv.org/content/early/2020/06/25/2020.06.24.20138933},
-  eprint =
-                  {https://www.medrxiv.org/content/early/2020/06/25/2020.06.24.20138933.full.pdf},
-  journal =	 {medRxiv},
-  status =	 {preprint}
-}
-
-@article{Louhimo14,
-  author =	 {Riku Louhimo and Viljami Aittom{\"a}ki and Ali
-                  Faisal and Marko Laakso and Ping Chen and Kristian
-                  Ovaska and Erkka Valo and Leo Lahti and Vladimir
-                  Rogojin and Samuel Kaski and Sampsa Hautaniemi.},
-  journal =	 {Systems Biomedicine (special issue)},
-  volume =	 1,
-  issue =	 2,
-  pages =	 {130--136},
-  keywords =	 {bioscience},
-  title =	 {Systematic Use of Computational Methods Allows
-                  Stratifying Treatment Responders in Glioblastoma
-                  Multiforme},
-  note =	 {Critical Assessment of Massive Data Analysis (CAMDA)
-                  workshop},
-  year =	 2014,
-  month =	 4,
-  pdf =
-                  {https://github.com/openresearchlabs/openresearchlabs.github.io/blob/master/content/publication_resources/papers/2014-Louhimo.pdf},
-  doi =		 {10.4161/sysb.28904}
-}
-
-@article{Louhimo14,
-  author =	 {Riku Louhimo and Viljami Aittom{\"a}ki and Ali
-                  Faisal and Marko Laakso and Ping Chen and Kristian
-                  Ovaska and Erkka Valo and Leo Lahti and Vladimir
-                  Rogojin and Samuel Kaski and Sampsa Hautaniemi.},
-  journal =	 {Systems Biomedicine (special issue)},
-  volume =	 1,
-  issue =	 2,
-  pages =	 {130--136},
-  keywords =	 {bioscience},
-  title =	 {Systematic Use of Computational Methods Allows
-                  Stratifying Treatment Responders in Glioblastoma
-                  Multiforme},
-  note =	 {Critical Assessment of Massive Data Analysis (CAMDA)
-                  workshop},
-  year =	 2014,
-  month =	 4,
-  pdf =		 {papers/2014-Louhimo.pdf},
-  doi =		 {10.4161/sysb.28904}
-}
-
-@article{Louhimo14,
-  title =	 {Systematic Use of Computational Methods Allows
-                  Stratifying Treatment Responders in Glioblastoma
-                  Multiforme},
-  author =	 {Riku Louhimo and Viljami Aittom{\"a}ki and Ali
-                  Faisal and Marko Laakso and Ping Chen and Kristian
-                  Ovaska and Erkka Valo and Leo Lahti and Vladimir
-                  Rogojin and Samuel Kaski and Sampsa Hautaniemi.},
-  year =	 2014,
-  month =	 4,
-  journal =	 {Systems Biomedicine (special issue)},
-  volume =	 1,
-  pages =	 {130--136},
-  doi =		 {10.4161/sysb.28904},
-  note =	 {Critical Assessment of Massive Data Analysis (CAMDA)
-                  workshop},
-  issue =	 2,
-  keywords =	 {bioscience},
-  url =
-                  {https://github.com/openresearchlabs/openresearchlabs.github.io/blob/master/content/publication_resources/papers/2014-Louhimo.pdf}
-}
-
-@InProceedings{Makela2019dhn,
-  author =	 {Eetu M{\"a}kel{\"a} and Mikko Tolonen and Jani
-                  Marjanen and Antti Kanner and Ville Vaara and Leo
-                  Lahti},
-  title =	 {Interdisciplinary collaboration in studying
-                  newspaper materiality},
-  pages =	 {55-66},
-  booktitle =	 {Proc. Twin Talks workshop. Digital Humanities in the
-                  Nordic Countries},
-  series =	 {CEUR Workshop Proceedings},
-  year =	 2019,
-  month =	 {March},
-  address =	 {Copenhagen},
-  volume =	 2365,
-  editor =	 {Steven Krauwer and Darja Fišer},
-  status =	 {dh},
-  keywords =	 {dh},
-  pdf =		 {papers/2019-Makela-DHN.pdf},
-  url =
-                  {http://ceur-ws.org/Vol-2365/07-TwinTalks-DHN2019_paper_7.pdf}
-}
-
-@inproceedings{Makela2019dhn,
-  title =	 {Interdisciplinary collaboration in studying
-                  newspaper materiality},
-  author =	 {Eetu M{\"a}kel{\"a} and Mikko Tolonen and Jani
-                  Marjanen and Antti Kanner and Ville Vaara and Leo
-                  Lahti},
-  year =	 2019,
-  month =	 {March},
-  booktitle =	 {Proc. Twin Talks workshop. Digital Humanities in the
-                  Nordic Countries},
-  address =	 {Copenhagen},
-  series =	 {CEUR Workshop Proceedings},
-  volume =	 2365,
-  pages =	 {55--66},
-  url =
-                  {http://ceur-ws.org/Vol-2365/07-TwinTalks-DHN2019_paper_7.pdf},
-  editor =	 {Steven Krauwer and Darja Fišer},
-  status =	 {dh},
-  keywords =	 {dh},
-  url =
-                  {https://github.com/openresearchlabs/openresearchlabs.github.io/blob/master/content/publication_resources/papers/2019-Makela-DHN.pdf}
-}
-
-@InProceedings{Makela2020,
-  author =	 {Eetu, M and Lagus, K and Lahti, L and Säily,
-                  T and Tolonen, M and
-                  Hämäläinen, M and Kaislaniemi,
-                  S and Nevalainen, T},
-  title =	 {Wrangling with Non-Standard Data},
-  booktitle =	 {Proc. Digital Humanities in the Nordic Countries},
-  year =	 2020,
-  month =	 {March},
-  series =	 {CEUR Workshop Proceedings},
-  pages =	 {81--96},
-  volume =	 2612,
-  editor =	 {Sanita Reinsone and Inguna Skadiņa and Anda
-                  Baklāne and Jānis Daugavietis},
-  pdf =		 {papers/2020-Makela-DHN.pdf},
-  status =	 {dh}
-}
-
-@inproceedings{Makela2020,
-  title =	 {Wrangling with Non-Standard Data},
-  author =	 {Eetu, M and Lagus, K and Lahti, L and Säily,
-                  T and Tolonen, M and
-                  Hämäläinen, M and Kaislaniemi,
-                  S and Nevalainen, T},
-  year =	 2020,
-  month =	 {March},
-  booktitle =	 {Proc. Digital Humanities in the Nordic Countries},
-  series =	 {CEUR Workshop Proceedings},
-  volume =	 2612,
-  pages =	 {81--96},
-  editor =	 {Sanita Reinsone and Inguna Skadiņa and Anda
-                  Baklāne and Jānis Daugavietis},
-  url =
-                  {https://github.com/openresearchlabs/openresearchlabs.github.io/blob/master/content/publication_resources/papers/2020-Makela-DHN.pdf},
-  keywords =	 {dh}
-}
-
-@misc{Makela2021hs,
-  author =	 {Eetu Mäkelä and Leo Lahti and Johanna
-                  Lilja and Pekka Heikkinen},
-  title =	 {Laki estää tehokkaiden
-                  tutkimusmenetelmien käytön},
-  howpublished = {HS Mielipide},
-  month =	 {October},
-  year =	 2021,
-  url =
-                  {https://www.hs.fi/mielipide/art-2000008325656.html?share=6421b425ce95dfc19d87511d90f6d3c4},
-  keywords =	 {opinion}
-}
-
-@article{MarcosZambrano2021,
-  title =	 {Applications of Machine Learning in Human Microbiome
-                  Studies: A Review on Feature Selection, Biomarker
-                  Identification, Disease Prediction and Treatment},
-  author =	 {Marcos-Zambrano, Laura Judith and
-                  Karaduzovic-Hadziabdic, Kanita and Loncar Turukalo,
-                  Tatjana and Przymus, Piotr and Trajkovik, Vladimir
-                  and Aasmets, Oliver and Berland, Magali and Gruca,
-                  Aleksandra and Hasic, Jasminka and Hron, Karel and
-                  Klammsteiner, Thomas and Kolev, Mikhail and Lahti,
-                  Leo and Lopes, Marta B and Moreno, Victor and
-                  Naskinova, Irina and Org, Elin and Paciência,
-                  Inês and Papoutsoglou, Georgios and Shigdel,
-                  Rajesh and Stres, Blaz and Vilne, Baiba and Yousef,
-                  Malik and Zdravevski, Eftim and Tsamarindos, Ioannis
-                  and Carrillo de Santa Pau, Enrique and Claesson,
-                  Marcus J. and Moreno-Indias, Isabel and Truu, Jaak},
-  year =	 2021,
-  journal =	 {Frontiers in Microbiology},
-  volume =	 12,
-  pages =	 313,
-  doi =		 {10.3389/fmicb.2021.634511},
-  issn =	 {1664-302X},
-  url =
-                  {https://www.frontiersin.org/article/10.3389/fmicb.2021.634511},
-  keywords =	 {bioscience}
-}
-
-@Article{Marjanen2019,
-  author =	 {Jani Marjanen and Ville Vaara and Antti Kanner and
-                  Hege Roivainen and Eetu Mäkelä and Leo
-                  Lahti and Mikko Tolonen},
-  title =	 {A National Public Sphere? Analyzing the Language,
-                  Location, and Form of Newspapers in Finland,
-                  1771–1917},
-  journal =	 {Journal of European Periodical Studies},
-  year =	 2019,
-  volume =	 4,
-  number =	 1,
-  month =	 {June},
-  doi =		 {10.21825/jeps.v4i1.10483},
-  url =		 {https://ojs.ugent.be/jeps/article/view/10483},
-  note =	 {Special issue: Digital Approaches Towards Serial
-                  Publications},
-  pdf =
-                  {https://github.com/openresearchlabs/openresearchlabs.github.io/blob/master/content/publication_resources/papers/2019-Marjanen-JEPS.pdf},
-  status =	 {dh},
-  keywords =	 {dh}
-}
-
-@article{Marjanen2019,
-  title =	 {A National Public Sphere? Analyzing the Language,
-                  Location, and Form of Newspapers in Finland,
-                  1771–1917},
-  author =	 {Jani Marjanen and Ville Vaara and Antti Kanner and
-                  Hege Roivainen and Eetu Mäkelä and Leo
-                  Lahti and Mikko Tolonen},
-  year =	 2019,
-  month =	 {June},
-  journal =	 {Journal of European Periodical Studies},
-  volume =	 4,
-  number =	 1,
-  doi =		 {10.21825/jeps.v4i1.10483},
-  url =		 {https://ojs.ugent.be/jeps/article/view/10483},
-  note =	 {Special issue: Digital Approaches Towards Serial
-                  Publications},
-  url =
-                  {https://github.com/openresearchlabs/openresearchlabs.github.io/blob/master/content/publication_resources/papers/2019-Marjanen-JEPS.pdf},
-  status =	 {dh},
-  keywords =	 {dh}
-}
-
-@Article{MorenoIndias2021,
-  author =	 {Isabel Moreno-Indias and Leo Lahti and Miroslava
-                  Nedyalkova and Ilze Elbere and Gennady
-                  V. Roshchupkin and Muhamed Adilovic and Onder
-                  Aydemir and Burcu Bakir-Gungor and Enrique
-                  Carrillo-de Santa Pau and Domenica D'Elia and Magesh
-                  S. Desai and Laurent Falquet and Aycan Gundogdu and
-                  Karel Hron and Thomas Klammsteiner and Marta
-                  B. Lopes and Laura J. Marcos Zambrano and
-                  Cláudia Marques and Michael Mason and Patrick
-                  May and Lejla Pašić and Gianvito Pio
-                  and Sándor Pongor and Vasilis J. Promponas
-                  and Piotr Przymus and Julio
-                  Sáez-Rodríguez and Alexia Sampri and
-                  Rajesh Shigdel and Blaz Stres and Ramona Suharoschi
-                  and Jaak Truu and Ciprian-Octavian Truică and
-                  Baiba Vilne and Dimitrios P. Vlachakis and
-                  Ercüment Yılmaz and Georg Zeller and
-                  Aldert Zomer and David Gómez-Cabrero and
-                  Marcus Claesson},
-  title =	 {Statistical and machine learning techniques in human
-                  microbiome studies: contemporary challenges and
-                  solutions},
-  journal =	 {Frontiers in Microbiology},
-  volume =	 12,
-  pages =	 277,
-  month =	 {February},
-  year =	 2021,
-  doi =		 {10.3389/fmicb.2021.635781},
-  keywords =	 {bioscience}
-}
-
-@article{MorenoIndias2021,
-  title =	 {Statistical and machine learning techniques in human
-                  microbiome studies: contemporary challenges and
-                  solutions},
-  author =	 {Isabel Moreno-Indias and Leo Lahti and Miroslava
-                  Nedyalkova and Ilze Elbere and Gennady
-                  V. Roshchupkin and Muhamed Adilovic and Onder
-                  Aydemir and Burcu Bakir-Gungor and Enrique
-                  Carrillo-de Santa Pau and Domenica D'Elia and Magesh
-                  S. Desai and Laurent Falquet and Aycan Gundogdu and
-                  Karel Hron and Thomas Klammsteiner and Marta
-                  B. Lopes and Laura J. Marcos Zambrano and
-                  Cláudia Marques and Michael Mason and Patrick
-                  May and Lejla Pašić and Gianvito Pio
-                  and Sándor Pongor and Vasilis J. Promponas
-                  and Piotr Przymus and Julio
-                  Sáez-Rodríguez and Alexia Sampri and
-                  Rajesh Shigdel and Blaz Stres and Ramona Suharoschi
-                  and Jaak Truu and Ciprian-Octavian Truică and
-                  Baiba Vilne and Dimitrios P. Vlachakis and
-                  Ercüment Yılmaz and Georg Zeller and
-                  Aldert Zomer and David Gómez-Cabrero and
-                  Marcus Claesson},
-  year =	 2021,
-  month =	 {February},
-  journal =	 {Frontiers in Microbiology},
-  volume =	 12,
-  pages =	 277,
-  doi =		 {10.3389/fmicb.2021.635781},
-  keywords =	 {bioscience}
-}
-
-@Article{Mosakhani10,
-  author =	 {Neda Mosakhani and Mohamed Guled and Leo Lahti and
-                  Ioana Borze and Minna Forsman and Jorma Ryh{\"a}nen
-                  and Sakari Knuutila},
-  title =	 {Unique microRNA profile in Dupuytren's contracture
-                  supports deregulation of beta-catenin pathway},
-  journal =	 {Modern Pathology},
-  year =	 2010,
-  volume =	 23,
-  pages =	 {1544--1522},
-  month =	 11,
-  doi =		 {10.1038/modpathol.2010.146},
-  pdf =
-                  {https://github.com/openresearchlabs/openresearchlabs.github.io/blob/master/content/publication_resources/papers/2010-ModernPathology-Mosakhani-Dupuytre.pdf},
-  note =	 {International Dupuytren Award for best research
-                  paper in 2011}
 }
 
 @Article{Mosakhani10,
@@ -2863,1990 +2070,104 @@
                   paper in 2011}
 }
 
-@article{Mosakhani10,
-  title =	 {Unique microRNA profile in Dupuytren's contracture
-                  supports deregulation of beta-catenin pathway},
-  author =	 {Neda Mosakhani and Mohamed Guled and Leo Lahti and
-                  Ioana Borze and Minna Forsman and Jorma Ryh{\"a}nen
-                  and Sakari Knuutila},
+@Article{Borze11,
+  author =	 {Ioana Borze and Mohamed Guled and Suad Musse and
+                  Anna Raunio and Erkki Elonen and Ulla
+                  Saarinen-Pihkala and Marja-Liisa
+                  Karjalainen-Lindsberg and Leo Lahti and Sakari
+                  Knuutila.},
+  title =	 {MicroRNA microarrays on archive bone marrow core
+                  biopsies of leukemias - method validation},
+  journal =	 {Leukemia Research},
+  year =	 2011,
+  volume =	 35,
+  month =	 2,
+  issue =	 2,
+  pages =	 {188--195},
+  doi =		 {10.1016/j.leukres.2010.08.005}
+}
+
+@Misc{Lahti10pint,
+  author =	 {Olli-Pekka Huovilainen and Leo Lahti},
+  title =	 {Pairwise integration of functional genomics data},
+  howpublished = {software},
+  month =	 {April},
   year =	 2010,
-  month =	 11,
-  journal =	 {Modern Pathology},
-  volume =	 23,
-  pages =	 {1544--1522},
-  doi =		 {10.1038/modpathol.2010.146},
-  note =	 {International Dupuytren Award for best research
-                  paper in 2011},
   url =
-                  {https://github.com/openresearchlabs/openresearchlabs.github.io/blob/master/content/publication_resources/papers/2010-ModernPathology-Mosakhani-Dupuytre.pdf},
-  keywords =	 {bioscience}
+                  {http://bioconductor.org/packages/devel/bioc/html/pint.html},
+  note =	 {R/BioConductor: pint}
 }
 
-@Article{Mosakhani12,
-  author =	 {Neda Mosakhani and Leo Lahti and Ioana Borze and
-                  Marja-Liisa Karjalainen-Lindsberg and Jari Sundstrom
-                  and Raija Ristamaki and Pia Osterlund and Sakari
-                  Knuutila and and Virinder Kaur Sarhadi},
-  title =	 {MicroRNA profiling predicts survival in anti-EGFR
-                  treated chemorefractory metastatic colorectal cancer
-                  patients with wild-type KRAS and BRAF},
-  journal =	 {Cancer Genetics},
-  year =	 2012,
-  volume =	 205,
-  number =	 11,
-  pages =	 {545-51},
-  keywords =	 {bioscience},
-  pdf =
-                  {https://github.com/openresearchlabs/openresearchlabs.github.io/blob/master/content/publication_resources/papers/2012-Mosakhani-CG.pdf},
-  authorship =	 {second},
-  month =	 11,
-  doi =		 {10.1016/j.cancergen.2012.08.003}
+@Misc{Lahti10dmt,
+  author =	 {Leo Lahti and Abhishek Tripathi and Olli-Pekka
+                  Huovilainen},
+  title =	 {Dependency modeling toolkit},
+  howpublished = {software},
+  publisher =	 {ICML workshop},
+  month =	 6,
+  year =	 2010,
+  url =		 {http://dmt.r-forge.r-project.org/},
+  note =	 {CRAN: dmt}
 }
 
-@Article{Mosakhani12,
-  author =	 {Neda Mosakhani and Leo Lahti and Ioana Borze and
-                  Marja-Liisa Karjalainen-Lindsberg and Jari Sundstrom
-                  and Raija Ristamaki and Pia Osterlund and Sakari
-                  Knuutila and and Virinder Kaur Sarhadi},
-  title =	 {MicroRNA profiling predicts survival in anti-EGFR
-                  treated chemorefractory metastatic colorectal cancer
-                  patients with wild-type KRAS and BRAF},
-  journal =	 {Cancer Genetics},
-  year =	 2012,
-  volume =	 205,
-  number =	 11,
-  pages =	 {545-51},
-  keywords =	 {bioscience},
-  pdf =		 {papers/2012-Mosakhani-CG.pdf},
-  authorship =	 {second},
-  month =	 11,
-  doi =		 {10.1016/j.cancergen.2012.08.003}
-}
-
-@article{Mosakhani12,
-  title =	 {MicroRNA profiling predicts survival in anti-EGFR
-                  treated chemorefractory metastatic colorectal cancer
-                  patients with wild-type KRAS and BRAF},
-  author =	 {Neda Mosakhani and Leo Lahti and Ioana Borze and
-                  Marja-Liisa Karjalainen-Lindsberg and Jari Sundstrom
-                  and Raija Ristamaki and Pia Osterlund and Sakari
-                  Knuutila and and Virinder Kaur Sarhadi},
-  year =	 2012,
-  month =	 11,
-  journal =	 {Cancer Genetics},
-  volume =	 205,
-  number =	 11,
-  pages =	 {545--51},
-  doi =		 {10.1016/j.cancergen.2012.08.003},
-  keywords =	 {bioscience},
-  url =
-                  {https://github.com/openresearchlabs/openresearchlabs.github.io/blob/master/content/publication_resources/papers/2012-Mosakhani-CG.pdf},
-  authorship =	 {second}
-}
-
-@Article{Mosakhani12LL,
-  author =	 {N Mosakhani and VK Sarhadi and A Usvasalo and ML
-                  Karjalainen-Lindsberg and L Lahti and K Tuononen and
-                  UM Saarinen-Pihkala and S Knuutila},
-  title =	 {MicroRNA profiling in pediatric acute lymphoblastic
-                  leukemia: novel prognostic tools},
-  journal =	 {Leukemia \& Lymphoma},
-  year =	 2012,
-  pdf =
-                  {https://github.com/openresearchlabs/openresearchlabs.github.io/blob/master/content/publication_resources/papers/2012-Mosakhani-LL.pdf},
-  volume =	 53,
-  number =	 12,
-  pages =	 {2517-2520},
-  keywords =	 {bioscience},
-  month =	 {Dec},
-  doi =		 {10.3109/10428194.2012.685731}
-}
-
-@Article{Mosakhani12LL,
-  author =	 {N Mosakhani and VK Sarhadi and A Usvasalo and ML
-                  Karjalainen-Lindsberg and L Lahti and K Tuononen and
-                  UM Saarinen-Pihkala and S Knuutila},
-  title =	 {MicroRNA profiling in pediatric acute lymphoblastic
-                  leukemia: novel prognostic tools},
-  journal =	 {Leukemia \& Lymphoma},
-  year =	 2012,
-  pdf =		 {papers/2012-Mosakhani-LL.pdf},
-  volume =	 53,
-  number =	 12,
-  pages =	 {2517-2520},
-  keywords =	 {bioscience},
-  month =	 {Dec},
-  doi =		 {10.3109/10428194.2012.685731}
-}
-
-@article{Mosakhani12LL,
-  title =	 {MicroRNA profiling in pediatric acute lymphoblastic
-                  leukemia: novel prognostic tools},
-  author =	 {N Mosakhani and VK Sarhadi and A Usvasalo and ML
-                  Karjalainen-Lindsberg and L Lahti and K Tuononen and
-                  UM Saarinen-Pihkala and S Knuutila},
-  year =	 2012,
-  month =	 {Dec},
-  journal =	 {Leukemia \& Lymphoma},
-  volume =	 53,
-  number =	 12,
-  pages =	 {2517--2520},
-  doi =		 {10.3109/10428194.2012.685731},
-  url =
-                  {https://github.com/openresearchlabs/openresearchlabs.github.io/blob/master/content/publication_resources/papers/2012-Mosakhani-LL.pdf},
-  keywords =	 {bioscience}
-}
-
-@Article{Niini11mfh,
-  author =	 {Tarja Niini and Leo Lahti and Francesca Michelacci
-                  and Shinsuke Ninomiya and Claudia Maria Hattinger
-                  and Mohamed Guled and Tom B{\"o}hling and Piero
-                  Picci and Massimo Serra and Sakari Knuutila},
-  title =	 {Array Comparative Genomic Hybridization Reveals
-                  Frequent Alterations of G1/S Checkpoint Genes in
-                  Undifferentiated Pleomorphic Sarcoma of Bone},
-  journal =	 {Genes, Chromosomes and Cancer},
-  year =	 2011,
-  authorship =	 {second},
-  pdf =
-                  {https://github.com/openresearchlabs/openresearchlabs.github.io/blob/master/content/publication_resources/papers/2011-Niini-GCC.pdf},
-  volume =	 50,
-  number =	 5,
-  month =	 5,
-  pages =	 {291--306},
-  keywords =	 {bioscience},
-  doi =		 {10.1002/gcc.20851}
-}
-
-@Article{Niini11mfh,
-  author =	 {Tarja Niini and Leo Lahti and Francesca Michelacci
-                  and Shinsuke Ninomiya and Claudia Maria Hattinger
-                  and Mohamed Guled and Tom B{\"o}hling and Piero
-                  Picci and Massimo Serra and Sakari Knuutila},
-  title =	 {Array Comparative Genomic Hybridization Reveals
-                  Frequent Alterations of G1/S Checkpoint Genes in
-                  Undifferentiated Pleomorphic Sarcoma of Bone},
-  journal =	 {Genes, Chromosomes and Cancer},
-  year =	 2011,
-  authorship =	 {second},
-  pdf =		 {papers/2011-Niini-GCC.pdf},
-  volume =	 50,
-  number =	 5,
-  month =	 5,
-  pages =	 {291--306},
-  keywords =	 {bioscience},
-  doi =		 {10.1002/gcc.20851}
-}
-
-@article{Niini11mfh,
-  title =	 {Array Comparative Genomic Hybridization Reveals
-                  Frequent Alterations of G1/S Checkpoint Genes in
-                  Undifferentiated Pleomorphic Sarcoma of Bone},
-  author =	 {Tarja Niini and Leo Lahti and Francesca Michelacci
-                  and Shinsuke Ninomiya and Claudia Maria Hattinger
-                  and Mohamed Guled and Tom B{\"o}hling and Piero
-                  Picci and Massimo Serra and Sakari Knuutila},
-  year =	 2011,
-  month =	 5,
-  journal =	 {Genes, Chromosomes and Cancer},
-  volume =	 50,
-  number =	 5,
-  pages =	 {291--306},
-  doi =		 {10.1002/gcc.20851},
-  authorship =	 {second},
-  url =
-                  {https://github.com/openresearchlabs/openresearchlabs.github.io/blob/master/content/publication_resources/papers/2011-Niini-GCC.pdf},
-  keywords =	 {bioscience}
-}
-
-@Article{Niini12,
-  author =	 {Tarja Niini and Ilari Scheinin and Leo Lahti and
-                  Suvi Savola and Fredrik Mertens and Jaakko
-                  Hollmén and Tom Böhling and Aarne
-                  Kivioja and Karolin H Nord and Sakari Knuutila},
-  title =	 {Homozygous Deletions of Cadherin Genes in
-                  Chondrosarcoma – an Array CGH Study},
-  journal =	 {Cancer Genetics},
-  year =	 2012,
-  volume =	 205,
-  number =	 11,
-  pages =	 {588-93},
-  keywords =	 {bioscience},
-  month =	 11,
-  doi =		 {10.1016/j.cancergen.2012.09.007},
-  pmid =	 23146407
-}
-
-@Article{Niini12,
-  author =	 {Tarja Niini and Ilari Scheinin and Leo Lahti and
-                  Suvi Savola and Fredrik Mertens and Jaakko
-                  Hollmén and Tom Böhling and Aarne
-                  Kivioja and Karolin H Nord and Sakari Knuutila},
-  title =	 {Homozygous Deletions of Cadherin Genes in
-                  Chondrosarcoma – an Array CGH Study},
-  journal =	 {Cancer Genetics},
-  year =	 2012,
-  volume =	 205,
-  number =	 11,
-  pages =	 {588-93},
-  keywords =	 {bioscience},
-  month =	 11,
-  doi =		 {10.1016/j.cancergen.2012.09.007},
-  pmid =	 23146407
-}
-
-@article{Niini12,
-  title =	 {Homozygous Deletions of Cadherin Genes in
-                  Chondrosarcoma – an Array CGH Study},
-  author =	 {Tarja Niini and Ilari Scheinin and Leo Lahti and
-                  Suvi Savola and Fredrik Mertens and Jaakko
-                  Hollmén and Tom Böhling and Aarne
-                  Kivioja and Karolin H Nord and Sakari Knuutila},
-  year =	 2012,
-  month =	 11,
-  journal =	 {Cancer Genetics},
-  volume =	 205,
-  number =	 11,
-  pages =	 {588--93},
-  doi =		 {10.1016/j.cancergen.2012.09.007},
-  keywords =	 {bioscience},
-  pmid =	 23146407
-}
-
-@article{Nylund2020,
-  title =	 {Diet, perceived intestinal well-being, fecal
-                  microbiota and short chain fatty acids in oat-using
-                  subjects with celiac disease or gluten sensitivity.},
-  author =	 {Lotta Nylund and Salla Hakkola and Leo Lahti and
-                  Seppo Salminen and Marko Kalliomäki and Baoru
-                  Yang and Kaisa M. Linderborg},
-  year =	 2020,
-  month =	 {August},
-  journal =	 {Nutrients},
-  volume =	 12,
-  pages =	 2570,
-  doi =		 {10.3390/nu12092570},
-  note =	 {Special issue.},
-  issue =	 9,
-  keywords =	 {bioscience}
-}
-
-@Misc{Lahti10blog,
-  author =	 {Leo Lahti},
-  title =	 {opencomp blog},
-  category =	 {blog},
-  url =		 {http://antagomir.wordpress.com/}
-                  {http://bioinformatics.oxfordjournals.org/content/early/2010/09/02/bioinformatics.btq500.abstract.html?ijkey=N1zzjtUBRng3wCM&keytype=ref},
-  pdf =		 {papers/2010-Bioinformatics-Lahti-NetResponse.pdf},
-  annote =	 {ArXiv: http://arxiv.org/abs/1202.0501; R/Matlab
-                  source code http://netpro.r-forge.r-project.org}
-}
-
-@Article{Nymark07,
-  author =	 {Penny Nymark and Pamela M. Lindholm and Mikko
-                  V. Korpela and Leo Lahti and Salla Ruosaari and
-                  Samuel Kaski and Jaakko Hollmen and Sisko Anttila
-                  and Vuokko L. Kinnula and Sakari Knuutila},
-  title =	 {Gene Expression Profiles in Asbestos-exposed
-                  Epithelial and Mesothelial Lung Cell Lines},
-  journal =	 {BMC Genomics},
-  year =	 2007,
-  month =	 3,
-  volume =	 8,
-  number =	 62,
-  keywords =	 {bioscience},
-  doi =		 {10.1186/1471-2164-8-62},
-  annote =	 {CCA on two asbestos-exposed cell lines.}
-}
-
-@Article{Nymark07,
-  author =	 {Penny Nymark and Pamela M. Lindholm and Mikko
-                  V. Korpela and Leo Lahti and Salla Ruosaari and
-                  Samuel Kaski and Jaakko Hollmen and Sisko Anttila
-                  and Vuokko L. Kinnula and Sakari Knuutila},
-  title =	 {Gene Expression Profiles in Asbestos-exposed
-                  Epithelial and Mesothelial Lung Cell Lines},
-  journal =	 {BMC Genomics},
-  year =	 2007,
-  month =	 3,
-  volume =	 8,
-  number =	 62,
-  keywords =	 {bioscience},
-  doi =		 {10.1186/1471-2164-8-62},
-  annote =	 {CCA on two asbestos-exposed cell lines.}
-}
-
-@article{Nymark07,
-  title =	 {Gene Expression Profiles in Asbestos-exposed
-                  Epithelial and Mesothelial Lung Cell Lines},
-  author =	 {Penny Nymark and Pamela M. Lindholm and Mikko
-                  V. Korpela and Leo Lahti and Salla Ruosaari and
-                  Samuel Kaski and Jaakko Hollmen and Sisko Anttila
-                  and Vuokko L. Kinnula and Sakari Knuutila},
-  year =	 2007,
-  month =	 3,
-  journal =	 {BMC Genomics},
-  volume =	 8,
-  number =	 62,
-  doi =		 {10.1186/1471-2164-8-62},
-  keywords =	 {bioscience},
-  annote =	 {CCA on two asbestos-exposed cell lines.}
-}
-
-@Article{Nymark11,
-  author =	 {Penny Nymark and Mohamed Guled and Ioana Borze and
-                  Ali Faisal and Leo Lahti and Kaisa Salmenkivi and
-                  Eeva Kettunen and Sisko Anttila and Sakari Knuutila},
-  title =	 {Integrative Analysis of microRNA, mRNA and aCGH Data
-                  Reveals Asbestos- and Histology-Related Changes in
-                  Lung Cancer},
-  journal =	 {Genes, Chromosomes and Cancer},
-  pdf =
-                  {https://github.com/openresearchlabs/openresearchlabs.github.io/blob/master/content/publication_resources/papers/2011-Nymark-GCC.pdf},
-  year =	 2011,
-  volume =	 50,
-  number =	 8,
-  pages =	 {585--597},
-  month =	 8,
-  keywords =	 {bioscience},
-  doi =		 {10.1002/gcc.20880}
-}
-
-@Article{Nymark11,
-  author =	 {Penny Nymark and Mohamed Guled and Ioana Borze and
-                  Ali Faisal and Leo Lahti and Kaisa Salmenkivi and
-                  Eeva Kettunen and Sisko Anttila and Sakari Knuutila},
-  title =	 {Integrative Analysis of microRNA, mRNA and aCGH Data
-                  Reveals Asbestos- and Histology-Related Changes in
-                  Lung Cancer},
-  journal =	 {Genes, Chromosomes and Cancer},
-  pdf =		 {papers/2011-Nymark-GCC.pdf},
-  year =	 2011,
-  volume =	 50,
-  number =	 8,
-  pages =	 {585--597},
-  month =	 8,
-  keywords =	 {bioscience},
-  doi =		 {10.1002/gcc.20880}
-}
-
-@article{Nymark11,
-  title =	 {Integrative Analysis of microRNA, mRNA and aCGH Data
-                  Reveals Asbestos- and Histology-Related Changes in
-                  Lung Cancer},
-  author =	 {Penny Nymark and Mohamed Guled and Ioana Borze and
-                  Ali Faisal and Leo Lahti and Kaisa Salmenkivi and
-                  Eeva Kettunen and Sisko Anttila and Sakari Knuutila},
-  year =	 2011,
-  month =	 8,
-  journal =	 {Genes, Chromosomes and Cancer},
-  volume =	 50,
-  number =	 8,
-  pages =	 {585--597},
-  doi =		 {10.1002/gcc.20880},
-  url =
-                  {https://github.com/openresearchlabs/openresearchlabs.github.io/blob/master/content/publication_resources/papers/2011-Nymark-GCC.pdf},
-  keywords =	 {bioscience}
-}
-
-@Article{OKeefe15,
-  author =	 {SJD O'Keefe and JV Li and L Lahti and J Ou and F
-                  Carbonero and K Mohammed and JM Posma and J Kinross
-                  and E Wahl and E Ruder and K Vipperla and V Naidoo
-                  and L Mtshali and S Tims and PGB Puylaert, J DeLany
-                  and A Krasinskas and AC Benefiel and HO Kaseb and K
-                  Newton and JK Nicholson and WM de Vos and HR Gaskins
-                  and EG Zoetendal},
-  title =	 {Fat, Fiber and Cancer Risk in African, Americans and
-                  Rural Africans},
-  journal =	 {Nature Communications},
-  year =	 2015,
-  volume =	 6,
-  pages =	 6342,
-  keywords =	 {gut},
-  keywords =	 {bioscience},
-  keywords =	 {highlight},
-  month =	 {Apr},
-  doi =		 {10.1038/ncomms7342},
-  note =	 {Top science article in Guardian on the release day.},
-  pdf =
-                  {https://github.com/openresearchlabs/openresearchlabs.github.io/blob/master/content/publication_resources/papers/2015-OKeefe-NComms.pdf},
-  annote =	 {Guardian:
-                  http://www.theguardian.com/science/2015/apr/28/bowel-cancer-risk-may-be-reduced-by-rural-african-diet-study-finds}
-}
-
-@Article{OKeefe15,
-  author =	 {SJD O'Keefe and JV Li and L Lahti and J Ou and F
-                  Carbonero and K Mohammed and JM Posma and J Kinross
-                  and E Wahl and E Ruder and K Vipperla and V Naidoo
-                  and L Mtshali and S Tims and PGB Puylaert, J DeLany
-                  and A Krasinskas and AC Benefiel and HO Kaseb and K
-                  Newton and JK Nicholson and WM de Vos and HR Gaskins
-                  and EG Zoetendal},
-  title =	 {Fat, Fiber and Cancer Risk in African, Americans and
-                  Rural Africans},
-  journal =	 {Nature Communications},
-  year =	 2015,
-  volume =	 6,
-  pages =	 6342,
-  keywords =	 {gut},
-  keywords =	 {bioscience},
-  keywords =	 {highlight},
-  month =	 {Apr},
-  doi =		 {10.1038/ncomms7342},
-  note =	 {Top science article in Guardian on the release day.},
-  pdf =		 {papers/2015-OKeefe-NComms.pdf},
-  annote =	 {Guardian:
-                  http://www.theguardian.com/science/2015/apr/28/bowel-cancer-risk-may-be-reduced-by-rural-african-diet-study-finds}
-}
-
-@article{OKeefe15,
-  title =	 {Fat, Fiber and Cancer Risk in African, Americans and
-                  Rural Africans},
-  author =	 {SJD O'Keefe and JV Li and L Lahti and J Ou and F
-                  Carbonero and K Mohammed and JM Posma and J Kinross
-                  and E Wahl and E Ruder and K Vipperla and V Naidoo
-                  and L Mtshali and S Tims and PGB Puylaert, J DeLany
-                  and A Krasinskas and AC Benefiel and HO Kaseb and K
-                  Newton and JK Nicholson and WM de Vos and HR Gaskins
-                  and EG Zoetendal},
-  year =	 2015,
-  month =	 {Apr},
-  journal =	 {Nature Communications},
-  volume =	 6,
-  pages =	 6342,
-  doi =		 {10.1038/ncomms7342},
-  note =	 {Top science article in Guardian on the release day.},
-  keywords =	 {gut},
-  keywords =	 {bioscience},
-  url =
-                  {https://github.com/openresearchlabs/openresearchlabs.github.io/blob/master/content/publication_resources/papers/2015-OKeefe-NComms.pdf},
-  annote =	 {Guardian:
-                  http://www.theguardian.com/science/2015/apr/28/bowel-cancer-risk-may-be-reduced-by-rural-african-diet-study-finds}
-}
-
-@article{Palmu2020,
-  title =	 {Association Between the Gut Microbiota and Blood
-                  Pressure in a Population Cohort of 6953 Individuals},
-  author =	 {Joonatan Palmu and Aaro Salosensaari and Aki
-                  S. Havulinna and Susan Cheng and Michael Inouye and
-                  Mohit Jain and Rodolfo A. Salido and Karenina
-                  Sanders and Caitriona Brennan and Gregory
-                  C. Humphrey and Jon G. Sanders and Erkki Vartiainen
-                  and Tiina Laatikainen and Pekka Jousilahti and
-                  Veikko Salomaa and Rob Knight and Leo Lahti and
-                  Teemu J. Niiranen},
-  year =	 2020,
-  month =	 {July},
-  journal =	 {Journal of the American Heart Association},
-  doi =		 {10.1161/JAHA.120.016641},
-  keywords =	 {bioscience}
-}
-
-@article{Palmu2020JAHA,
-  title =	 {Eicosanoid Inflammatory Mediators Are Robustly
-                  Associated with Blood Pressure in the General
-                  Population},
-  author =	 {Joonatan Palmu and others},
-  year =	 2020,
-  journal =	 {Journal of American Heart Association},
-  volume =	 9,
-  pages =	 {e016641},
-  doi =		 {10.1161/JAHA.120.017598},
-  issue =	 15,
-  keywords =	 {bioscience}
-}
-
-@article{Palmu2021ijerph,
-  title =	 {Targeting gut microbiota to treat hypertension: a
-                  systematic review},
-  author =	 {Joonatan Palmu and Leo Lahti and Teemu Niiranen},
-  year =	 2021,
-  month =	 January,
-  journal =	 {International Journal of Environmental Research and
-                  Public Health},
-  volume =	 18,
-  number =	 3,
-  pages =	 1248,
-  doi =		 {10.3390/ijerph18031248},
-  keywords =	 {bioscience},
-  tag =		 {review}
-}
-
-@article{Pekkala2020,
-  title =	 {Prebiotic Xylo-oligosaccharides Targeting
-                  Faecalibacterium prausnitzii Prevent High Fat
-                  Diet-induced Hepatic Steatosis in Rats},
-  author =	 {Sanna Lensu and Raghunath Pariyani and Elina
-                  Mäkinen and Baoru Yang and Wisam Saleem and
-                  Eveliina Munukka and Maarit Lehti and Baoru Yang and
-                  Jere Linden and Marja Tiirola and Leo Lahti and Satu
-                  Pekkala},
-  year =	 2020,
+@Misc{Lahti10netresponse,
+  author =	 {Leo Lahti and Antonio Gusmao and Olli-Pekka
+                  Huovilainen},
+  title =	 {NetResponse (functional network analysis)},
+  howpublished = {software},
   month =	 {October},
-  journal =	 {Nutrients},
-  volume =	 12,
-  number =	 11,
-  pages =	 3225,
-  doi =		 {10.3390/nu12113225},
-  keywords =	 {bioscience}
-}
-
-@Article{Qin2021,
-  author =	 {Youwen Qin and Aki S. Havulinna and Yang Liu and
-                  Pekka Jousilahti and Scott C. Ritchie and Alex
-                  Tokolyi and Jon G. Sanders and Liisa Valsta and
-                  Marta Brożyńska and Qiyun Zhu and
-                  Anupriya Tripathi and Yoshiki Vazquez-Baeza and
-                  Rohit Loomba and Susan Cheng and Mohit Jain and
-                  Teemu Niiranen and Leo Lahti and Rob Knight and
-                  Veikko Salomaa and Michael Inouye and Guillaume
-                  Méric},
-  title =	 {Combined effects of host genetics and diet on human
-                  gut microbiota and incident disease in a single
-                  population cohort},
-  journal =	 {medRxiv (preprint)},
-  year =	 2021,
-  pages =	 {2020.09.12.20193045},
-  keywords =	 {preprint},
-  doi =		 {10.1101/2020.09.12.20193045}
-}
-
-@Article{Ritari15,
-  author =	 {Jarmo Ritari and Jarkko Salojärvi and Leo
-                  Lahti and Willem M. de Vos},
-  title =	 {Improved taxonomic assignment of human intestinal
-                  16S rRNA sequences by a dedicated reference
-                  database},
-  journal =	 {BMC Genomics},
-  pdf =
-                  {https://github.com/openresearchlabs/openresearchlabs.github.io/blob/master/content/publication_resources/papers/2015-Ritari-BMCGenomics.pdf},
-  year =	 2015,
-  volume =	 16,
-  keywords =	 {bioscience},
-  pages =	 1056,
-  month =	 12,
-  doi =		 {10.1186/s12864-015-2265-y}
-}
-
-@Article{Ritari15,
-  author =	 {Jarmo Ritari and Jarkko Salojärvi and Leo
-                  Lahti and Willem M. de Vos},
-  title =	 {Improved taxonomic assignment of human intestinal
-                  16S rRNA sequences by a dedicated reference
-                  database},
-  journal =	 {BMC Genomics},
-  pdf =		 {papers/2015-Ritari-BMCGenomics.pdf},
-  year =	 2015,
-  volume =	 16,
-  keywords =	 {bioscience},
-  pages =	 1056,
-  month =	 12,
-  doi =		 {10.1186/s12864-015-2265-y}
-}
-
-@article{Ritari15,
-  title =	 {Improved taxonomic assignment of human intestinal
-                  16S rRNA sequences by a dedicated reference
-                  database},
-  author =	 {Jarmo Ritari and Jarkko Salojärvi and Leo
-                  Lahti and Willem M. de Vos},
-  year =	 2015,
-  month =	 12,
-  journal =	 {BMC Genomics},
-  volume =	 16,
-  pages =	 1056,
-  doi =		 {10.1186/s12864-015-2265-y},
+  year =	 2010,
   url =
-                  {https://github.com/openresearchlabs/openresearchlabs.github.io/blob/master/content/publication_resources/papers/2015-Ritari-BMCGenomics.pdf},
-  keywords =	 {bioscience}
+                  {http://www.bioconductor.org/help/bioc-views/devel/bioc/html/netresponse.html},
+  doi =		 {10.18129/B9.BIOC.NETRESPONSE},
+  note =	 {R/Bioconductor: netresponse}
 }
 
-@Article{Ruuskanen2021,
-  author =	 {Matti Ruuskanen and Guilhem Sommeria-Klein and Aki
-                  Havulinna and Teemu Niiranen and Leo Lahti},
-  title =	 {Modeling spatial patterns in host-associated
-                  microbial communities},
-  journal =	 {Environmental Microbiology},
-  year =	 2021,
-  volume =	 23,
-  number =	 5,
-  pages =	 {2374-2388},
-  month =	 {May},
-  doi =		 {10.1111/1462-2920.15462}
-}
-
-@article{Ruuskanen2021,
-  title =	 {Modeling spatial patterns in host-associated
-                  microbial communities},
-  author =	 {Matti Ruuskanen and Guilhem Sommeria-Klein and Aki
-                  Havulinna and Teemu Niiranen and Leo Lahti},
-  year =	 2021,
-  month =	 {May},
-  journal =	 {Environmental Microbiology},
-  volume =	 23,
-  number =	 5,
-  pages =	 {2374--2388},
-  keywords =	 {bioscience},
-  doi =		 {10.1111/1462-2920.15462}
-}
-
-@article{Ruuskanen2021gutmicrobes,
-  title =	 {Links between gut microbiome composition and fatty
-                  liver disease in a large population sample},
-  author =	 {Matti O. Ruuskanen and Fredrik Åberg and
-                  Ville Männistö and Aki S. Havulinna
-                  and Guillaume Méric and Yang Liu and Rohit
-                  Loomba and Yoshiki Vázquez-Baeza and Anupriya
-                  Tripathi and Liisa M. Valsta and Michael Inouye and
-                  Pekka Jousilahti and Veikko Salomaa and Mohit Jain
-                  and Rob Knight and Leo Lahti and Teemu J. Niiranen},
-  year =	 2021,
-  month =	 {March},
-  journal =	 {Gut Microbes},
-  volume =	 13,
-  doi =		 {10.1080/19490976.2021.1888673},
-  issue =	 1,
-  keywords =	 {bioscience}
-}
-
-@Article{Salosensaari2021,
-  author =	 {Aaro Salosensaari* and Ville Laitinen* and Aki S
-                  Havulinna and Guillaume Meric and Susan Cheng and
-                  Markus Perola and Liisa Valsta and Georg Alfthan and
-                  Michael Inouye and Jeramie D Watrous and Tao Long
-                  and Rodolfo Salido and Karenina Sanders and
-                  Caitriona Brennan and Gregory C Humphrey and Jon G
-                  Sanders and Mohit Jain and Pekka Jousilahti and
-                  Veikko Salomaa and Rob Knight and Leo Lahti* and
-                  Teemu Niiranen*},
-  title =	 {Taxonomic signatures of cause-specific mortality
-                  risk in human gut microbiome},
-  journal =	 {Nature Communications},
-  year =	 2021,
-  volume =	 12,
-  pages =	 2671,
-  doi =		 {10.1038/s41467-021-22962-y},
-  keywords =	 {bioscience},
-  annote =	 {Preprint featured in HS Tiede Jan 30, 2020. Featured
-                  in Science Magazine Jan 22, 2020
-                  https://www.sciencemag.org/news/2020/01/microbes-your-gut-could-predict-whether-you-re-likely-die-next-15-years}
-}
-
-@article{Salosensaari2021,
-  title =	 {Taxonomic signatures of cause-specific mortality
-                  risk in human gut microbiome},
-  author =	 {Aaro Salosensaari* and Ville Laitinen* and Aki S
-                  Havulinna and Guillaume Meric and Susan Cheng and
-                  Markus Perola and Liisa Valsta and Georg Alfthan and
-                  Michael Inouye and Jeramie D Watrous and Tao Long
-                  and Rodolfo Salido and Karenina Sanders and
-                  Caitriona Brennan and Gregory C Humphrey and Jon G
-                  Sanders and Mohit Jain and Pekka Jousilahti and
-                  Veikko Salomaa and Rob Knight and Leo Lahti* and
-                  Teemu Niiranen*},
-  year =	 2021,
-  journal =	 {Nature Communications},
-  volume =	 12,
-  pages =	 2671,
-  doi =		 {10.1038/s41467-021-22962-y},
-  keywords =	 {bioscience},
-  annote =	 {Preprint featured in HS Tiede Jan 30, 2020. Featured
-                  in Science Magazine Jan 22, 2020
-                  https://www.sciencemag.org/news/2020/01/microbes-your-gut-could-predict-whether-you-re-likely-die-next-15-years}
-}
-
-@Article{Sarhadi13,
-  author =	 {Virinder Kaur Sarhadi and Leo Lahti and Ilari
-                  Scheinin and Anne Tyyb{\"a}kinoja and Suvi Savola
-                  and Anu Usvasalo and Riikka R{\"a}ty and Erkki
-                  Elonen and Pekka Ellonen and Ulla M Saarinen-Pihkala
-                  and Sakari Knuutila},
-  keywords =	 {bioscience},
-  title =	 {Targeted Resequencing of 9p in Acute Lymphoblastic
-                  Leukemia Yields Concordant Results with Array CGH
-                  and Reveals Novel Genomic Alterations},
-  journal =	 {Genomics},
-  pdf =
-                  {https://github.com/openresearchlabs/openresearchlabs.github.io/blob/master/content/publication_resources/papers/2013-Sarhadi-Genomics.pdf},
-  year =	 2013,
-  volume =	 102,
-  month =	 9,
-  authorship =	 {shared first},
-  number =	 3,
-  pages =	 {182--188},
-  doi =		 {10.1016/j.ygeno.2013.01.001}
-}
-
-@Article{Sarhadi13,
-  author =	 {Virinder Kaur Sarhadi and Leo Lahti and Ilari
-                  Scheinin and Anne Tyyb{\"a}kinoja and Suvi Savola
-                  and Anu Usvasalo and Riikka R{\"a}ty and Erkki
-                  Elonen and Pekka Ellonen and Ulla M Saarinen-Pihkala
-                  and Sakari Knuutila},
-  keywords =	 {bioscience},
-  title =	 {Targeted Resequencing of 9p in Acute Lymphoblastic
-                  Leukemia Yields Concordant Results with Array CGH
-                  and Reveals Novel Genomic Alterations},
-  journal =	 {Genomics},
-  pdf =		 {papers/2013-Sarhadi-Genomics.pdf},
-  year =	 2013,
-  volume =	 102,
-  month =	 9,
-  authorship =	 {shared first},
-  number =	 3,
-  pages =	 {182--188},
-  doi =		 {10.1016/j.ygeno.2013.01.001}
-}
-
-@article{Sarhadi13,
-  title =	 {Targeted Resequencing of 9p in Acute Lymphoblastic
-                  Leukemia Yields Concordant Results with Array CGH
-                  and Reveals Novel Genomic Alterations},
-  author =	 {Virinder Kaur Sarhadi and Leo Lahti and Ilari
-                  Scheinin and Anne Tyyb{\"a}kinoja and Suvi Savola
-                  and Anu Usvasalo and Riikka R{\"a}ty and Erkki
-                  Elonen and Pekka Ellonen and Ulla M Saarinen-Pihkala
-                  and Sakari Knuutila},
-  year =	 2013,
-  month =	 9,
-  journal =	 {Genomics},
-  volume =	 102,
-  number =	 3,
-  pages =	 {182--188},
-  doi =		 {10.1016/j.ygeno.2013.01.001},
-  keywords =	 {bioscience},
-  url =
-                  {https://github.com/openresearchlabs/openresearchlabs.github.io/blob/master/content/publication_resources/papers/2013-Sarhadi-Genomics.pdf},
-  authorship =	 {shared first}
-}
-
-@Article{Sarhadi2020,
-  author =	 {Sarhadi, V and Lahti, L and Saberi, F and Youssef, O
-                  and Kokkola, A and Karla, T and Tikkanen, M and
-                  Rautelin, H and Puolakkainen, P and Salehi, R and
-                  Knuutila, S},
-  title =	 {Gut Microbiota and Host Gene Mutations in Colorectal
-                  Cancer Patients and Controls of Iranian and Finnish
-                  Origin},
-  journal =	 {Anticancer Research},
-  year =	 2020,
-  volume =	 40,
-  number =	 3,
-  pages =	 {1325-1334},
-  month =	 {March},
-  doi =		 {10.21873/anticanres.14074},
-  keywords =	 {bioscience},
-  pdf =		 {papers/2020-Sarhadi-Anticanc.pdf}
-}
-
-@article{Sarhadi2020,
-  title =	 {Gut Microbiota and Host Gene Mutations in Colorectal
-                  Cancer Patients and Controls of Iranian and Finnish
-                  Origin},
-  author =	 {Sarhadi, V and Lahti, L and Saberi, F and Youssef, O
-                  and Kokkola, A and Karla, T and Tikkanen, M and
-                  Rautelin, H and Puolakkainen, P and Salehi, R and
-                  Knuutila, S},
-  year =	 2020,
-  month =	 {March},
-  journal =	 {Anticancer Research},
-  volume =	 40,
-  number =	 3,
-  pages =	 {1325--1334},
-  doi =		 {10.21873/anticanres.14074},
-  keywords =	 {bioscience},
-  url =
-                  {https://github.com/openresearchlabs/openresearchlabs.github.io/blob/master/content/publication_resources/papers/2020-Sarhadi-Anticanc.pdf}
-}
-
-@article{Sarhadi2021,
-  title =	 {Gut microbiota of patients with different subtypes
-                  of gastric cancer and gastrointestinal stromal
-                  tumors},
-  author =	 {Virinder Sarhadi and Binu Mathew and Arto Kokkola A
-                  and Tiina Karla and Milja Tikkanen and Hilpi
-                  Rautelin and Leo Lahti and Pauli Puolakkainen and
-                  Sakari Knuutila},
-  year =	 2021,
-  journal =	 {Gut Pathogens},
-  volume =	 13,
-  pages =	 {1--9},
-  doi =		 {10.1186/s13099-021-00403-x},
-  keywords =	 {bioscience},
-  issue =	 11
-}
-
-@Article{Shetty2017,
-  author =	 {Shetty, SA and Hugenholtz, F and Lahti, L and Smidt,
-                  H and de Vos, WM and Danchin, A},
-  title =	 {Intestinal microbiome landscaping: Insight in
-                  community assemblage and implications for microbial
-                  modulation strategies},
-  journal =	 {FEMS Microbiology Reviews},
-  volume =	 41,
-  issue =	 2,
-  month =	 {March},
-  keywords =	 {bioscience},
-  keywords =	 {review},
-  pages =	 {182--199},
-  year =	 2017,
-  pdf =
-                  {https://github.com/openresearchlabs/openresearchlabs.github.io/blob/master/content/publication_resources/papers/2017-Shetty-FEMS.pdf},
-  pages =	 {fuw045},
-  doi =		 {10.1093/femsre/fuw045}
-}
-
-@Article{Shetty2017,
-  author =	 {Shetty, SA and Hugenholtz, F and Lahti, L and Smidt,
-                  H and de Vos, WM and Danchin, A},
-  title =	 {Intestinal microbiome landscaping: Insight in
-                  community assemblage and implications for microbial
-                  modulation strategies},
-  journal =	 {FEMS Microbiology Reviews},
-  volume =	 41,
-  issue =	 2,
-  month =	 {March},
-  keywords =	 {bioscience},
-  keywords =	 {review},
-  pages =	 {182--199},
-  year =	 2017,
-  pdf =		 {papers/2017-Shetty-FEMS.pdf},
-  pages =	 {fuw045},
-  doi =		 {10.1093/femsre/fuw045}
-}
-
-@article{Shetty2017,
-  title =	 {Intestinal microbiome landscaping: Insight in
-                  community assemblage and implications for microbial
-                  modulation strategies},
-  author =	 {Shetty, SA and Hugenholtz, F and Lahti, L and Smidt,
-                  H and de Vos, WM and Danchin, A},
-  year =	 2017,
-  month =	 {March},
-  journal =	 {FEMS Microbiology Reviews},
-  volume =	 41,
-  pages =	 {182--199},
-  note =	 {fuw045},
-  doi =		 {10.1093/femsre/fuw045},
-  issue =	 2,
-  keywords =	 {bioscience},
-  note =	 {review},
-  url =
-                  {https://github.com/openresearchlabs/openresearchlabs.github.io/blob/master/content/publication_resources/papers/2017-Shetty-FEMS.pdf}
-}
-
-@article{Shetty2019,
-  title =	 {Microbiome data science},
-  author =	 {Sudarshan Shetty and Leo Lahti},
-  year =	 2019,
-  month =	 {October},
-  journal =	 {Journal of Biosciences},
-  volume =	 44,
-  pages =	 115,
-  doi =		 {10.1007/s12038-019-9930-2},
-  url =
-                  {https://github.com/openresearchlabs/openresearchlabs.github.io/blob/master/content/publication_resources/papers/2019-Shetty-MDS.pdf},
-  keywords =	 {bioscience},
-  category =	 {review}
-}
-
-@Article{Siavash15,
-  author =	 {Siavash Atashgahi and Rozelin Aydin and Mauricio
-                  R. Dimitrov and Detmer Sipkema and Kelly Hamonts and
-                  Leo Lahti and Farai Maphosa and Thomas Kruse and
-                  Edoardo Saccenti and Dirk Springael, Winnie Dejonghe
-                  and Hauke Smidt},
-  title =	 {Impact of a wastewater treatment plant on microbial
-                  community composition and function in a hyporheic
-                  zone of a eutrophic river},
-  journal =	 {Scientific Reports},
-  keywords =	 {bioscience},
-  year =	 2015,
-  volume =	 5,
-  number =	 17284,
-  month =	 11,
-  doi =		 {10.1038/srep17284},
-  pdf =
-                  {https://github.com/openresearchlabs/openresearchlabs.github.io/blob/master/content/publication_resources/papers/2015-Atagashi.pdf}
-}
-
-@Article{Siavash15,
-  author =	 {Siavash Atashgahi and Rozelin Aydin and Mauricio
-                  R. Dimitrov and Detmer Sipkema and Kelly Hamonts and
-                  Leo Lahti and Farai Maphosa and Thomas Kruse and
-                  Edoardo Saccenti and Dirk Springael, Winnie Dejonghe
-                  and Hauke Smidt},
-  title =	 {Impact of a wastewater treatment plant on microbial
-                  community composition and function in a hyporheic
-                  zone of a eutrophic river},
-  journal =	 {Scientific Reports},
-  keywords =	 {bioscience},
-  year =	 2015,
-  volume =	 5,
-  number =	 17284,
-  month =	 11,
-  doi =		 {10.1038/srep17284},
-  pdf =		 {papers/2015-Atagashi.pdf}
-}
-
-@article{Siavash15,
-  title =	 {Impact of a wastewater treatment plant on microbial
-                  community composition and function in a hyporheic
-                  zone of a eutrophic river},
-  author =	 {Siavash Atashgahi and Rozelin Aydin and Mauricio
-                  R. Dimitrov and Detmer Sipkema and Kelly Hamonts and
-                  Leo Lahti and Farai Maphosa and Thomas Kruse and
-                  Edoardo Saccenti and Dirk Springael, Winnie Dejonghe
-                  and Hauke Smidt},
-  year =	 2015,
-  month =	 11,
-  journal =	 {Scientific Reports},
-  volume =	 5,
-  number =	 17284,
-  doi =		 {10.1038/srep17284},
-  keywords =	 {bioscience},
-  url =
-                  {https://github.com/openresearchlabs/openresearchlabs.github.io/blob/master/content/publication_resources/papers/2015-Atagashi.pdf}
-}
-
-@TechReport{Sinkkonen03tr,
-  author =	 {Janne Sinkkonen and Janne Nikkil\"{a} and Leo Lahti
-                  and Samuel Kaski},
-  title =	 {Associative Clustering by Maximizing a {B}ayes
-                  Factor},
-  institution =	 {Helsinki University of Technology and Laboratory of
-                  Computer and Information Science},
-  year =	 2003,
-  month =	 6,
-  number =	 {A68},
-  pdf =		 {papers/2003-TechRep-Sinkkonen-ACBayesFactor.pdf},
-  address =	 {Espoo, Finland}
-}
-
-@TechReport{Sinkkonen03tr,
-  author =	 {Janne Sinkkonen and Janne Nikkil\"{a} and Leo Lahti
-                  and Samuel Kaski},
-  title =	 {Associative Clustering by Maximizing a {B}ayes
-                  Factor},
-  institution =	 {Helsinki University of Technology and Laboratory of
-                  Computer and Information Science},
-  year =	 2003,
-  month =	 6,
-  number =	 {A68},
-  pdf =
-                  {https://github.com/openresearchlabs/openresearchlabs.github.io/blob/master/content/publication_resources/papers/2003-TechRep-Sinkkonen-ACBayesFactor.pdf},
-  address =	 {Espoo, Finland}
-}
-
-@techreport{Sinkkonen03tr,
-  title =	 {Associative Clustering by Maximizing a {B}ayes
-                  Factor},
-  author =	 {Janne Sinkkonen and Janne Nikkil\"{a} and Leo Lahti
-                  and Samuel Kaski},
-  year =	 2003,
-  month =	 6,
-  address =	 {Espoo, Finland},
-  number =	 {A68},
-  institution =	 {Helsinki University of Technology and Laboratory of
-                  Computer and Information Science},
-  keywords =	 {bioscience},
-  url =
-                  {https://github.com/openresearchlabs/openresearchlabs.github.io/blob/master/content/publication_resources/papers/2003-TechRep-Sinkkonen-ACBayesFactor.pdf}
-}
-
-@InCollection{Sinkkonen04ecml,
-  author =	 {Janne Sinkkonen and Janne Nikkil\"{a} and Leo Lahti
-                  and Samuel Kaski},
-  title =	 {Associative Clustering},
-  booktitle =	 {Proceedings of the ECML'04, 15th European Conference
-                  on Machine Learning},
-  editor =	 {Boulicaut and Esposito and Giannotti and Pedreschi},
-  pages =	 {396--406},
-  publisher =	 {Springer},
-  address =	 {Berlin},
-  category =	 {abstract},
-  status =	 {datascience},
-  year =	 2004,
-  url =
-                  {http://www.cis.hut.fi/projects/mi/abstracts/ecml04.html},
-  pdf =
-                  {https://github.com/openresearchlabs/openresearchlabs.github.io/blob/master/content/publication_resources/papers/2004-ECML-Sinkkonen-AC.pdf}
-}
-
-@InCollection{Sinkkonen04ecml,
-  author =	 {Janne Sinkkonen and Janne Nikkil\"{a} and Leo Lahti
-                  and Samuel Kaski},
-  title =	 {Associative Clustering},
-  booktitle =	 {Proceedings of the ECML'04, 15th European Conference
-                  on Machine Learning},
-  editor =	 {Boulicaut and Esposito and Giannotti and Pedreschi},
-  pages =	 {396--406},
-  publisher =	 {Springer},
-  address =	 {Berlin},
-  category =	 {abstract},
-  status =	 {datascience},
-  year =	 2004,
-  url =
-                  {http://www.cis.hut.fi/projects/mi/abstracts/ecml04.html},
-  pdf =		 {papers/2004-ECML-Sinkkonen-AC.pdf}
-}
-
-@incollection{Sinkkonen04ecml,
-  title =	 {Associative Clustering},
-  author =	 {Janne Sinkkonen and Janne Nikkil\"{a} and Leo Lahti
-                  and Samuel Kaski},
-  year =	 2004,
-  booktitle =	 {Proceedings of the ECML'04, 15th European Conference
-                  on Machine Learning},
-  publisher =	 {Springer},
-  address =	 {Berlin},
-  pages =	 {396--406},
-  url =
-                  {http://www.cis.hut.fi/projects/mi/abstracts/ecml04.html},
-  category =	 {abstract},
-  editor =	 {Boulicaut and Esposito and Giannotti and Pedreschi},
-  keywords =	 {datascience},
-  url =
-                  {https://github.com/openresearchlabs/openresearchlabs.github.io/blob/master/content/publication_resources/papers/2004-ECML-Sinkkonen-AC.pdf}
-}
-
-@TechReport{Sinkkonen05tr,
-  author =	 {Janne Sinkkonen and Samuel Kaski and Janne
-                  Nikkil{\"a} and Leo Lahti},
-  title =	 {Associative Clustering (AC): Technical Details},
-  institution =	 {Helsinki University of Technology},
-  year =	 2005,
-  number =	 {A84},
-  address =	 {Espoo, Finland},
-  month =	 {April},
-  keywords =	 {datascience},
-  pdf =		 {papers/2005-TechRep-Sinkkonen-ACtechdetails.pdf},
-  note =	 {Publications in Computer and Information Science}
-}
-
-@TechReport{Sinkkonen05tr,
-  author =	 {Janne Sinkkonen and Samuel Kaski and Janne
-                  Nikkil{\"a} and Leo Lahti},
-  title =	 {Associative Clustering (AC): Technical Details},
-  institution =	 {Helsinki University of Technology},
-  year =	 2005,
-  number =	 {A84},
-  address =	 {Espoo, Finland},
-  month =	 {April},
-  status =	 {datascience},
-  pdf =		 {papers/2005-TechRep-Sinkkonen-ACtechdetails.pdf},
-  note =	 {Publications in Computer and Information Science}
-}
-
-@techreport{Sinkkonen05tr,
-  title =	 {Associative Clustering (AC): Technical Details},
-  author =	 {Janne Sinkkonen and Samuel Kaski and Janne
-                  Nikkil{\"a} and Leo Lahti},
-  year =	 2005,
-  month =	 {April},
-  address =	 {Espoo, Finland},
-  number =	 {A84},
-  note =	 {Publications in Computer and Information Science},
-  institution =	 {Helsinki University of Technology},
-  keywords =	 {datascience},
-  url =
-                  {https://github.com/openresearchlabs/openresearchlabs.github.io/blob/master/content/publication_resources/papers/2005-TechRep-Sinkkonen-ACtechdetails.pdf}
-}
-
-@Article{Su2015,
-  author =	 {Jing Su and Carl Ekman and Nikolay Oskolkov and Leo
-                  Lahti and Kristoffer Ström and Alvis Brazma
-                  and Leif Groop and Johan Rung and and Ola Hansson},
-  title =	 {A novel atlas of gene expression in human skeletal
-                  muscle reveals molecular changes associated with
-                  aging},
-  journal =	 {Skeletal Muscle},
-  keywords =	 {bioscience},
-  year =	 2015,
-  volume =	 5,
-  number =	 35,
-  doi =		 {10.1186/s13395-015-0059-1},
-  month =	 10,
-  pdf =
-                  {https://github.com/openresearchlabs/openresearchlabs.github.io/blob/master/content/publication_resources/papers/2015-Su-SkeletalMuscle.pdf}
-}
-
-@Article{Su2015,
-  author =	 {Jing Su and Carl Ekman and Nikolay Oskolkov and Leo
-                  Lahti and Kristoffer Ström and Alvis Brazma
-                  and Leif Groop and Johan Rung and and Ola Hansson},
-  title =	 {A novel atlas of gene expression in human skeletal
-                  muscle reveals molecular changes associated with
-                  aging},
-  journal =	 {Skeletal Muscle},
-  keywords =	 {bioscience},
-  year =	 2015,
-  volume =	 5,
-  number =	 35,
-  doi =		 {10.1186/s13395-015-0059-1},
-  month =	 10,
-  pdf =		 {papers/2015-Su-SkeletalMuscle.pdf}
-}
-
-@article{Su2015,
-  title =	 {A novel atlas of gene expression in human skeletal
-                  muscle reveals molecular changes associated with
-                  aging},
-  author =	 {Jing Su and Carl Ekman and Nikolay Oskolkov and Leo
-                  Lahti and Kristoffer Ström and Alvis Brazma
-                  and Leif Groop and Johan Rung and and Ola Hansson},
-  year =	 2015,
-  month =	 10,
-  journal =	 {Skeletal Muscle},
-  volume =	 5,
-  number =	 35,
-  doi =		 {10.1186/s13395-015-0059-1},
-  keywords =	 {bioscience},
-  url =
-                  {https://github.com/openresearchlabs/openresearchlabs.github.io/blob/master/content/publication_resources/papers/2015-Su-SkeletalMuscle.pdf}
-}
-
-@InProceedings{Tiihonen2021chr,
-  author =	 {Iiro Tiihonen and Mikko Tolonen and Leo Lahti},
-  title =	 {Probabilistic Analysis of Early Modern British Book
-                  Prices},
-  booktitle =	 {{Proc. CEUR Workshop Proceedings on Computational
-                  Humanities Research}},
-  year =	 2021,
-  pages =	 {39--48},
-  keywords =	 {dh},
-  month =	 {Nov},
-  url =
-                  {https://github.com/openresearchlabs/openresearchlabs.github.io/blob/master/content/publication_resources/papers/2021-Tiihonen-CHR.pdf},
-  note =	 {In M Ehrmann, F Karsdorp et al. (eds).}
-}
-
-@Article{Timmis2019,
-  author =	 {K Timmis K and F Jebok F and M Rohde M and L Lahti L
-                  and G Molinari},
-  title =	 {Microbiome yarns: The Global Phenotype-Genotype
-                  Survey. Episode III: importance of microbiota
-                  diversification for microbiome function and biome
-                  health},
-  journal =	 {Microbial Biotechnology},
-  year =	 2019,
-  month =	 {April},
-  doi =		 {10.1111/1751-7915.13406},
-  status =	 {misc},
-  keywords =	 {misc},
-  annote =	 {Comics piece for the popularization of microbiome
-                  research.}
-}
-
-@Article{Timmis2019,
-  author =	 {K Timmis K and F Jebok F and M Rohde M and L Lahti L
-                  and G Molinari},
-  title =	 {Microbiome yarns: The Global Phenotype-Genotype
-                  Survey. Episode III: importance of microbiota
-                  diversification for microbiome function and biome
-                  health},
-  journal =	 {Microbial Biotechnology},
-  year =	 2019,
-  month =	 {April},
-  doi =		 {10.1111/1751-7915.13406},
-  status =	 {misc},
-  keywords =	 {misc},
-  annote =	 {Comics piece for the popularization of microbiome
-                  research.}
-}
-
-@article{Timmis2019,
-  title =	 {Microbiome yarns: The Global Phenotype-Genotype
-                  Survey. Episode III: importance of microbiota
-                  diversification for microbiome function and biome
-                  health},
-  author =	 {Timmis, K and Jebok, F and Rohde, M and Lahti, L and
-                  Molinari, G},
-  year =	 2019,
-  month =	 {April},
-  journal =	 {Microbial Biotechnology},
-  doi =		 {10.1111/1751-7915.13406},
-  keywords =	 {misc},
-  annote =	 {Comics piece for the popularization of microbiome
-                  research.}
-}
-
-@Article{Tolonen15EnnenNyt,
-  author =	 {Mikko Tolonen and Leo Lahti},
-  title =	 {Aatehistoria ja digitaalisten aineistojen
-                  mahdollisuudet},
-  journal =	 {Ennen \& Nyt 2},
-  authorship =	 {shared first},
-  year =	 2015,
-  volume =	 2,
-  category =	 {review},
-  language =	 {Finnish},
-  month =	 8,
-  pdf =
-                  {https://github.com/openresearchlabs/openresearchlabs.github.io/blob/master/content/publication_resources/papers/2015-EnnenNyt-Tolonen.pdf},
-  status =	 {dh},
-  url =
-                  {http://www.ennenjanyt.net/2015/08/aatehistoria-ja-digitaalisten-aineistojen-mahdollisuudet}
-}
-
-@Article{Tolonen15EnnenNyt,
-  author =	 {Mikko Tolonen and Leo Lahti},
-  title =	 {Aatehistoria ja digitaalisten aineistojen
-                  mahdollisuudet},
-  journal =	 {Ennen \& Nyt 2},
-  authorship =	 {shared first},
-  year =	 2015,
-  volume =	 2,
-  category =	 {review},
-  language =	 {Finnish},
-  month =	 8,
-  pdf =		 {papers/2015-EnnenNyt-Tolonen.pdf},
-  status =	 {dh},
-  url =
-                  {http://www.ennenjanyt.net/2015/08/aatehistoria-ja-digitaalisten-aineistojen-mahdollisuudet}
-}
-
-@article{Tolonen15EnnenNyt,
-  title =	 {Aatehistoria ja digitaalisten aineistojen
-                  mahdollisuudet},
-  author =	 {Mikko Tolonen and Leo Lahti},
-  year =	 2015,
-  month =	 8,
-  journal =	 {Ennen \& Nyt 2},
-  volume =	 2,
-  keywords =	 {dh},
-  authorship =	 {shared first},
-  language =	 {Finnish},
-  url =
-                  {https://github.com/openresearchlabs/openresearchlabs.github.io/blob/master/content/publication_resources/papers/2015-EnnenNyt-Tolonen.pdf},
-  keywords =	 {dh}
-}
-
-@InProceedings{Tolonen16dh,
-  author =	 {Mikko Tolonen and Niko Ilom{\"a}ki and Hege
-                  Roivainen and Leo Lahti},
-  title =	 {Printing in a Periphery: a Quantitative Study of
-                  Finnish Knowledge Production, 1640-1828},
-  booktitle =	 {Digital Humanities 2016: Conference Abstracts},
-  year =	 2016,
-  category =	 {abstract},
-  status =	 {dh},
-  publisher =	 {Jagiellonian University & Pedagogical University,
-                  Kraków},
-  address =	 {Krakow, Poland},
-  url =		 {http://dh2016.adho.org/abstracts/9},
-  pages =	 {383--385},
-  month =	 7,
-  keywords =	 {dh}
-}
-
-@InProceedings{Tolonen16dh,
-  author =	 {Mikko Tolonen and Niko Ilom{\"a}ki and Hege
-                  Roivainen and Leo Lahti},
-  title =	 {Printing in a Periphery: a Quantitative Study of
-                  Finnish Knowledge Production, 1640-1828},
-  booktitle =	 {Digital Humanities 2016: Conference Abstracts},
-  year =	 2016,
-  category =	 {abstract},
-  status =	 {dh},
-  publisher =	 {Jagiellonian University & Pedagogical University,
-                  Kraków},
-  address =	 {Krakow, Poland},
-  url =		 {http://dh2016.adho.org/abstracts/9},
-  pages =	 {383--385},
-  month =	 7,
-  keywords =	 {dh}
-}
-
-@inproceedings{Tolonen16dh,
-  title =	 {Printing in a Periphery: a Quantitative Study of
-                  Finnish Knowledge Production, 1640-1828},
-  author =	 {Mikko Tolonen and Niko Ilom{\"a}ki and Hege
-                  Roivainen and Leo Lahti},
-  year =	 2016,
-  month =	 7,
-  booktitle =	 {Digital Humanities 2016: Conference Abstracts},
-  publisher =	 {Jagiellonian University & Pedagogical University,
-                  Kraków},
-  address =	 {Krakow, Poland},
-  pages =	 {383--385},
-  url =		 {http://dh2016.adho.org/abstracts/9},
-  category =	 {abstract},
-  keywords =	 {dh}
-}
-
-@article{Tolonen2018gaudeamus,
-  title =	 {Digitaaliset ihmistieteet ja historiantutkimus},
-  author =	 {Mikko Tolonen and Leo Lahti},
-  year =	 2018,
-  journal =	 {Menneisyyden rakentajat},
-  booktitle =	 {Menneisyyden rakentajat},
-  publisher =	 {Gaudeamus},
-  url =		 {https://www.gaudeamus.fi/menneisyyden-rakentajat/},
-  note =	 {(in Finnish). In: Hannikainen, MO and Danielsbacka,
-                  M and Tepora, T (eds.). Menneisyyden
-                  rakentajat. Gaudeamus, Helsinki, 2018.},
-  authorship =	 {second},
-  language =	 {Finnish},
-  editor =	 {Hannikainen, MO and Danielsbacka, M and Tepora, T},
-  journaltitle = {Menneisyyden rakentajat},
-  keywords =	 {dh},
-  annote =	 {This is a book chapter but classified as article as
-                  could not find a way to include this to CSL
-                  automatically generated bibliography yet.}
-}
-
-@InProceedings{Tolonen2019dhn,
-  author =	 {Mikko Tolonen and Jani Marjanen and Hege Roivainen
-                  and Leo Lahti},
-  title =	 {Scaling up bibliographic data science},
-  booktitle =	 {Proceedings of the Digital Humanities in the Nordics
-                  (DHN2019)},
-  year =	 2019,
-  month =	 {March},
-  address =	 {Copenhagen},
-  editor =	 {Costanza Navarretta and Manex Agirrezabal and Bente
-                  Maegaard},
-  pdf =		 {papers/2019-Tolonen-DHN.pdf},
-  status =	 {dh},
-  keywords =	 {dh}
-}
-
-@inproceedings{Tolonen2019dhn,
-  title =	 {Scaling up bibliographic data science},
-  author =	 {Mikko Tolonen and Jani Marjanen and Hege Roivainen
-                  and Leo Lahti},
-  year =	 2019,
-  month =	 {March},
-  booktitle =	 {Proceedings of the Digital Humanities in the Nordics
-                  (DHN2019)},
-  address =	 {Copenhagen},
-  editor =	 {Costanza Navarretta and Manex Agirrezabal and Bente
-                  Maegaard},
-  url =
-                  {https://github.com/openresearchlabs/openresearchlabs.github.io/blob/master/content/publication_resources/papers/2019-Tolonen-DHN.pdf},
-  status =	 {dh},
-  keywords =	 {dh}
-}
-
-@InBook{Tolonen2021canon,
-  author =	 {Mikko Tolonen and Mark J. Hill and Ali Zeeshan Ijaz
-                  and Ville Vaara and Leo Lahti},
-  editor =	 {Baird, I.},
-  chapter =	 {Examining the Early Modern Canon: The English Short
-                  Title Catalogue and Large-Scale Patterns of Cultural
-                  Production.},
-  publisher =	 {Palgrave Macmillan, Cham.},
-  booktitle =	 {Data Visualization in Enlightenment Literature and
-                  Culture},
-  year =	 2021,
-  doi =		 {10.1007/978-3-030-54913-8_3},
-  month =	 {March},
-  note =	 {Book chapter in: Data Visualization in Enlightenment
-                  Literature and Culture}
-}
-
-@incollection{Tolonen2021canon,
-  title =	 {Examining the Early Modern Canon: The English Short
-                  Title Catalogue and Large-Scale Patterns of Cultural
-                  Production.},
-  author =	 {Mikko Tolonen and Mark J. Hill and Ali Zeeshan Ijaz
-                  and Ville Vaara and Leo Lahti},
-  year =	 2021,
-  month =	 {March},
-  booktitle =	 {Data Visualization in Enlightenment Literature and
-                  Culture},
-  publisher =	 {Palgrave Macmillan, Cham.},
-  doi =		 {10.1007/978-3-030-54913-8_3},
-  note =	 {Book chapter in: Data Visualization in Enlightenment
-                  Literature and Culture},
-  editor =	 {Baird, I.},
-  chapter =	 3,
-  keywords =	 {dh}
-}
-
-@article{Tolonen2021rcl,
-  author =	 {Tolonen, M and M{\"a}kel{\"a}, E and Ijaz, A and
-                  Lahti, L},
-  title =	 {Corpus Linguistics and Eighteenth Century
-                  Collections Online (ECCO)},
-  journal =	 {Research in Corpus Linguistics},
-  year =	 2021,
-  volume =	 9,
-  number =	 1,
-  pages =	 {19--34},
-  doi =		 {10.32714/ricl.09.01.03},
-  keywords =	 {dh}
-}
-
-@article{Tolonen2021rcl,
-  title =	 {Corpus Linguistics and Eighteenth Century
-                  Collections Online (ECCO)},
-  author =	 {Tolonen, M and M{\"a}kel{\"a}, E and Ijaz, A and
-                  Lahti, L},
-  year =	 2021,
-  journal =	 {Research in Corpus Linguistics},
-  volume =	 9,
-  number =	 1,
-  pages =	 {19--34},
-  doi =		 {10.32714/ricl.09.01.03},
-  keywords =	 {dh}
-}
-
-@inproceedings{Vaara2019dh,
-  title =	 {The Emerging Paradigm of Bibliographic Data Science},
-  author =	 {Ville Vaara and Ali Ijaz and Iiro Tiihonen and Simon
-                  Hengchen and Antti Kanner and Tanja S{\"a}ily and
-                  Leo Lahti},
-  year =	 2019,
-  month =	 {July},
-  booktitle =	 {Proceedings of the Digital Humanities (DH2019)},
-  note =	 {In press.},
-  keywords =	 {dh}
-}
-
-@article{Vaura2020jch,
-  title =	 {Unsupervised hierarchical clustering identifies a
-                  metabolically challenged subgroup of hypertensive
-                  individuals},
-  author =	 {Felix C. Vaura and Veikko V. Salomaa and Ilkka
-                  M. Kantola and Risto Kaaja and Leo Lahti and Teemu
-                  J. Niiranen},
-  year =	 2020,
-  month =	 {August},
-  journal =	 {Journal of Clinical Hypertension},
-  volume =	 22,
-  number =	 9,
-  pages =	 {1546--1553},
-  doi =		 {10.1111/jch.13984},
-  keywords =	 {bioscience}
-}
-
-@Article{Youssef2018,
-  author =	 {Omar Youssef and Leo Lahti and Arto Kokkola and
-                  Tiina Karla and Milja Tikkanen and Homa Ehsan and
-                  Monika Carpelan‑Holmström and
-                  Selja Koskensalo and Tom Böhling and Hilpi
-                  Rautelin and Pauli Puolakkainen and Sakari Knuutila
-                  and Virinder Sarhadi},
-  title =	 {Stool Microbiota Composition Differs in Patients
-                  with Stomach, Colon, and Rectal Neoplasms},
-  journal =	 {Digestive Diseases and Sciences},
-  year =	 2018,
-  volume =	 63,
-  number =	 11,
-  pages =	 {2950--2958},
-  authorship =	 {shared first},
-  month =	 {July},
-  keywords =	 {bioscience},
-  pdf =
-                  {https://github.com/openresearchlabs/openresearchlabs.github.io/blob/master/content/publication_resources/papers/2018-Youssef.pdf},
-  doi =		 {10.1007/s10620-018-5190-5}
-}
-
-@Article{Youssef2018,
-  author =	 {Omar Youssef and Leo Lahti and Arto Kokkola and
-                  Tiina Karla and Milja Tikkanen and Homa Ehsan and
-                  Monika Carpelan‑Holmström and
-                  Selja Koskensalo and Tom Böhling and Hilpi
-                  Rautelin and Pauli Puolakkainen and Sakari Knuutila
-                  and Virinder Sarhadi},
-  title =	 {Stool Microbiota Composition Differs in Patients
-                  with Stomach, Colon, and Rectal Neoplasms},
-  journal =	 {Digestive Diseases and Sciences},
-  year =	 2018,
-  volume =	 63,
-  number =	 11,
-  pages =	 {2950--2958},
-  authorship =	 {shared first},
-  month =	 {July},
-  keywords =	 {bioscience},
-  pdf =		 {papers/2018-Youssef.pdf},
-  doi =		 {10.1007/s10620-018-5190-5}
-}
-
-@article{Youssef2018,
-  title =	 {Stool Microbiota Composition Differs in Patients
-                  with Stomach, Colon, and Rectal Neoplasms},
-  author =	 {Omar Youssef and Leo Lahti and Arto Kokkola and
-                  Tiina Karla and Milja Tikkanen and Homa Ehsan and
-                  Monika Carpelan‑Holmström and
-                  Selja Koskensalo and Tom Böhling and Hilpi
-                  Rautelin and Pauli Puolakkainen and Sakari Knuutila
-                  and Virinder Sarhadi},
-  year =	 2018,
-  month =	 {July},
-  journal =	 {Digestive Diseases and Sciences},
-  volume =	 63,
-  number =	 11,
-  pages =	 {2950--2958},
-  doi =		 {10.1007/s10620-018-5190-5},
-  authorship =	 {shared first},
-  keywords =	 {bioscience},
-  url =
-                  {https://github.com/openresearchlabs/openresearchlabs.github.io/blob/master/content/publication_resources/papers/2018-Youssef.pdf}
-}
-
-@article {Zhu2021,
-  author =	 {Zhu, Qiyun and Huang, Shi and Gonzalez, Antonio and
-                  McGrath, Imran and McDonald, Daniel and Haiminen,
-                  Niina and Armstrong, George and V{\'a}zquez-Baeza,
-                  Yoshiki and Yu, Julian and Kuczynski, Justin and
-                  Sepich-Poore, Gregory D and Swafford, Austin D and
-                  Das, Promi and Shaffer, Justin P and Lejzerowicz,
-                  Franck and Belda-Ferre, Pedro and Havulinna, Aki S
-                  and M{\'e}ric, Guillaume and Niiranen, Teemu and
-                  Lahti, Leo and Salomaa, Veikko and Kim, Ho-Cheol and
-                  Jain, Mohit and Inouye, Michael and Gilbert, Jack
-                  and Knight, Rob},
-  title =	 {OGUs enable effective, phylogeny-aware analysis of
-                  even shallow metagenome community structures},
-  elocation-id = {2021.04.04.438427},
-  year =	 2021,
-  doi =		 {10.1101/2021.04.04.438427},
-  URL =
-                  {https://www.biorxiv.org/content/early/2021/04/06/2021.04.04.438427},
-  eprint =
-                  {https://www.biorxiv.org/content/early/2021/04/06/2021.04.04.438427.full.pdf},
-  journal =	 {bioRxiv},
-  status =	 {preprint},
-  keywords =	 {preprint}
-}
-
-@article{Zhu2021,
-  title =	 {OGUs enable effective, phylogeny-aware analysis of
-                  even shallow metagenome community structures},
-  author =	 {Zhu, Qiyun and Huang, Shi and Gonzalez, Antonio and
-                  McGrath, Imran and McDonald, Daniel and Haiminen,
-                  Niina and Armstrong, George and V{\'a}zquez-Baeza,
-                  Yoshiki and Yu, Julian and Kuczynski, Justin and
-                  Sepich-Poore, Gregory D and Swafford, Austin D and
-                  Das, Promi and Shaffer, Justin P and Lejzerowicz,
-                  Franck and Belda-Ferre, Pedro and Havulinna, Aki S
-                  and M{\'e}ric, Guillaume and Niiranen, Teemu and
-                  Lahti, Leo and Salomaa, Veikko and Kim, Ho-Cheol and
-                  Jain, Mohit and Inouye, Michael and Gilbert, Jack
-                  and Knight, Rob},
-  year =	 2021,
-  journal =	 {bioRxiv},
-  doi =		 {10.1101/2021.04.04.438427},
-  url =
-                  {https://www.biorxiv.org/content/early/2021/04/06/2021.04.04.438427},
-  elocation-id = {2021.04.04.438427},
-  eprint =
-                  {https://www.biorxiv.org/content/early/2021/04/06/2021.04.04.438427.full.pdf},
-  keywords =	 {preprint}
-}
-
-@article{bender13,
-  title =	 {Intestinal microbiota, individuality and health. In:
-                  Computational Methods Aiding Early-Stage Drug Design
-                  (Dagstuhl Seminar 13212)},
+@Misc{Lahti09rpa,
   author =	 {Leo Lahti},
-  year =	 2013,
-  journal =	 {Dagstuhl Reports},
-  publisher =	 {Schloss Dagstuhl--Leibniz-Zentrum fuer Informatik},
-  address =	 {Dagstuhl, Germany},
-  volume =	 3,
-  number =	 5,
-  pages =	 {78--94},
-  doi =		 {10.4230/DagRep.3.5.78},
-  issn =	 {2192-5283},
-  url =		 {http://drops.dagstuhl.de/opus/volltexte/2013/4179},
-  category =	 {abstract},
-  keywords =	 {bioscience},
-  editor =	 {Andreas Bender and Hinrich G{\"o}hlmann and Sepp
-                  Hochreiter and Ziv Shkedy},
-  urn =		 {urn:nbn:de:0030-drops-41791},
-  annote =	 {Keywords: Bioinformatics, Chemoinformatics, Machine
-                  learning, Statistics, Interdisciplinary
-                  applications. Short abstract for the Dagstuhl
-                  seminar.}
-}
-
-@article{crossys2021,
-  title =	 {Systemic cross-talk between brain, gut, and
-                  peripheral tissues in glucose homeostasis: effects
-                  of exercise training (CROSSYS): Exercise training
-                  intervention in monozygotic twins discordant for
-                  body weight},
-  author =	 {Marja A. Heiskanen and Sanna M. Honkala and Ronja
-                  A. Ojala and Riikka Lautamäki and Kalle
-                  Koskensalo and Martin Lietzén and Jaakko
-                  Hentilä and Virva Saunavaara and Jani
-                  Saunavaara and Mika Helmiö and Eliisa
-                  Löyttyniemi and Lauri Nummenmaa and Maria
-                  C. Collado and Tarja Malm and Leo Lahti and Kirsi
-                  H. Pietiläinen and Jaakko Kaprio and Juha
-                  O. Rinne and Jarna C. Hannukainen},
-  year =	 2021,
-  journal =	 {BMC Sports Science, Medicine and Rehabilitation},
-  volume =	 13,
-  pages =	 16,
-  doi =		 {10.1186/s13102-021-00241-z},
-  keywords =	 {bioscience}
-}
-
-@Article{lahti14natcomm,
-  author =	 {Leo Lahti and Jarkko Saloj{\"a}rvi and Anne Salonen
-                  and Marten Scheffer and Willem M. de Vos},
-  title =	 {Tipping elements in the human intestinal ecosystem},
-  journal =	 {Nature Communications},
-  year =	 2014,
-  volume =	 5,
-  pages =	 4344,
-  pdf =
-                  {https://github.com/openresearchlabs/openresearchlabs.github.io/blob/master/content/publication_resources/papers/2014-Lahti-NatComm.pdf},
-  month =	 7,
-  authorship =	 {first},
-  keywords =	 {bioscience},
-  keywords =	 {highlight},
-  doi =		 {10.1038/ncomms5344}
-}
-
-@Article{lahti14natcomm,
-  author =	 {Leo Lahti and Jarkko Saloj{\"a}rvi and Anne Salonen
-                  and Marten Scheffer and Willem M. de Vos},
-  title =	 {Tipping elements in the human intestinal ecosystem},
-  journal =	 {Nature Communications},
-  year =	 2014,
-  volume =	 5,
-  pages =	 4344,
-  pdf =		 {papers/2014-Lahti-NatComm.pdf},
-  month =	 7,
-  authorship =	 {first},
-  keywords =	 {bioscience},
-  keywords =	 {highlight},
-  doi =		 {10.1038/ncomms5344}
-}
-
-@article{lahti14natcomm,
-  title =	 {Tipping elements in the human intestinal ecosystem},
-  author =	 {Leo Lahti and Jarkko Saloj{\"a}rvi and Anne Salonen
-                  and Marten Scheffer and Willem M. de Vos},
-  year =	 2014,
-  month =	 7,
-  journal =	 {Nature Communications},
-  volume =	 5,
-  pages =	 4344,
-  doi =		 {10.1038/ncomms5344},
+  title =	 {RPA: probe reliability and differential gene
+                  expression analysis},
+  howpublished = {software},
+  month =	 {October},
+  year =	 2009,
   url =
-                  {https://github.com/openresearchlabs/openresearchlabs.github.io/blob/master/content/publication_resources/papers/2014-Lahti-NatComm.pdf},
-  authorship =	 {first},
-  keywords =	 {bioscience}
+                  {http://bioconductor.org/packages/release/bioc/html/RPA.html},
+  doi =		 {10.18129/B9.BIOC.RPA},
+  note =	 {R/Bioconductor: RPA}
 }
 
-@techreport{openedu2020,
-  title =	 {National policy and executive plan by the higher
-                  education and research community for 2021-2025 -
-                  Policy component 1: Open access to educational
-                  resources.},
-  author =	 {Expert Panel in Open Education (Open Science
-                  Coordination in Finland)},
-  year =	 2020,
-  publisher =	 {Committee for Public Information (TJNK) and
-                  Federation of Finnish Learned Societies (TSV).},
-  address =	 {Helsinki, Finland},
-  journal =	 {Responsible Research Series},
-  volume =	 16,
-  keywords =	 {openscience}
-}
-
-@Article{openutu2018,
-  key =		 {report},
-  author =	 {University of Turku},
-  title =	 {Turun yliopiston avoimen tutkimuksen politiikka /
-                  Open Research Policy},
-  howpublished = {Report},
-  journal =	 {unknwown},
-  journaltitle = {unknown},
-  status =	 {openscience},
-  category =	 {report},
-  month =	 {May},
-  year =	 2018,
-  pdf =
-                  {https://github.com/openresearchlabs/openresearchlabs.github.io/blob/master/content/publication_resources/papers/2018-avoimen-tutkimuksen-politiikka-fi.pdf},
-  url =
-                  {https://www.utu.fi/sites/default/files/public\%3A//media/file/ty-avoimen-tutkimuksen-politiikka-fi.pdf},
-  note =	 {(in Finnish)},
-  annote =	 {Member in the work group that developed the report.}
-}
-
-@Article{openutu2018,
-  key =		 {report},
-  author =	 {University of Turku},
-  title =	 {Turun yliopiston avoimen tutkimuksen politiikka /
-                  Open Research Policy},
-  howpublished = {Report},
-  journal =	 {unknwown},
-  journaltitle = {unknown},
-  status =	 {openscience},
-  category =	 {report},
-  month =	 {May},
-  year =	 2018,
-  pdf =		 {papers/2018-avoimen-tutkimuksen-politiikka-fi.pdf},
-  url =
-                  {https://www.utu.fi/sites/default/files/public\%3A//media/file/ty-avoimen-tutkimuksen-politiikka-fi.pdf},
-  note =	 {(in Finnish)},
-  annote =	 {Member in the work group that developed the report.}
-}
-
-@techreport{openutu2018,
-  title =	 {Turun yliopiston avoimen tutkimuksen politiikka /
-                  Open Research Policy},
-  year =	 2018,
-  month =	 {May},
-  author =	 {{OpenUTU work group}},
-  journal =	 {unknwown},
-  category =	 {report},
-  note =	 {(in Finnish)},
-  key =		 {report},
-  institution =	 {University of Turku},
-  howpublished = {Report},
-  journaltitle = {unknown},
-  keywords =	 {openscience},
-  url =
-                  {https://github.com/openresearchlabs/openresearchlabs.github.io/blob/master/content/publication_resources/papers/2018-avoimen-tutkimuksen-politiikka-fi.pdf},
-  annote =	 {Member in the work group that developed the report.}
-}
-
-@Article{salonen14,
-  author =	 {Anne Salonen and Leo Lahti and Jarkko Saloj{\"a}rvi
-                  and Grietje Holtrop and Katri Korpela and Sylvia
-                  Duncan and Priya Date and Alexandra Johnstone and
-                  Gerald Lobley and Petra Louis and Harry Flint and
-                  Willem M. de Vos},
-  title =	 {Impact of diet and individual variation on
-                  intestinal microbiota composition and fermentation
-                  products in obese men},
-  journal =	 {ISME Journal},
-  year =	 2014,
-  keywords =	 {bioscience},
-  volume =	 8,
-  pdf =		 {papers/2014-Salonen-ISME.pdf},
-  authorship =	 {second},
-  pages =	 {2218--2230},
-  doi =		 {10.1038/ismej.2014.63}
-}
-
-@Article{salonen14,
-  author =	 {Anne Salonen and Leo Lahti and Jarkko Saloj{\"a}rvi
-                  and Grietje Holtrop and Katri Korpela and Sylvia
-                  Duncan and Priya Date and Alexandra Johnstone and
-                  Gerald Lobley and Petra Louis and Harry Flint and
-                  Willem M. de Vos},
-  title =	 {Impact of diet and individual variation on
-                  intestinal microbiota composition and fermentation
-                  products in obese men},
-  journal =	 {ISME Journal},
-  year =	 2014,
-  keywords =	 {bioscience},
-  volume =	 8,
-  pdf =
-                  {https://github.com/openresearchlabs/openresearchlabs.github.io/blob/master/content/publication_resources/papers/2014-Salonen-ISME.pdf},
-  authorship =	 {second},
-  pages =	 {2218--2230},
-  doi =		 {10.1038/ismej.2014.63},
-  author =	 {Keith Harris and Todd L Parsons and Umer Z Ijaz and
-                  Leo Lahti and Ian Holmes and Christopher Quince},
-  title =	 {Linking statistical and ecological theory: Hubbell's
-                  unified neutral theory of biodiversity as a
-                  hierarchical Dirichlet process},
-  journal =	 {Proceedings of the IEEE},
-  keywords =	 {bioscience},
-  keywords =	 {highlight},
-  year =	 2017,
-  volume =	 105,
-  number =	 3,
-  pages =	 {516--529},
-  pdf =		 {papers/2017-Harris-IEEE.pdf},
-  month =	 {March},
-  doi =		 {10.1109/JPROC.2015.2428213}
-}
-
-@article{salonen14,
-  title =	 {Impact of diet and individual variation on
-                  intestinal microbiota composition and fermentation
-                  products in obese men},
-  author =	 {Anne Salonen and Leo Lahti and Jarkko Saloj{\"a}rvi
-                  and Grietje Holtrop and Katri Korpela and Sylvia
-                  Duncan and Priya Date and Alexandra Johnstone and
-                  Gerald Lobley and Petra Louis and Harry Flint and
-                  Willem M. de Vos},
-  year =	 2014,
-  journal =	 {ISME Journal},
-  volume =	 8,
-  pages =	 {2218--2230},
-  doi =		 {10.1038/ismej.2014.63},
-  keywords =	 {bioscience},
-  url =
-                  {https://github.com/openresearchlabs/openresearchlabs.github.io/blob/master/content/publication_resources/papers/2014-Salonen-ISME.pdf},
-  authorship =	 {second}
-}
-
-@Article{sarhadi14,
-  author =	 {Virinder Sarhadi and Leo Lahti and Ilari Scheinin
-                  and Pekka Ellonen and Eeva Kettunen and Massimo
-                  Serra and Katia Scotlandi and Pierro Picci and
-                  Sakari Knuutila},
-  title =	 {Copy Number Alterations and Neoplasia Specific
-                  Mutations in MELK, PDCD1LG2, TLN1, and PAX5 at 9p in
-                  Different Neoplasias},
+@Article{Guled09,
+  author =	 {Mohamed Guled and Leo Lahti and Pamela M. Lindholm
+                  and Kaisa Salmenkivi and Izhar Bagwan and Andrew
+                  G. Nicholson and Sakari Knuutila},
+  title =	 {CDKN2A, NF2 and JUN Are Dysregulated Among Other
+                  Genes by miRNAs in Malignant Mesothelioma - a miRNA
+                  Microarray Analysis},
   journal =	 {Genes, Chromosomes and Cancer},
-  year =	 2014,
-  volume =	 53,
+  year =	 2009,
+  volume =	 48,
   number =	 7,
-  pages =	 {579--588},
   month =	 7,
+  pdf =		 {papers/2009-GCC-Guled-miRNA.pdf},
   authorship =	 {second},
-  doi =		 {10.1002/gcc.22168}
+  pages =	 {615--623},
+  doi =		 {10.1002/gcc.20669}
 }
 
-@Article{sarhadi14,
-  author =	 {Virinder Sarhadi and Leo Lahti and Ilari Scheinin
-                  and Pekka Ellonen and Eeva Kettunen and Massimo
-                  Serra and Katia Scotlandi and Pierro Picci and
-                  Sakari Knuutila},
-  title =	 {Copy Number Alterations and Neoplasia Specific
-                  Mutations in MELK, PDCD1LG2, TLN1, and PAX5 at 9p in
-                  Different Neoplasias},
-  journal =	 {Genes, Chromosomes and Cancer},
-  year =	 2014,
-  volume =	 53,
-  number =	 7,
-  pages =	 {579--588},
-  month =	 7,
-  authorship =	 {second},
-  doi =		 {10.1002/gcc.22168}
-}
-
-@article{sarhadi14,
-  title =	 {Copy Number Alterations and Neoplasia Specific
-                  Mutations in MELK, PDCD1LG2, TLN1, and PAX5 at 9p in
-                  Different Neoplasias},
-  author =	 {Virinder Sarhadi and Leo Lahti and Ilari Scheinin
-                  and Pekka Ellonen and Eeva Kettunen and Massimo
-                  Serra and Katia Scotlandi and Pierro Picci and
-                  Sakari Knuutila},
-  year =	 2014,
-  month =	 7,
-  journal =	 {Genes, Chromosomes and Cancer},
-  volume =	 53,
-  number =	 7,
-  pages =	 {579--588},
-  doi =		 {10.1002/gcc.22168},
-  keywords =	 {bioscience},
-  authorship =	 {second}
-}
-
-@Article{stolaki2019,
-  author =	 {Stolaki, Maria and Minekus, Mans and Venema, Koen
-                  and Lahti, Leo and Smid, Eddy J. and Kleerebezem,
-                  Michiel and Zoetendal, Erwin G},
-  title =	 {Microbial communities in a dynamic {it in vitro}
-                  model for the human ileum resemble the human ileal
-                  microbiota},
-  journal =	 {FEMS Microbiology Ecology},
-  year =	 2019,
-  keywords =	 {bioscience},
-  vol =		 95,
-  number =	 8,
-  pages =	 {fiz096},
-  month =	 {August},
-  doi =		 {10.1093/femsec/fiz096},
-  pdf =
-                  {https://github.com/openresearchlabs/openresearchlabs.github.io/blob/master/content/publication_resources/papers/2019-Stolaki-FEMS.pdf}
-}
-
-@Article{stolaki2019,
-  author =	 {Stolaki, Maria and Minekus, Mans and Venema, Koen
-                  and Lahti, Leo and Smid, Eddy J. and Kleerebezem,
-                  Michiel and Zoetendal, Erwin G},
-  title =	 {Microbial communities in a dynamic {it in vitro}
-                  model for the human ileum resemble the human ileal
-                  microbiota},
-  journal =	 {FEMS Microbiology Ecology},
-  year =	 2019,
-  keywords =	 {bioscience},
-  vol =		 95,
-  number =	 8,
-  pages =	 {fiz096},
-  month =	 {August},
-  doi =		 {10.1093/femsec/fiz096},
-  pdf =		 {papers/2019-Stolaki-FEMS.pdf}
-}
-
-@article{stolaki2019,
-  title =	 {Microbial communities in a dynamic {it in vitro}
-                  model for the human ileum resemble the human ileal
-                  microbiota},
-  author =	 {Stolaki, Maria and Minekus, Mans and Venema, Koen
-                  and Lahti, Leo and Smid, Eddy J. and Kleerebezem,
-                  Michiel and Zoetendal, Erwin G},
-  year =	 2019,
-  month =	 {August},
-  journal =	 {FEMS Microbiology Ecology},
-  number =	 8,
-  pages =	 {fiz096},
-  doi =		 {10.1093/femsec/fiz096},
-  keywords =	 {bioscience},
-  vol =		 95,
-  url =
-                  {https://github.com/openresearchlabs/openresearchlabs.github.io/blob/master/content/publication_resources/papers/2019-Stolaki-FEMS.pdf}
-}
-
-@Article{tolonen2019,
-  author =	 {Mikko Tolonen and Leo Lahti and Hege Roivainen and
-                  Jani Marjanen},
-  title =	 {A Quantitative Approach to Book-Printing in Sweden
-                  and Finland, 1640–1828},
-  journal =	 {Historical Methods: A Journal of Quantitative and
-                  Interdisciplinary History},
-  year =	 2019,
-  volume =	 52,
-  issue =	 1,
-  publisher =	 {Routledge},
-  pages =	 {57--78},
-  doi =		 {10.1080/01615440.2018.1526657},
-  status =	 {dh},
-  keywords =	 {dh},
-  pdf =
-                  {https://github.com/openresearchlabs/openresearchlabs.github.io/blob/master/content/publication_resources/papers/2019-Tolonen.pdf}
-}
-
-@Article{tolonen2019,
-  author =	 {Mikko Tolonen and Leo Lahti and Hege Roivainen and
-                  Jani Marjanen},
-  title =	 {A Quantitative Approach to Book-Printing in Sweden
-                  and Finland, 1640–1828},
-  journal =	 {Historical Methods: A Journal of Quantitative and
-                  Interdisciplinary History},
-  year =	 2019,
-  volume =	 52,
-  issue =	 1,
-  publisher =	 {Routledge},
-  pages =	 {57--78},
-  doi =		 {10.1080/01615440.2018.1526657},
-  status =	 {dh},
-  keywords =	 {dh},
-  pdf =		 {papers/2019-Tolonen.pdf}
-}
-
-@article{tolonen2019,
-  title =	 {A Quantitative Approach to Book-Printing in Sweden
-                  and Finland, 1640–1828},
-  author =	 {Mikko Tolonen and Leo Lahti and Hege Roivainen and
-                  Jani Marjanen},
-  year =	 2019,
-  journal =	 {Historical Methods: A Journal of Quantitative and
-                  Interdisciplinary History},
-  publisher =	 {Routledge},
-  volume =	 52,
-  pages =	 {57--78},
-  doi =		 {10.1080/01615440.2018.1526657},
-  issue =	 1,
-  keywords =	 {dh},
-  url =
-                  {https://github.com/openresearchlabs/openresearchlabs.github.io/blob/master/content/publication_resources/papers/2019-Tolonen.pdf}
+@InProceedings{Lahti09mlsp,
+  author =	 {Leo Lahti and Samuel Myllykangas and Sakari Knuutila
+                  and Samuel Kaski},
+  title =	 {Dependency detection with similarity constraints},
+  editor =	 {Adali T, Chanussot J, Jutten C, and Larsen J},
+  booktitle =	 {Proc. MLSP'09 IEEE International Workshop on Machine
+                  Learning for Signal Processing XIX},
+  year =	 2009,
+  howpublished = {software},
+  pages =	 {198--203},
+  address =	 {Piscataway, NJ},
+  pdf =		 {papers/2009-MLSP-Lahti-SimCCA.pdf},
+  note =	 {R/Bioconductor: pint},
+  authorship =	 {first, corresponding},
+  url =		 {http://arxiv.org/abs/1101.5919},
+  arxiv =	 {1101.5919}
 }

--- a/content/publication_resources/bibtex/lahti.bib
+++ b/content/publication_resources/bibtex/lahti.bib
@@ -1,5 +1,24 @@
 
 
+
+
+
+@Article{Mokkala2021,
+  author =	 {Kati Mokkala and Tero Vahlberg and Noora Houttu and
+                  Ella Koivuniemi and Leo Lahti and Kirsi Laitinen},
+  title =	 {Impact of combined consumption of fish oil and
+                  probiotics on the serum metabolome in pregnant women
+                  with overweight or obesity},
+  journal =	 {EbioMedicine},
+  year =	 2021,
+  volume =	 73,
+  pages =	 103655,
+  month =	 {November},
+  doi =		 {10.1016/j.ebiom.2021.103655},
+  keywords =	 {bioscience}
+}
+
+
 @article{Liu2021liver,
 	title        = {Early prediction of liver disease using conventional risk factors and gut microbiome-augmented gradient boosting},
 	author       = {Liu, Yang and Meric, Guillaume and Havulinna, Aki S. and Teo, Shu Mei and Ruuskanen, Matti and Sanders, Jon and Zhu, Qiyun and Tripathi, Anupriya and Verspoor, Karin and Cheng, Susan and Jain, Mo and Jousilahti, Pekka and Vazquez-Baeza, Yoshiki and Loomba, Rohit and Lahti, Leo and Niiranen, Teemu and Salomaa, Veikko and Knight, Rob and Inouye, Michael},

--- a/content/publication_resources/bibtex/lahti.bib
+++ b/content/publication_resources/bibtex/lahti.bib
@@ -1,3 +1,20 @@
+@Article{Ruuskanen2021diabetes,
+  author =	 {Matti O. Ruuskanen and Pande P. Erawijantari and Aki S. Havulinna and Yang Liu and Guillaume Meric and Michael Inouye and Pekka Jousilahti and Veikko Salomaa and Mohit Jain and Rob Knight and Leo Lahti and Teemu J. Niiranen},
+  title =	 {Gut microbiome composition is predictive of incident type 2 diabetes},
+  journal =	 {medRxiv},
+  year =	 {2021},
+  volume =	 {},
+  number =	 {},
+  pages =	 {2021.11.10.21266163},
+  month =	 {},
+  url =		 {},
+  status = {preprint},
+  note =	 {},
+  doi = {10.1101/2021.11.10.21266163 },
+  annote =	 {}  
+}
+
+
 
 
 

--- a/content/research/microbiome-data-science.md
+++ b/content/research/microbiome-data-science.md
@@ -9,13 +9,13 @@ keywords: microbiome
 
 ### Microbiome data science: selected examples
 
-{{< articles id = "Lahti2021bioc" >}}
-
 {{< articles id = "Salosensaari2021" >}}
 
-{{< articles id = "Ruuskanen2021" >}}
+{{< articles id = "MorenoIndias2021" >}}
 
-{{< articles id = "Hintikka2021" >}}
+{{< articles id = "Lahti2021bioc" >}}
+
+{{< articles id = "Ruuskanen2021" >}}
 
 {{< articles id = "Gonze2018" >}}
 
@@ -25,15 +25,9 @@ keywords: microbiome
 
 {{< articles id = "Harris17" >}}
 
-{{< articles id = "MorenoIndias2021" >}}
 
 
-
-### More publications in microbiome data science
-
-[**All publications**](/research/all)
-
----
+### More microbiome data science and life science applications
 
 {{< articles keyword = "bioscience" >}}
 

--- a/content/research/preprints.md
+++ b/content/research/preprints.md
@@ -7,7 +7,7 @@ keywords: Preprints
 
 ### Preprints
 
-{{< articles keyword = "preprint" >}}
+{{< articles status = "preprint" >}}
 
 
 ### All publications

--- a/data/publications/lahti.json
+++ b/data/publications/lahti.json
@@ -1,5 +1,75 @@
 [
   {
+    "DOI": "10.1101/2021.11.10.21266163 ",
+    "URL": "",
+    "annote": "",
+    "author": [
+      {
+        "family": "Ruuskanen",
+        "given": "Matti O."
+      },
+      {
+        "family": "Erawijantari",
+        "given": "Pande P."
+      },
+      {
+        "family": "Havulinna",
+        "given": "Aki S."
+      },
+      {
+        "family": "Liu",
+        "given": "Yang"
+      },
+      {
+        "family": "Meric",
+        "given": "Guillaume"
+      },
+      {
+        "family": "Inouye",
+        "given": "Michael"
+      },
+      {
+        "family": "Jousilahti",
+        "given": "Pekka"
+      },
+      {
+        "family": "Salomaa",
+        "given": "Veikko"
+      },
+      {
+        "family": "Jain",
+        "given": "Mohit"
+      },
+      {
+        "family": "Knight",
+        "given": "Rob"
+      },
+      {
+        "family": "Lahti",
+        "given": "Leo"
+      },
+      {
+        "family": "Niiranen",
+        "given": "Teemu J."
+      }
+    ],
+    "container-title": "medRxiv",
+    "id": "Ruuskanen2021diabetes",
+    "issue": "",
+    "issued": {
+      "date-parts": [
+        [
+          2021
+        ]
+      ]
+    },
+    "note": "",
+    "page": "2021.11.10.21266163",
+    "title": "Gut microbiome composition is predictive of incident type 2 diabetes",
+    "type": "article-journal",
+    "volume": ""
+  },
+  {
     "DOI": "10.1016/j.ebiom.2021.103655",
     "author": [
       {

--- a/data/publications/lahti.json
+++ b/data/publications/lahti.json
@@ -1,5 +1,48 @@
 [
   {
+    "DOI": "10.1016/j.ebiom.2021.103655",
+    "author": [
+      {
+        "family": "Mokkala",
+        "given": "Kati"
+      },
+      {
+        "family": "Vahlberg",
+        "given": "Tero"
+      },
+      {
+        "family": "Houttu",
+        "given": "Noora"
+      },
+      {
+        "family": "Koivuniemi",
+        "given": "Ella"
+      },
+      {
+        "family": "Lahti",
+        "given": "Leo"
+      },
+      {
+        "family": "Laitinen",
+        "given": "Kirsi"
+      }
+    ],
+    "container-title": "EbioMedicine",
+    "id": "Mokkala2021",
+    "issued": {
+      "date-parts": [
+        [
+          2021
+        ]
+      ]
+    },
+    "keyword": "bioscience",
+    "page": "103655",
+    "title": "Impact of combined consumption of fish oil and probiotics on the serum metabolome in pregnant women with overweight or obesity",
+    "type": "article-journal",
+    "volume": "73"
+  },
+  {
     "DOI": "10.1101/2020.06.24.20138933",
     "URL": "https://www.medrxiv.org/content/early/2020/06/25/2020.06.24.20138933",
     "author": [

--- a/data/publications/lahti.json
+++ b/data/publications/lahti.json
@@ -1,5 +1,111 @@
 [
   {
+    "DOI": "10.1101/2020.09.12.20193045",
+    "URL": "",
+    "author": [
+      {
+        "family": "Qin",
+        "given": "Youwen"
+      },
+      {
+        "family": "Havulinna",
+        "given": "Aki S."
+      },
+      {
+        "family": "Liu",
+        "given": "Yang"
+      },
+      {
+        "family": "Jousilahti",
+        "given": "Pekka"
+      },
+      {
+        "family": "Ritchie",
+        "given": "Scott C."
+      },
+      {
+        "family": "Tokolyi",
+        "given": "Alex"
+      },
+      {
+        "family": "Sanders",
+        "given": "Jon G."
+      },
+      {
+        "family": "Valsta",
+        "given": "Liisa"
+      },
+      {
+        "family": "Brożyńska",
+        "given": "Marta"
+      },
+      {
+        "family": "Zhu",
+        "given": "Qiyun"
+      },
+      {
+        "family": "Tripathi",
+        "given": "Anupriya"
+      },
+      {
+        "family": "Vazquez-Baeza",
+        "given": "Yoshiki"
+      },
+      {
+        "family": "Loomba",
+        "given": "Rohit"
+      },
+      {
+        "family": "Cheng",
+        "given": "Susan"
+      },
+      {
+        "family": "Jain",
+        "given": "Mohit"
+      },
+      {
+        "family": "Niiranen",
+        "given": "Teemu"
+      },
+      {
+        "family": "Lahti",
+        "given": "Leo"
+      },
+      {
+        "family": "Knight",
+        "given": "Rob"
+      },
+      {
+        "family": "Salomaa",
+        "given": "Veikko"
+      },
+      {
+        "family": "Inouye",
+        "given": "Michael"
+      },
+      {
+        "family": "Méric",
+        "given": "Guillaume"
+      }
+    ],
+    "container-title": "medRxiv (preprint)",
+    "id": "Qin2021",
+    "issue": "",
+    "issued": {
+      "date-parts": [
+        [
+          2021
+        ]
+      ]
+    },
+    "keyword": "preprint",
+    "note": "",
+    "page": "2020.09.12.20193045",
+    "title": "Combined effects of host genetics and diet on human gut microbiota and incident disease in a single population cohort",
+    "type": "article-journal",
+    "volume": ""
+  },
+  {
     "DOI": "10.32714/ricl.09.01.03",
     "author": [
       {

--- a/data/publications/lahti.json
+++ b/data/publications/lahti.json
@@ -1,6 +1,6 @@
 [
   {
-    "DOI": "10.1101/2021.11.10.21266163 ",
+    "DOI": "10.1101/2021.11.10.21266163",
     "URL": "",
     "annote": "",
     "author": [
@@ -103,7 +103,8 @@
     "issued": {
       "date-parts": [
         [
-          2021
+          2021,
+          11
         ]
       ]
     },
@@ -112,100 +113,6 @@
     "title": "Impact of combined consumption of fish oil and probiotics on the serum metabolome in pregnant women with overweight or obesity",
     "type": "article-journal",
     "volume": "73"
-  },
-  {
-    "DOI": "10.1101/2020.06.24.20138933",
-    "URL": "https://www.medrxiv.org/content/early/2020/06/25/2020.06.24.20138933",
-    "author": [
-      {
-        "family": "Liu",
-        "given": "Yang"
-      },
-      {
-        "family": "Meric",
-        "given": "Guillaume"
-      },
-      {
-        "family": "Havulinna",
-        "given": "Aki S."
-      },
-      {
-        "family": "Teo",
-        "given": "Shu Mei"
-      },
-      {
-        "family": "Ruuskanen",
-        "given": "Matti"
-      },
-      {
-        "family": "Sanders",
-        "given": "Jon"
-      },
-      {
-        "family": "Zhu",
-        "given": "Qiyun"
-      },
-      {
-        "family": "Tripathi",
-        "given": "Anupriya"
-      },
-      {
-        "family": "Verspoor",
-        "given": "Karin"
-      },
-      {
-        "family": "Cheng",
-        "given": "Susan"
-      },
-      {
-        "family": "Jain",
-        "given": "Mo"
-      },
-      {
-        "family": "Jousilahti",
-        "given": "Pekka"
-      },
-      {
-        "family": "Vazquez-Baeza",
-        "given": "Yoshiki"
-      },
-      {
-        "family": "Loomba",
-        "given": "Rohit"
-      },
-      {
-        "family": "Lahti",
-        "given": "Leo"
-      },
-      {
-        "family": "Niiranen",
-        "given": "Teemu"
-      },
-      {
-        "family": "Salomaa",
-        "given": "Veikko"
-      },
-      {
-        "family": "Knight",
-        "given": "Rob"
-      },
-      {
-        "family": "Inouye",
-        "given": "Michael"
-      }
-    ],
-    "container-title": "medRxiv",
-    "id": "Liu2021liver",
-    "issued": {
-      "date-parts": [
-        [
-          2020
-        ]
-      ]
-    },
-    "keyword": "preprint",
-    "title": "Early prediction of liver disease using conventional risk factors and gut microbiome-augmented gradient boosting",
-    "type": "article-journal"
   },
   {
     "DOI": "10.1101/2020.09.12.20193045",
@@ -453,7 +360,8 @@
     "issued": {
       "date-parts": [
         [
-          2021
+          2021,
+          9
         ]
       ]
     },
@@ -462,402 +370,6 @@
     "title": "Probabilistic early warning signals",
     "type": "article-journal",
     "volume": "11"
-  },
-  {
-    "DOI": "10.1089/jwh.2017.6488",
-    "URL": "https://github.com/openresearchlabs/openresearchlabs.github.io/blob/master/content/publication_resources/papers/2018-Aatsinki.pdf",
-    "author": [
-      {
-        "family": "Aatsinki",
-        "given": "Anna-Katariina"
-      },
-      {
-        "family": "Uusitupa",
-        "given": "Henna-Maria"
-      },
-      {
-        "family": "Munukka",
-        "given": "Eveliina"
-      },
-      {
-        "family": "Pesonen",
-        "given": "Henri"
-      },
-      {
-        "family": "Rintala",
-        "given": "Anniina"
-      },
-      {
-        "family": "Pietilä",
-        "given": "Sami"
-      },
-      {
-        "family": "Lahti",
-        "given": "Leo"
-      },
-      {
-        "family": "Eerola",
-        "given": "Erkki"
-      },
-      {
-        "family": "Karlsson",
-        "given": "Linnea"
-      },
-      {
-        "family": "Karlsson",
-        "given": "Hasse"
-      }
-    ],
-    "container-title": "Journal of Womens Health",
-    "id": "Aatsinki2018",
-    "issued": {
-      "date-parts": [
-        [
-          2018,
-          5
-        ]
-      ]
-    },
-    "keyword": "bioscience",
-    "note": "Epub ahead of print.",
-    "title": "Gut microbiota composition in mid-pregnancy is associated with gestational weight gain but not prepregnancy body mass index",
-    "type": "article-journal"
-  },
-  {
-    "DOI": "10.1016/j.bbi.2019.05.035",
-    "URL": "https://github.com/openresearchlabs/openresearchlabs.github.io/blob/master/content/publication_resources/papers/2019-Aatsinki.pdf",
-    "author": [
-      {
-        "family": "Aatsinki",
-        "given": "Anna"
-      },
-      {
-        "family": "Lahti",
-        "given": "Leo"
-      },
-      {
-        "family": "Uusitupa",
-        "given": "Henna"
-      },
-      {
-        "family": "Munukka",
-        "given": "Eveliina"
-      },
-      {
-        "family": "Anniina Keskitalo",
-        "given": "Saara Nolvi"
-      },
-      {
-        "family": "O’Mahony",
-        "given": "Siobhain"
-      },
-      {
-        "family": "Pietilä",
-        "given": "Sami"
-      },
-      {
-        "family": "Elo",
-        "given": "Laura"
-      },
-      {
-        "family": "Eerola",
-        "given": "Erkki"
-      },
-      {
-        "family": "Karlsson",
-        "given": "Hasse"
-      },
-      {
-        "family": "Karlsson",
-        "given": "Linnea"
-      }
-    ],
-    "container-title": "Brain Behavior and Immunity",
-    "id": "Aatsinki2019",
-    "issued": {
-      "date-parts": [
-        [
-          2019,
-          5
-        ]
-      ]
-    },
-    "keyword": "bioscience",
-    "page": "849-858",
-    "title": "Gut microbiota composition is associated with temperament traits in infants",
-    "type": "article-journal",
-    "volume": "80"
-  },
-  {
-    "DOI": "10.1016/j.psyneuen.2020.104754",
-    "author": [
-      {
-        "family": "Aatsinki",
-        "given": "Anna-Katariina"
-      },
-      {
-        "family": "Keskitalo",
-        "given": "Anniina"
-      },
-      {
-        "family": "Laitinen",
-        "given": "Ville"
-      },
-      {
-        "family": "Munukka",
-        "given": "Eveliina"
-      },
-      {
-        "family": "Uusitupa",
-        "given": "Henna-Maria"
-      },
-      {
-        "family": "Lahti",
-        "given": "Leo"
-      },
-      {
-        "family": "Kortesluoma",
-        "given": "Susanna"
-      },
-      {
-        "family": "Mustonen",
-        "given": "Paula"
-      },
-      {
-        "family": "Rodrigues",
-        "given": "Ana João"
-      },
-      {
-        "family": "Coimbra",
-        "given": "Bárbara"
-      },
-      {
-        "family": "Huovinen",
-        "given": "Pentti"
-      },
-      {
-        "family": "Karlsson",
-        "given": "Hasse"
-      },
-      {
-        "family": "Karlsson",
-        "given": "Linnea"
-      }
-    ],
-    "container-title": "Psychoneuroendocrinology",
-    "id": "Aatsinki2020",
-    "issued": {
-      "date-parts": [
-        [
-          2020
-        ]
-      ]
-    },
-    "keyword": "bioscience",
-    "page": "104754",
-    "title": "Maternal prenatal psychological distress and hair cortisol levels associate with infant fecal microbiota composition at 2.5 months of age",
-    "type": "article-journal",
-    "volume": "119"
-  },
-  {
-    "DOI": "10.12688/f1000research.5686.2",
-    "URL": "https://github.com/openresearchlabs/openresearchlabs.github.io/blob/master/content/publication_resources/papers/2014-Aleksic.pdf",
-    "author": [
-      {
-        "family": "Aleksic",
-        "given": "Jelena"
-      },
-      {
-        "family": "Alexa",
-        "given": "Adrian"
-      },
-      {
-        "family": "Attwood",
-        "given": "Teresa K"
-      },
-      {
-        "family": "Hong",
-        "given": "Neil Chue"
-      },
-      {
-        "family": "Dahlö",
-        "given": "Martin"
-      },
-      {
-        "family": "Davey",
-        "given": "Robert"
-      },
-      {
-        "family": "Dinkel",
-        "given": "Holger"
-      },
-      {
-        "family": "Förstner",
-        "given": "Konrad U"
-      },
-      {
-        "family": "Grigorov",
-        "given": "Ivo"
-      },
-      {
-        "family": "Hériché",
-        "given": "Jean-Karim"
-      },
-      {
-        "family": "Lahti",
-        "given": "Leo"
-      },
-      {
-        "family": "MacLean",
-        "given": "Dan"
-      },
-      {
-        "family": "Markie",
-        "given": "Michael L"
-      },
-      {
-        "family": "Molloy",
-        "given": "Jenny"
-      },
-      {
-        "family": "Schneider",
-        "given": "Maria Victoria"
-      },
-      {
-        "family": "Scott",
-        "given": "Camille"
-      },
-      {
-        "family": "Smith-Unna",
-        "given": "Richard"
-      },
-      {
-        "family": "Vieira",
-        "given": "Bruno Miguel"
-      }
-    ],
-    "container-title": "F1000Research",
-    "id": "Aleksic14",
-    "issued": {
-      "date-parts": [
-        [
-          2015,
-          1
-        ]
-      ]
-    },
-    "keyword": "openscience",
-    "note": "AllBio: Open Science & Reproducibility Best Practice Workshop",
-    "page": "271",
-    "title": "The open science peer review oath",
-    "type": "article-journal",
-    "volume": "3"
-  },
-  {
-    "DOI": "10.1038/nmeth.3103",
-    "URL": "https://github.com/openresearchlabs/openresearchlabs.github.io/blob/master/content/publication_resources/papers/2014-Alneberg-NatMeth.pdf",
-    "author": [
-      {
-        "family": "Alneberg",
-        "given": "Johannes"
-      },
-      {
-        "family": "Bjarnason",
-        "given": "Brynjar Smári"
-      },
-      {
-        "dropping-particle": "de",
-        "family": "Bruijn",
-        "given": "Ino"
-      },
-      {
-        "family": "Schirmer",
-        "given": "Melanie"
-      },
-      {
-        "family": "Quick",
-        "given": "Joshua"
-      },
-      {
-        "family": "Ijaz",
-        "given": "Umer Z"
-      },
-      {
-        "family": "Lahti",
-        "given": "Leo"
-      },
-      {
-        "family": "Loman",
-        "given": "Nicholas J"
-      },
-      {
-        "family": "Andersson",
-        "given": "Anders F"
-      },
-      {
-        "family": "Quince",
-        "given": "Christopher"
-      }
-    ],
-    "container-title": "Nature Methods",
-    "id": "Alneberg14",
-    "issue": "1144–1146",
-    "issued": {
-      "date-parts": [
-        [
-          2014
-        ]
-      ]
-    },
-    "keyword": "bioscience",
-    "note": "CONCOCT algorithm",
-    "title": "Binning metagenomic contigs by coverage and composition",
-    "type": "article-journal",
-    "volume": "11"
-  },
-  {
-    "DOI": "10.1103/PhysRevE.97.062407",
-    "ISSN": "2470-0045",
-    "URL": "https://github.com/openresearchlabs/openresearchlabs.github.io/blob/master/content/publication_resources/papers/2018-Arani-PhysRevE.pdf",
-    "author": [
-      {
-        "family": "Arani",
-        "given": "Babak M. S."
-      },
-      {
-        "family": "Mahmoudi",
-        "given": "Mahdi"
-      },
-      {
-        "family": "Lahti",
-        "given": "Leo"
-      },
-      {
-        "family": "González",
-        "given": "Javier"
-      },
-      {
-        "family": "Wit",
-        "given": "Ernst C."
-      }
-    ],
-    "container-title": "Physical Review E",
-    "id": "Arani2018",
-    "issue": "6",
-    "issued": {
-      "date-parts": [
-        [
-          2018,
-          6
-        ]
-      ]
-    },
-    "keyword": "datascience",
-    "page": "062407",
-    "publisher": "American Physical Society",
-    "title": "Stability estimation of autoregulated genes under michaelis-menten type kinetics",
-    "type": "article-journal",
-    "volume": "97"
   },
   {
     "DOI": "10.1126/science.aay4895",
@@ -890,7 +402,8 @@
     "issued": {
       "date-parts": [
         [
-          2021
+          2021,
+          6
         ]
       ]
     },
@@ -899,639 +412,6 @@
     "title": "Exit time as a measure of ecological resilience",
     "type": "article-journal",
     "volume": "372"
-  },
-  {
-    "URL": "https://github.com/openresearchlabs/openresearchlabs.github.io/blob/master/content/publication_resources/papers/2018-Bjork-ATT.pdf",
-    "author": [
-      {
-        "family": "Björk",
-        "given": "Anna"
-      },
-      {
-        "family": "Paavolainen",
-        "given": "Juho-Matti"
-      },
-      {
-        "family": "Ropponen",
-        "given": "Teemu"
-      },
-      {
-        "family": "Laakso",
-        "given": "Mikael"
-      },
-      {
-        "family": "Lahti",
-        "given": "Leo"
-      }
-    ],
-    "id": "Bjork2018",
-    "issued": {
-      "date-parts": [
-        [
-          2018
-        ]
-      ]
-    },
-    "keyword": "openscience",
-    "note": "Report on the openness of major scientific publishers commissioned by Finnish Ministry of Education and Culture",
-    "publisher": "unknown; Open Science and Research Initiative (ATT)",
-    "status": "openscience",
-    "title": "Opening academic publishing: Development and application of systematic evaluation criteria",
-    "title-short": "Opening academic publishing",
-    "type": "report"
-  },
-  {
-    "DOI": "10.1016/j.leukres.2010.08.005",
-    "author": [
-      {
-        "family": "Borze",
-        "given": "Ioana"
-      },
-      {
-        "family": "Guled",
-        "given": "Mohamed"
-      },
-      {
-        "family": "Musse",
-        "given": "Suad"
-      },
-      {
-        "family": "Raunio",
-        "given": "Anna"
-      },
-      {
-        "family": "Elonen",
-        "given": "Erkki"
-      },
-      {
-        "family": "Saarinen-Pihkala",
-        "given": "Ulla"
-      },
-      {
-        "family": "Karjalainen-Lindsberg",
-        "given": "Marja-Liisa"
-      },
-      {
-        "family": "Lahti",
-        "given": "Leo"
-      },
-      {
-        "family": "Knuutila.",
-        "given": "Sakari"
-      }
-    ],
-    "container-title": "Leukemia Research",
-    "id": "Borze11",
-    "issued": {
-      "date-parts": [
-        [
-          2011,
-          2
-        ]
-      ]
-    },
-    "keyword": "bioscience",
-    "page": "188-195",
-    "title": "MicroRNA microarrays on archive bone marrow core biopsies of leukemias - method validation",
-    "type": "article-journal",
-    "volume": "35"
-  },
-  {
-    "DOI": "10.1186/s40168-017-0309-z",
-    "URL": "https://github.com/openresearchlabs/openresearchlabs.github.io/blob/master/content/publication_resources/papers/2017-Buelow-Microbiome.pdf",
-    "author": [
-      {
-        "family": "Buelow",
-        "given": "Elena"
-      },
-      {
-        "family": "González",
-        "given": "Teresita d.J. Bello"
-      },
-      {
-        "family": "Fuentes",
-        "given": "Susana"
-      },
-      {
-        "family": "Steenhuijsen Piters",
-        "given": "Wouter A. A.",
-        "non-dropping-particle": "de"
-      },
-      {
-        "family": "Lahti",
-        "given": "Leo"
-      },
-      {
-        "family": "Bayjanov",
-        "given": "Jumamurat R."
-      },
-      {
-        "family": "Majoor",
-        "given": "Eline A. M."
-      },
-      {
-        "family": "Braat",
-        "given": "Johanna C."
-      },
-      {
-        "dropping-particle": "van",
-        "family": "Mourik",
-        "given": "Maaike S."
-      },
-      {
-        "family": "Oostdijk",
-        "given": "Evelien A. N."
-      },
-      {
-        "family": "Willems",
-        "given": "Rob J. L."
-      },
-      {
-        "family": "Bonten",
-        "given": "Marc J. M."
-      },
-      {
-        "dropping-particle": "van",
-        "family": "Passel",
-        "given": "Mark W. J."
-      },
-      {
-        "family": "Smidt",
-        "given": "Hauke"
-      },
-      {
-        "dropping-particle": "van",
-        "family": "Schaik",
-        "given": "Willem"
-      }
-    ],
-    "container-title": "Microbiome",
-    "id": "Buelow2017",
-    "issue": "1",
-    "issued": {
-      "date-parts": [
-        [
-          2017,
-          8
-        ]
-      ]
-    },
-    "keyword": "bioscience",
-    "page": "88",
-    "title": "Comparative gut microbiota and resistome profiling of intensive care patients receiving selective digestive tract decontamination and healthy subjects",
-    "type": "article-journal",
-    "volume": "5"
-  },
-  {
-    "DOI": "10.1093/nar/gni193",
-    "URL": "https://github.com/openresearchlabs/openresearchlabs.github.io/blob/master/content/publication_resources/papers/2005-Elo-NAR.pdf",
-    "author": [
-      {
-        "family": "Elo",
-        "given": "Laura L."
-      },
-      {
-        "family": "Lahti",
-        "given": "Leo"
-      },
-      {
-        "family": "Skottman",
-        "given": "Heli"
-      },
-      {
-        "family": "Kyläniemi",
-        "given": "Minna"
-      },
-      {
-        "family": "Lahesmaa",
-        "given": "Riitta"
-      },
-      {
-        "family": "Aittokallio",
-        "given": "Tero"
-      }
-    ],
-    "container-title": "Nucleic Acids Research",
-    "id": "Elo05",
-    "issue": "22",
-    "issued": {
-      "date-parts": [
-        [
-          2005,
-          12
-        ]
-      ]
-    },
-    "keyword": "bioscience",
-    "page": "e193",
-    "title": "Integrating probe-level expression changes across generations of affymetrix arrays",
-    "type": "article-journal",
-    "volume": "33"
-  },
-  {
-    "URL": "https://github.com/openresearchlabs/openresearchlabs.github.io/blob/master/content/publication_resources/papers/2011-Faisal-NIPS.pdf",
-    "author": [
-      {
-        "family": "Faisal",
-        "given": "Ali"
-      },
-      {
-        "family": "Louhimo",
-        "given": "Riku"
-      },
-      {
-        "family": "Lahti",
-        "given": "Leo"
-      },
-      {
-        "family": "Hautaniemi",
-        "given": "Sampsa"
-      },
-      {
-        "family": "Kaski",
-        "given": "Samuel"
-      }
-    ],
-    "container-title": "NIPS 2011 workshop from statistical genetics to predictive models in personalized medicine",
-    "id": "Faisal2011",
-    "issued": {
-      "date-parts": [
-        [
-          2011
-        ]
-      ]
-    },
-    "keyword": "bioscience",
-    "title": "Biomarker discovery via dependency analysis of multi-view functional genomics data",
-    "type": "paper-conference"
-  },
-  {
-    "DOI": "10.1016/j.mib.2015.04.004",
-    "URL": "https://github.com/openresearchlabs/openresearchlabs.github.io/blob/master/content/publication_resources/papers/2015-Faust-CurrOpMicrob.pdf",
-    "author": [
-      {
-        "family": "Faust",
-        "given": "Karoline"
-      },
-      {
-        "family": "Lahti",
-        "given": "Leo"
-      },
-      {
-        "family": "Gonze",
-        "given": "Didier"
-      },
-      {
-        "dropping-particle": "de",
-        "family": "Vos",
-        "given": "Willem M"
-      },
-      {
-        "family": "Raes",
-        "given": "Jeroen"
-      }
-    ],
-    "container-title": "Current Opinion in Microbiology",
-    "id": "Faust15",
-    "issued": {
-      "date-parts": [
-        [
-          2015,
-          6
-        ]
-      ]
-    },
-    "keyword": "bioscience",
-    "page": "56-66",
-    "title": "Metagenomics meets time series analysis: Unraveling microbial community dynamics",
-    "title-short": "Metagenomics meets time series analysis",
-    "type": "article-journal",
-    "volume": "25"
-  },
-  {
-    "DOI": "10.1038/ismej.2017.60",
-    "URL": "https://github.com/openresearchlabs/openresearchlabs.github.io/blob/master/content/publication_resources/papers/2017-Faust-ISME.pdf",
-    "author": [
-      {
-        "family": "Gonze",
-        "given": "Didier"
-      },
-      {
-        "family": "Lahti",
-        "given": "Leo"
-      },
-      {
-        "family": "Raes",
-        "given": "Jeroen"
-      },
-      {
-        "family": "Faust",
-        "given": "Karoline"
-      }
-    ],
-    "container-title": "ISME Journal",
-    "id": "Faust2017",
-    "issued": {
-      "date-parts": [
-        [
-          2017,
-          5
-        ]
-      ]
-    },
-    "keyword": "bioscience",
-    "page": "2159-2166",
-    "title": "Multi-stability and the origin of microbial community types",
-    "type": "article-journal",
-    "volume": "11"
-  },
-  {
-    "DOI": "10.1186/s40168-018-0496-2",
-    "URL": "https://github.com/openresearchlabs/openresearchlabs.github.io/blob/master/content/publication_resources/papers/2018-Faust-Microbiome.pdf",
-    "author": [
-      {
-        "family": "Faust",
-        "given": "Karoline"
-      },
-      {
-        "family": "Bauchinger",
-        "given": "Franziska"
-      },
-      {
-        "family": "Laroche",
-        "given": "Beatrice"
-      },
-      {
-        "dropping-particle": "de",
-        "family": "Buyl",
-        "given": "Sophie"
-      },
-      {
-        "family": "Lahti",
-        "given": "Leo"
-      },
-      {
-        "family": "Washburne",
-        "given": "Alex D"
-      },
-      {
-        "family": "Gonze",
-        "given": "Didier"
-      },
-      {
-        "family": "Widder",
-        "given": "Stefanie"
-      }
-    ],
-    "container-title": "Microbiome",
-    "id": "Faust2018",
-    "issue": "120",
-    "issued": {
-      "date-parts": [
-        [
-          2018
-        ]
-      ]
-    },
-    "keyword": "bioscience",
-    "title": "Signatures of ecological processes in microbial community time series",
-    "type": "article-journal",
-    "volume": "6"
-  },
-  {
-    "DOI": "10.1016/j.mib.2018.07.004",
-    "URL": "https://github.com/openresearchlabs/openresearchlabs.github.io/blob/master/content/publication_resources/papers/2018-Gonze.pdf",
-    "author": [
-      {
-        "family": "Gonze",
-        "given": "Didier"
-      },
-      {
-        "family": "Coyte",
-        "given": "Katharine Z"
-      },
-      {
-        "family": "Lahti",
-        "given": "Leo"
-      },
-      {
-        "family": "Faust",
-        "given": "Karoline"
-      }
-    ],
-    "container-title": "Current Opinion in Microbiology",
-    "id": "Gonze2018",
-    "issued": {
-      "date-parts": [
-        [
-          2018
-        ]
-      ]
-    },
-    "keyword": "bioscience",
-    "page": "41-49",
-    "title": "Microbial communities as dynamical systems",
-    "type": "article-journal",
-    "volume": "44"
-  },
-  {
-    "DOI": "10.1002/gcc.20669",
-    "URL": "https://github.com/openresearchlabs/openresearchlabs.github.io/blob/master/content/publication_resources/papers/2009-GCC-Guled-miRNA.pdf",
-    "author": [
-      {
-        "family": "Guled",
-        "given": "Mohamed"
-      },
-      {
-        "family": "Lahti",
-        "given": "Leo"
-      },
-      {
-        "family": "Lindholm",
-        "given": "Pamela M."
-      },
-      {
-        "family": "Salmenkivi",
-        "given": "Kaisa"
-      },
-      {
-        "family": "Bagwan",
-        "given": "Izhar"
-      },
-      {
-        "family": "Nicholson",
-        "given": "Andrew G."
-      },
-      {
-        "family": "Knuutila",
-        "given": "Sakari"
-      }
-    ],
-    "container-title": "Genes, Chromosomes and Cancer",
-    "id": "Guled09",
-    "issue": "7",
-    "issued": {
-      "date-parts": [
-        [
-          2009,
-          7
-        ]
-      ]
-    },
-    "keyword": "bioscience",
-    "page": "615-623",
-    "title": "CDKN2A, NF2 and JUN are dysregulated among other genes by miRNAs in malignant mesothelioma - a miRNA microarray analysis",
-    "type": "article-journal",
-    "volume": "48"
-  },
-  {
-    "DOI": "10.1109/JPROC.2015.2428213",
-    "URL": "https://github.com/openresearchlabs/openresearchlabs.github.io/blob/master/content/publication_resources/papers/2017-Harris-IEEE.pdf",
-    "author": [
-      {
-        "family": "Harris",
-        "given": "Keith"
-      },
-      {
-        "family": "Parsons",
-        "given": "Todd L"
-      },
-      {
-        "family": "Ijaz",
-        "given": "Umer Z"
-      },
-      {
-        "family": "Lahti",
-        "given": "Leo"
-      },
-      {
-        "family": "Holmes",
-        "given": "Ian"
-      },
-      {
-        "family": "Quince",
-        "given": "Christopher"
-      }
-    ],
-    "container-title": "Proceedings of the IEEE",
-    "id": "Harris17",
-    "issue": "3",
-    "issued": {
-      "date-parts": [
-        [
-          2017
-        ]
-      ]
-    },
-    "keyword": "bioscience",
-    "page": "516-529",
-    "title": "Linking statistical and ecological theory: Hubbell’s unified neutral theory of biodiversity as a hierarchical dirichlet process",
-    "title-short": "Linking statistical and ecological theory",
-    "type": "article-journal",
-    "volume": "105"
-  },
-  {
-    "author": [
-      {
-        "family": "Hill",
-        "given": "Mark J"
-      },
-      {
-        "family": "Kanner",
-        "given": "Antti"
-      },
-      {
-        "family": "Marjanen",
-        "given": "Jani"
-      },
-      {
-        "family": "Vaara",
-        "given": "Ville"
-      },
-      {
-        "family": "Mäkelä",
-        "given": "Eetu"
-      },
-      {
-        "family": "Lahti",
-        "given": "Leo"
-      },
-      {
-        "family": "Tolonen",
-        "given": "Mikko"
-      }
-    ],
-    "container-title": "Proceedings of the digital humanities in the nordics conference",
-    "id": "Hill2018",
-    "issued": {
-      "date-parts": [
-        [
-          2018,
-          3
-        ]
-      ]
-    },
-    "keyword": "dh",
-    "publisher-place": "Helsinki, Finland",
-    "title": "Spheres of “public” in eighteenth-century britain",
-    "type": "paper-conference"
-  },
-  {
-    "URL": "https://github.com/openresearchlabs/openresearchlabs.github.io/blob/master/content/publication_resources/papers/2019-Hill-DHN.pdf",
-    "author": [
-      {
-        "family": "Hill",
-        "given": "Mark J"
-      },
-      {
-        "family": "Vaara",
-        "given": "Ville"
-      },
-      {
-        "family": "Säily",
-        "given": "Tanja"
-      },
-      {
-        "family": "Lahti",
-        "given": "Leo"
-      },
-      {
-        "family": "Tolonen",
-        "given": "Mikko"
-      }
-    ],
-    "collection-title": "CEUR workshop proceedings",
-    "container-title": "Proc. Digital humanities in the nordic countries",
-    "editor": [
-      {
-        "family": "Navarretta",
-        "given": "Costanza"
-      },
-      {
-        "family": "Agirrezabal",
-        "given": "Manex"
-      },
-      {
-        "family": "Maegaard",
-        "given": "Bente"
-      }
-    ],
-    "id": "Hill2019dhn",
-    "issued": {
-      "date-parts": [
-        [
-          2019
-        ]
-      ]
-    },
-    "keyword": "dh",
-    "note": "Best paper award.",
-    "page": "201-219",
-    "publisher-place": "Copenhagen",
-    "title": "Reconstructing intellectual networks: From the ESTC’s bibliographic metadata to historical material",
-    "title-short": "Reconstructing intellectual networks",
-    "type": "paper-conference",
-    "volume": "2364"
   },
   {
     "DOI": "10.3390/ijerph18084049",
@@ -1579,7 +459,8 @@
     "issued": {
       "date-parts": [
         [
-          2021
+          2021,
+          4
         ]
       ]
     },
@@ -1589,166 +470,6 @@
     "title-short": "Xylo-oligosaccharides in prevention of hepatic steatosis and adipose tissue inflammation",
     "type": "article-journal",
     "volume": "18"
-  },
-  {
-    "author": [
-      {
-        "family": "Ijaz",
-        "given": "Ali"
-      },
-      {
-        "family": "Roivainen",
-        "given": "Hege"
-      },
-      {
-        "family": "Lahti",
-        "given": "Leo"
-      }
-    ],
-    "container-title": "Proceedings of the digital humanities (DH2019)",
-    "id": "Ijaz2019dh",
-    "issued": {
-      "date-parts": [
-        [
-          2019
-        ]
-      ]
-    },
-    "keyword": "dh",
-    "note": "In press.",
-    "title": "Analytical edition detection in bibliographic metadata",
-    "type": "paper-conference"
-  },
-  {
-    "URL": "https://github.com/openresearchlabs/openresearchlabs.github.io/blob/master/content/publication_resources/papers/2019-Ijaz-RDHum.pdf",
-    "author": [
-      {
-        "family": "Ijaz",
-        "given": "Ali"
-      },
-      {
-        "family": "Tolonen",
-        "given": "Mikko"
-      },
-      {
-        "family": "Lahti",
-        "given": "Leo"
-      }
-    ],
-    "container-title": "Proceedings of the research data in the humanities conference",
-    "id": "Ijaz2019rdhum",
-    "issued": {
-      "date-parts": [
-        [
-          2019
-        ]
-      ]
-    },
-    "keyword": "dh",
-    "publisher-place": "Oulu",
-    "title": "Analytical determination of editions from bibliographic metadata",
-    "type": "paper-conference"
-  },
-  {
-    "URL": "https://github.com/openresearchlabs/openresearchlabs.github.io/blob/master/content/publication_resources/papers/2011-JalankaTuovinen-PLoS.pdf",
-    "author": [
-      {
-        "family": "Jalanka-Tuovinen",
-        "given": "Jonna"
-      },
-      {
-        "family": "Salonen",
-        "given": "Anne"
-      },
-      {
-        "family": "Nikkilä",
-        "given": "Janne"
-      },
-      {
-        "family": "Immonen",
-        "given": "Outi"
-      },
-      {
-        "family": "Kekkonen",
-        "given": "Riina"
-      },
-      {
-        "family": "Lahti",
-        "given": "Leo"
-      },
-      {
-        "family": "Palva",
-        "given": "Airi"
-      },
-      {
-        "dropping-particle": "de",
-        "family": "Vos",
-        "given": "Willem M."
-      }
-    ],
-    "container-title": "PLoS One",
-    "id": "Jalanka-Tuovinen11",
-    "issue": "7",
-    "issued": {
-      "date-parts": [
-        [
-          2011,
-          7
-        ]
-      ]
-    },
-    "keyword": "bioscience",
-    "page": "e23035",
-    "title": "Intestinal microbiota in healthy adults: Temporal analysis reveals individual and common core and relation to intestinal symptoms",
-    "title-short": "Intestinal microbiota in healthy adults",
-    "type": "article-journal",
-    "volume": "6"
-  },
-  {
-    "DOI": "10.1109/TCBB.2005.32",
-    "URL": "https://github.com/openresearchlabs/openresearchlabs.github.io/blob/master/content/publication_resources/papers/2005-TCBB–Kaski-AC.pdf",
-    "author": [
-      {
-        "family": "Kaski",
-        "given": "Samuel"
-      },
-      {
-        "family": "Nikkilä",
-        "given": "Janne"
-      },
-      {
-        "family": "Sinkkonen",
-        "given": "Janne"
-      },
-      {
-        "family": "Lahti",
-        "given": "Leo"
-      },
-      {
-        "family": "Knuuttila",
-        "given": "Juha"
-      },
-      {
-        "family": "Roos",
-        "given": "Christophe"
-      }
-    ],
-    "container-title": "IEEE/ACM Transactions on Computational Biology and Bioinformatics",
-    "id": "Kaski05",
-    "issue": "3",
-    "issued": {
-      "date-parts": [
-        [
-          2005
-        ]
-      ]
-    },
-    "keyword": "datascience",
-    "note": "Special Issue on Machine Learning for Bioinformatics – Part 2",
-    "page": "203-216",
-    "title": "Associative clustering for exploring dependencies between functional genomics data sets",
-    "type": "article-journal",
-    "volume": "2"
   },
   {
     "DOI": "10.1080/10253890.2021.1895110",
@@ -1800,7 +521,8 @@
     "issued": {
       "date-parts": [
         [
-          2021
+          2021,
+          3
         ]
       ]
     },
@@ -1810,1173 +532,6 @@
     "title": "Gut microbiota diversity but not composition is related to saliva cortisol stress response at the age of 2.5 months",
     "type": "article-journal",
     "volume": "24"
-  },
-  {
-    "DOI": "10.3390/sym13030368",
-    "author": [
-      {
-        "family": "Khalighi",
-        "given": "Moein"
-      },
-      {
-        "family": "Eftekhari",
-        "given": "Leila"
-      },
-      {
-        "family": "Hosseinpour",
-        "given": "Soleiman"
-      },
-      {
-        "family": "Lahti",
-        "given": "Leo"
-      }
-    ],
-    "container-title": "Symmetry",
-    "id": "Khalighi2021",
-    "issued": {
-      "date-parts": [
-        [
-          2020
-        ]
-      ]
-    },
-    "keyword": "datascience",
-    "page": "368",
-    "title": "Three-species lotka-volterra model with respect to caputo and caputo-fabrizio fractional operators",
-    "type": "article-journal",
-    "volume": "13"
-  },
-  {
-    "DOI": "10.7717/peerj.10442",
-    "author": [
-      {
-        "family": "Koffert",
-        "given": "Jukka"
-      },
-      {
-        "family": "Lahti",
-        "given": "Leo"
-      },
-      {
-        "family": "Nylund",
-        "given": "Lotta"
-      },
-      {
-        "family": "Salminen",
-        "given": "Seppo"
-      },
-      {
-        "family": "Hannukainen",
-        "given": "Jarna C"
-      },
-      {
-        "family": "Salminen",
-        "given": "Paulina"
-      },
-      {
-        "dropping-particle": "de",
-        "family": "Vos",
-        "given": "Willem"
-      },
-      {
-        "family": "Nuutila",
-        "given": "Pirjo"
-      }
-    ],
-    "container-title": "PeerJ – Life & Environment",
-    "id": "Koffert2020",
-    "issued": {
-      "date-parts": [
-        [
-          2020
-        ]
-      ]
-    },
-    "keyword": "bioscience",
-    "note": "Shared first authorship.",
-    "page": "e10442",
-    "title": "Partial restoration of normal intestinal microbiota in morbidly obese women six months after bariatric surgery",
-    "type": "article-journal",
-    "volume": "8"
-  },
-  {
-    "URL": "https://github.com/antagomir/thesis/blob/master/msc03/dtyo.pdf",
-    "author": [
-      {
-        "family": "Lahti",
-        "given": "Leo"
-      }
-    ],
-    "genre": "Master’s thesis",
-    "id": "Lahti03",
-    "issued": {
-      "date-parts": [
-        [
-          2003,
-          12
-        ]
-      ]
-    },
-    "keyword": "thesis",
-    "note": "(in Finnish)",
-    "publisher": "Helsinki University of Technology",
-    "title": "Comparative functional genome analysis using associative clustering",
-    "type": "thesis"
-  },
-  {
-    "URL": "https://github.com/openresearchlabs/openresearchlabs.github.io/blob/master/content/publication_resources/theses/LeoLahti-BSc-2008.pdf",
-    "author": [
-      {
-        "family": "Lahti",
-        "given": "Leo"
-      }
-    ],
-    "id": "Lahti09bsc",
-    "issued": {
-      "date-parts": [
-        [
-          2009,
-          7
-        ]
-      ]
-    },
-    "keyword": "thesis",
-    "note": "(In Finnish)",
-    "publisher": "B.Sc. thesis. University of Helsinki, Faculty of Political Sciences",
-    "title": "Concerning blackburn’s quasi-realism in securing moral discussion",
-    "type": ""
-  },
-  {
-    "URL": "https://github.com/openresearchlabs/openresearchlabs.github.io/blob/master/content/publication_resources/papers/2009-MLSP-Lahti-SimCCA.pdf",
-    "author": [
-      {
-        "family": "Lahti",
-        "given": "Leo"
-      },
-      {
-        "family": "Myllykangas",
-        "given": "Samuel"
-      },
-      {
-        "family": "Knuutila",
-        "given": "Sakari"
-      },
-      {
-        "family": "Kaski",
-        "given": "Samuel"
-      }
-    ],
-    "container-title": "Proc. MLSP’09 IEEE international workshop on machine learning for signal processing XIX",
-    "editor": [
-      {
-        "family": "Adali T",
-        "given": "Jutten C",
-        "suffix": "Chanussot J"
-      },
-      {
-        "family": "J",
-        "given": "Larsen"
-      }
-    ],
-    "id": "Lahti09mlsp",
-    "issued": {
-      "date-parts": [
-        [
-          2009
-        ]
-      ]
-    },
-    "keyword": "datascience",
-    "note": "R/Bioconductor: pint",
-    "page": "198-203",
-    "publisher": "software",
-    "publisher-place": "Piscataway, NJ",
-    "title": "Dependency detection with similarity constraints",
-    "type": "paper-conference"
-  },
-  {
-    "DOI": "10.18129/B9.BIOC.RPA",
-    "URL": "http://bioconductor.org/packages/release/bioc/html/RPA.html",
-    "author": [
-      {
-        "family": "Lahti",
-        "given": "Leo"
-      }
-    ],
-    "id": "Lahti09rpa",
-    "issued": {
-      "date-parts": [
-        [
-          2009
-        ]
-      ]
-    },
-    "keyword": "bioscience",
-    "note": "R/Bioconductor: RPA",
-    "publisher": "software",
-    "title": "RPA: Probe reliability and differential gene expression analysis",
-    "title-short": "RPA",
-    "type": ""
-  },
-  {
-    "DOI": "10.1093/bioinformatics/btq500",
-    "URL": "https://github.com/openresearchlabs/openresearchlabs.github.io/blob/master/content/publication_resources/papers/2010-Bioinformatics-Lahti-NetResponse.pdf",
-    "annote": "ArXiv: http://arxiv.org/abs/1202.0501; R/Matlab source code http://netpro.r-forge.r-project.org",
-    "author": [
-      {
-        "family": "Lahti",
-        "given": "Leo"
-      },
-      {
-        "family": "Knuuttila",
-        "given": "Juha E. A."
-      },
-      {
-        "family": "Kaski",
-        "given": "Samuel"
-      }
-    ],
-    "container-title": "Bioinformatics",
-    "id": "Lahti10bioinf",
-    "issued": {
-      "date-parts": [
-        [
-          2010,
-          11
-        ]
-      ]
-    },
-    "keyword": "bioscience",
-    "note": "R/Matlab implementations available at http://netpro.r-forge.r-project.org/",
-    "page": "2713-2720",
-    "title": "Global modeling of transcriptional responses in interaction networks",
-    "type": "article-journal",
-    "volume": "26"
-  },
-  {
-    "URL": "http://antagomir.wordpress.com/",
-    "author": [
-      {
-        "family": "Lahti",
-        "given": "Leo"
-      }
-    ],
-    "id": "Lahti10blog",
-    "keyword": "blog",
-    "title": "Opencomp blog",
-    "type": ""
-  },
-  {
-    "URL": "http://dmt.r-forge.r-project.org/",
-    "author": [
-      {
-        "family": "Lahti",
-        "given": "Leo"
-      },
-      {
-        "family": "Tripathi",
-        "given": "Abhishek"
-      },
-      {
-        "family": "Huovilainen",
-        "given": "Olli-Pekka"
-      }
-    ],
-    "id": "Lahti10dmt",
-    "issued": {
-      "date-parts": [
-        [
-          2010,
-          6
-        ]
-      ]
-    },
-    "keyword": "datascience",
-    "note": "CRAN: dmt",
-    "publisher": "software; ICML workshop",
-    "title": "Dependency modeling toolkit",
-    "type": ""
-  },
-  {
-    "DOI": "10.18129/B9.BIOC.NETRESPONSE",
-    "URL": "http://www.bioconductor.org/help/bioc-views/devel/bioc/html/netresponse.html",
-    "author": [
-      {
-        "family": "Lahti",
-        "given": "Leo"
-      },
-      {
-        "family": "Gusmao",
-        "given": "Antonio"
-      },
-      {
-        "family": "Huovilainen",
-        "given": "Olli-Pekka"
-      }
-    ],
-    "id": "Lahti10netresponse",
-    "issued": {
-      "date-parts": [
-        [
-          2010
-        ]
-      ]
-    },
-    "keyword": "datascience",
-    "note": "R/Bioconductor: netresponse",
-    "publisher": "software",
-    "title": "NetResponse (functional network analysis)",
-    "type": ""
-  },
-  {
-    "URL": "http://bioconductor.org/packages/devel/bioc/html/pint.html",
-    "author": [
-      {
-        "family": "Huovilainen",
-        "given": "Olli-Pekka"
-      },
-      {
-        "family": "Lahti",
-        "given": "Leo"
-      }
-    ],
-    "id": "Lahti10pint",
-    "issued": {
-      "date-parts": [
-        [
-          2010
-        ]
-      ]
-    },
-    "keyword": "datascience",
-    "note": "R/BioConductor: pint",
-    "publisher": "software",
-    "title": "Pairwise integration of functional genomics data",
-    "type": ""
-  },
-  {
-    "ISSN": "1797-5069",
-    "URL": "https://github.com/openresearchlabs/openresearchlabs.github.io/blob/master/content/publication_resources/papers/2010-Lahti-thesis.pdf",
-    "abstract": "Recent advances in high-throughput measurement technologies and efficient sharing of biomedical data through community databases have made it possible to investigate the complete collection of genetic material, the genome, which encodes the heritable genetic program of an organism. This has opened up new views to the study of living organisms with a profound impact on biological research. Functional genomics is a subdiscipline of molecular biology that investigates the functional organization of genetic information. This thesis develops computational strategies to investigate a key functional layer of the genome, the transcriptome. The time- and context-specific transcriptional activity of the genes regulates the function of living cells through protein synthesis. Efficient computational techniques are needed in order to extract useful information from high-dimensional genomic observations that are associated with high levels of complex variation. Statistical learning and probabilistic models provide the theoretical framework for combining statistical evidence across multiple observations and the wealth of background information in genomic data repositories. This thesis addresses three key challenges in transcriptome analysis. First, new preprocessing techniques that utilize side information in genomic sequence databases and microarray collections are developed to improve the accuracy of high-throughput microarray measurements. Second, a novel exploratory approach is proposed in order to construct a global view of cell-biological network activation patterns and functional relatedness between tissues across normal human body. Information in genomic interaction databases is used to derive constraints that help to focus the modeling in those parts of the data that are supported by known or potential interactions between the genes, and to scale up the analysis. The third contribution is to develop novel approaches to model dependency between co-occurring measurement sources. The methods are used to study cancer mechanisms and transcriptome evolution; integrative analysis of the human transcriptome and other layers of genomic information allows the identification of functional mechanisms and interactions that could not be detected based on the individual measurement sources. Open source implementations of the key methodological contributions have been released to facilitat e their further adoption by the research community.",
-    "author": [
-      {
-        "family": "Lahti",
-        "given": "Leo"
-      }
-    ],
-    "collection-title": "TKK dissertations in information and computer science",
-    "genre": "PhD thesis",
-    "id": "Lahti10thesis",
-    "issued": {
-      "date-parts": [
-        [
-          2010,
-          12
-        ]
-      ]
-    },
-    "keyword": "thesis, probabilistic models, Bayesian analysis, data integration, gene expression, microarrays, computational science, data analysis, machine learning, computational biology, open source, open access, creative commons",
-    "note": "LaTeX sources and the pdf version are openly available: https://github.com/antagomir/thesis/tree/master/phd10; Press release: https://github.com/antagomir/thesis/blob/master/phd10/Vaitostiedote-LeoLahti-20101207.pdf",
-    "number": "TKK-ICS-D19",
-    "publisher": "Aalto University School of Science and Technology, Faculty of Information and Natural Sciences, Department of Information and Computer Science",
-    "publisher-place": "Espoo",
-    "title": "Probabilistic analysis of the human transcriptome with side information",
-    "type": "thesis"
-  },
-  {
-    "URL": "http://louhos.github.io/",
-    "author": [
-      {
-        "family": "Lahti",
-        "given": "Leo"
-      },
-      {
-        "family": "Lehtomäki",
-        "given": "Joona"
-      },
-      {
-        "family": "Parkkinen",
-        "given": "Juuso"
-      },
-      {
-        "literal": "others"
-      }
-    ],
-    "id": "Lahti11-louhos",
-    "keyword": "blog",
-    "note": "Open government data analytics blog (in Finnish)",
-    "title": "Louhos blog",
-    "type": ""
-  },
-  {
-    "URL": "http://intcomp.r-forge.r-project.org/",
-    "author": [
-      {
-        "family": "Lahti",
-        "given": "Leo"
-      },
-      {
-        "family": "Schäfer",
-        "given": "Martin"
-      },
-      {
-        "family": "Klein",
-        "given": "Hans-Ulrich"
-      },
-      {
-        "family": "Bicciato",
-        "given": "Silvio"
-      },
-      {
-        "family": "Dugas",
-        "given": "Martin"
-      }
-    ],
-    "id": "Lahti11intcomp",
-    "issued": {
-      "date-parts": [
-        [
-          2011,
-          2
-        ]
-      ]
-    },
-    "keyword": "bioscience",
-    "note": "R-forge",
-    "publisher": "software",
-    "title": "Intcomp: A benchmarking pipeline for integrative cancer gene detection algorithms",
-    "title-short": "Intcomp",
-    "type": ""
-  },
-  {
-    "URL": "https://github.com/openresearchlabs/openresearchlabs.github.io/blob/master/content/publication_resources/papers/2011-MLSB-Lahti.pdf",
-    "author": [
-      {
-        "family": "Lahti",
-        "given": "Leo"
-      },
-      {
-        "family": "Kaski",
-        "given": "Samuel"
-      }
-    ],
-    "id": "Lahti11ismb",
-    "issued": {
-      "date-parts": [
-        [
-          2011
-        ]
-      ]
-    },
-    "keyword": "bioscience",
-    "note": "Machine Learning for Systems Biology workshop, ISMB, Vienna, Austria",
-    "title": "Probabilistic dependency models for data integration in functional genomics",
-    "type": ""
-  },
-  {
-    "DOI": "10.1109/TCBB.2009.38",
-    "URL": "https://github.com/openresearchlabs/openresearchlabs.github.io/blob/master/content/publication_resources/papers/2011-Lahti-TCBB.pdf",
-    "annote": "R/Bioconductor: RPA",
-    "author": [
-      {
-        "family": "Lahti",
-        "given": "Leo"
-      },
-      {
-        "family": "Elo",
-        "given": "Laura L."
-      },
-      {
-        "family": "Aittokallio",
-        "given": "Tero"
-      },
-      {
-        "family": "Kaski",
-        "given": "Samuel"
-      }
-    ],
-    "container-title": "IEEE/ACM Transactions on Computational Biology and Bioinformatics",
-    "id": "Lahti11rpa",
-    "issue": "1",
-    "issued": {
-      "date-parts": [
-        [
-          2011
-        ]
-      ]
-    },
-    "keyword": "bioscience",
-    "page": "217-225",
-    "publisher": "IEEE Computer Society",
-    "publisher-place": "Los Alamitos, CA, USA",
-    "title": "Probabilistic analysis of probe reliability in differential gene expression studies with short oligonucleotide arrays",
-    "type": "article-journal",
-    "volume": "8"
-  },
-  {
-    "DOI": "10.1111/j.1469-0691.2012.03855.x",
-    "URL": "https://github.com/openresearchlabs/openresearchlabs.github.io/blob/master/content/publication_resources/papers/2012-Salonen-CMI.pdf",
-    "author": [
-      {
-        "family": "Salonen",
-        "given": "Anne"
-      },
-      {
-        "family": "Salojärvi",
-        "given": "Jarkko"
-      },
-      {
-        "family": "Lahti",
-        "given": "Leo"
-      },
-      {
-        "dropping-particle": "and Willem M. de",
-        "family": "Vos"
-      }
-    ],
-    "container-title": "Clinical Microbiology and Infection",
-    "id": "Lahti12cmi",
-    "issue": "Suppl. 4",
-    "issued": {
-      "date-parts": [
-        [
-          2012
-        ]
-      ]
-    },
-    "keyword": "bioscience",
-    "page": "16-20",
-    "title": "The adult intestinal core microbiota is determined by analysis depth and health status",
-    "type": "article-journal",
-    "volume": "18"
-  },
-  {
-    "URL": "http://ropengov.github.io/",
-    "author": [
-      {
-        "family": "Lahti",
-        "given": "Leo"
-      },
-      {
-        "family": "Lehtomäki",
-        "given": "Joona"
-      },
-      {
-        "family": "Kainu",
-        "given": "Markus"
-      },
-      {
-        "family": "Parkkinen",
-        "given": "Juuso"
-      },
-      {
-        "literal": "others"
-      }
-    ],
-    "id": "Lahti13-ropengov",
-    "keyword": "blog",
-    "note": "Open government data analytics blog",
-    "title": "rOpenGov blog",
-    "type": ""
-  },
-  {
-    "URL": "http://ropengov.github.io",
-    "author": [
-      {
-        "family": "Leo Lahti",
-        "given": "Joona Lehtomäki",
-        "suffix": "Juuso Parkkinen"
-      },
-      {
-        "family": "Kainu",
-        "given": "Markus"
-      }
-    ],
-    "id": "Lahti13icml",
-    "issued": {
-      "date-parts": [
-        [
-          2013,
-          12
-        ]
-      ]
-    },
-    "keyword": "datascience",
-    "note": "ICML/MLOSS workshop (Int’l Conf. on Machine Learning - Open Source Software workshop).",
-    "publisher": "software",
-    "title": "rOpenGov: Open source ecosystem for computational social sciences and digital humanities",
-    "title-short": "rOpenGov",
-    "type": ""
-  },
-  {
-    "DOI": "10.1093/nar/gkt229",
-    "URL": "https://github.com/openresearchlabs/openresearchlabs.github.io/blob/master/content/publication_resources/papers/2013-Lahti-NAR.pdf",
-    "author": [
-      {
-        "family": "Lahti",
-        "given": "Leo"
-      },
-      {
-        "family": "Torrente",
-        "given": "Aurora"
-      },
-      {
-        "family": "Elo",
-        "given": "Laura L"
-      },
-      {
-        "family": "Brazma",
-        "given": "Alvis"
-      },
-      {
-        "family": "Rung",
-        "given": "Johan"
-      }
-    ],
-    "container-title": "Nucleic Acids Research",
-    "id": "Lahti13nar",
-    "issue": "10",
-    "issued": {
-      "date-parts": [
-        [
-          2013
-        ]
-      ]
-    },
-    "keyword": "bioscience",
-    "note": "Implementation available through Bioconductor RPA package.",
-    "page": "e110",
-    "title": "A fully scalable online pre-processing algorithm for short oligonucleotide microarray atlases",
-    "type": "article-journal",
-    "volume": "41"
-  },
-  {
-    "DOI": "10.7717/peerj.32",
-    "PMID": "23638368",
-    "URL": "https://github.com/openresearchlabs/openresearchlabs.github.io/blob/master/content/publication_resources/papers/2013-Lahti-PeerJ.pdf",
-    "author": [
-      {
-        "family": "Lahti",
-        "given": "Leo"
-      },
-      {
-        "family": "Salonen",
-        "given": "Anne"
-      },
-      {
-        "family": "Kekkonen",
-        "given": "Riina A."
-      },
-      {
-        "family": "Salojärvi",
-        "given": "Jarkko"
-      },
-      {
-        "family": "Jalanka-Tuovinen",
-        "given": "Jonna"
-      },
-      {
-        "family": "Palva",
-        "given": "Airi"
-      },
-      {
-        "family": "Orešič",
-        "given": "Matej"
-      },
-      {
-        "dropping-particle": "de",
-        "family": "Vos",
-        "given": "Willem M."
-      }
-    ],
-    "container-title": "PeerJ",
-    "id": "Lahti13provasI",
-    "issued": {
-      "date-parts": [
-        [
-          2013
-        ]
-      ]
-    },
-    "keyword": "bioscience",
-    "note": "Highly accessed, featured in PeerJ journal blog and Top-10 Microbiology collection.",
-    "page": "e32",
-    "title": "Associations between the human intestinal microbiota, lactobacillus rhamnosus GG and serum lipids indicated by integrated analysis of high-throughput profiling data",
-    "type": "article-journal",
-    "volume": "1"
-  },
-  {
-    "DOI": "10.18352/lq.10112",
-    "ISSN": "2213-056X",
-    "URL": "https://github.com/openresearchlabs/openresearchlabs.github.io/blob/master/content/publication_resources/papers/2015-Lahti-LIBERQuarterly.pdf",
-    "author": [
-      {
-        "family": "Lahti",
-        "given": "Leo"
-      },
-      {
-        "family": "Ilomäki",
-        "given": "Niko"
-      },
-      {
-        "family": "Tolonen",
-        "given": "Mikko"
-      }
-    ],
-    "container-title": "LIBER Quarterly",
-    "id": "Lahti15LIBER",
-    "issue": "2",
-    "issued": {
-      "date-parts": [
-        [
-          2015,
-          12
-        ]
-      ]
-    },
-    "keyword": "dh",
-    "page": "87-116",
-    "status": "dh",
-    "title": "A quantitative study of history in the english short-title catalogue (ESTC) 1470-1800",
-    "type": "article-journal",
-    "volume": "25"
-  },
-  {
-    "URL": "https://github.com/openresearchlabs/openresearchlabs.github.io/blob/master/content/publication_resources/papers/2017-Lahti-RJournal.pdf",
-    "annote": "R package homepage URL: http://ropengov.github.io/eurostat/",
-    "author": [
-      {
-        "family": "Lahti",
-        "given": "Leo"
-      },
-      {
-        "family": "Huovari",
-        "given": "Janne"
-      },
-      {
-        "family": "Kainu",
-        "given": "Markus"
-      },
-      {
-        "family": "Biecek",
-        "given": "Przemysław"
-      }
-    ],
-    "container-title": "The R Journal",
-    "id": "Lahti17eurostat",
-    "issue": "1",
-    "issued": {
-      "date-parts": [
-        [
-          2017
-        ]
-      ]
-    },
-    "keyword": "dh",
-    "page": "385-392",
-    "title": "Retrieval and analysis of eurostat open data with the eurostat package",
-    "type": "article-journal",
-    "volume": "9"
-  },
-  {
-    "DOI": "10.3897/rio.3.e13593",
-    "URL": "https://github.com/openresearchlabs/openresearchlabs.github.io/blob/master/content/publication_resources/papers/2017-Lahti-PHOS.pdf",
-    "author": [
-      {
-        "family": "Lahti",
-        "given": "Leo"
-      },
-      {
-        "dropping-particle": "da",
-        "family": "Silva",
-        "given": "Filipe"
-      },
-      {
-        "family": "Laine",
-        "given": "Markus Petteri"
-      },
-      {
-        "family": "Lähteenoja",
-        "given": "Viivi"
-      },
-      {
-        "family": "Tolonen",
-        "given": "Mikko"
-      }
-    ],
-    "container-title": "RIO Journal",
-    "id": "Lahti17phos",
-    "issued": {
-      "date-parts": [
-        [
-          2017,
-          5
-        ]
-      ]
-    },
-    "keyword": "dh",
-    "note": "Review of the international conference, including electronic material (video interviews, lectures and podcasts.",
-    "page": "e13593",
-    "status": "openscience",
-    "title": "Alchemy & algorithms: Perspectives on the philosophy and history of open science",
-    "title-short": "Alchemy & algorithms",
-    "type": "article-journal",
-    "volume": "3"
-  },
-  {
-    "URL": "https://github.com/antagomir/thesis/tree/master/julia01",
-    "author": [
-      {
-        "family": "Lahti",
-        "given": "Leo"
-      }
-    ],
-    "id": "Lahti2001",
-    "issued": {
-      "date-parts": [
-        [
-          2001
-        ]
-      ]
-    },
-    "keyword": "thesis",
-    "note": "Special assignment in Mathematics (in Finnish)",
-    "title": "Julian joukko iteraatioden valuma-altaan reunana",
-    "type": ""
-  },
-  {
-    "URL": "https://github.com/antagomir/thesis/tree/master/hausdorff02",
-    "author": [
-      {
-        "family": "Lahti",
-        "given": "Leo"
-      }
-    ],
-    "id": "Lahti2002",
-    "issued": {
-      "date-parts": [
-        [
-          2002
-        ]
-      ]
-    },
-    "keyword": "thesis",
-    "note": "Special assignment in Mathematics (in Finnish)",
-    "title": "Itsesimilaaristen joukkojen hausdorffin dimension määrittäminen",
-    "type": ""
-  },
-  {
-    "URL": "https://arxiv.org/abs/1109.4919",
-    "author": [
-      {
-        "family": "Lahti",
-        "given": "Leo"
-      }
-    ],
-    "id": "Lahti2006biopax",
-    "issued": {
-      "date-parts": [
-        [
-          2007
-        ]
-      ]
-    },
-    "keyword": "bioscience",
-    "note": "(in Finnish)",
-    "publisher": "arXiv",
-    "title": "A brief overview on the BioPAX and SBML standards",
-    "type": ""
-  },
-  {
-    "DOI": "10.1093/bib/bbs005",
-    "URL": "https://github.com/openresearchlabs/openresearchlabs.github.io/blob/master/content/publication_resources/papers/2013-Lahti-BriefBioinf.pdf",
-    "author": [
-      {
-        "family": "Lahti",
-        "given": "Leo"
-      },
-      {
-        "family": "Schäfer",
-        "given": "Martin"
-      },
-      {
-        "family": "Klein",
-        "given": "Hans-Ulrich"
-      },
-      {
-        "family": "Bicciato",
-        "given": "Silvio"
-      },
-      {
-        "family": "Dugas",
-        "given": "Martin"
-      }
-    ],
-    "container-title": "Briefings in Bioinformatics",
-    "id": "Lahti2012intcomp",
-    "issue": "1",
-    "issued": {
-      "date-parts": [
-        [
-          2013,
-          6
-        ]
-      ]
-    },
-    "keyword": "bioscience",
-    "page": "27-35",
-    "title": "Cancer gene prioritization by integrative analysis of mRNA expression and DNA copy number data: A comparative review",
-    "title-short": "Cancer gene prioritization by integrative analysis of mRNA expression and DNA copy number data",
-    "type": "article-journal",
-    "volume": "14"
-  },
-  {
-    "URL": "https://github.com/openresearchlabs/openresearchlabs.github.io/blob/devel/publications/https://github.com/openresearchlabs/openresearchlabs.github.io/blob/master/content/publication_resources/papers/2018-Lahti-IDA.pdf",
-    "author": [
-      {
-        "family": "Lahti",
-        "given": "Leo"
-      }
-    ],
-    "container-title": "Advances in intelligent data analysis XVII. Lecture notes in computer science 11191.",
-    "id": "Lahti2018IDA",
-    "issued": {
-      "date-parts": [
-        [
-          2018
-        ]
-      ]
-    },
-    "keyword": "openscience",
-    "note": "Conference proceedings.",
-    "publisher": "Springer Nature",
-    "publisher-place": "India",
-    "title": "Open data science",
-    "type": "paper-conference",
-    "volume": "11191"
-  },
-  {
-    "DOI": "10.1080/01639374.2018.1543747",
-    "URL": "https://github.com/openresearchlabs/openresearchlabs.github.io/blob/master/content/publication_resources/papers/2019-Lahti-CCQ.pdf",
-    "author": [
-      {
-        "family": "Lahti",
-        "given": "Leo"
-      },
-      {
-        "family": "Marjanen",
-        "given": "Jani"
-      },
-      {
-        "family": "Roivainen",
-        "given": "Hege"
-      },
-      {
-        "family": "Tolonen",
-        "given": "Mikko"
-      }
-    ],
-    "container-title": "Cataloging & Classification Quarterly",
-    "id": "Lahti2019bds",
-    "issue": "1",
-    "issued": {
-      "date-parts": [
-        [
-          2019
-        ]
-      ]
-    },
-    "keyword": "dh",
-    "note": "Special issue.",
-    "page": "5-23",
-    "publisher": "Routledge",
-    "title": "Bibliographic data science and the history of the book (c. 1500–1800)",
-    "type": "article-journal",
-    "volume": "57"
-  },
-  {
-    "URL": "https://github.com/openresearchlabs/openresearchlabs.github.io/blob/master/content/publication_resources/papers/2019-Lahti-RDHUM.pdf",
-    "author": [
-      {
-        "family": "Lahti",
-        "given": "Leo"
-      },
-      {
-        "family": "Vaara",
-        "given": "Ville"
-      },
-      {
-        "family": "Marjanen",
-        "given": "Jani"
-      },
-      {
-        "family": "Tolonen",
-        "given": "Mikko"
-      }
-    ],
-    "container-title": "Proceedings of the research data in the humanities conference",
-    "id": "Lahti2019rdhum",
-    "issued": {
-      "date-parts": [
-        [
-          2019
-        ]
-      ]
-    },
-    "keyword": "dh",
-    "publisher-place": "Oulu",
-    "title": "Best practices in bibliographic data science",
-    "type": "paper-conference"
-  },
-  {
-    "URL": "http://ceur-ws.org/Vol-2723/short46.pdf",
-    "author": [
-      {
-        "family": "Lahti",
-        "given": "Leo"
-      },
-      {
-        "family": "Mäkelä",
-        "given": "Eetu"
-      },
-      {
-        "family": "Tolonen",
-        "given": "Mikko"
-      }
-    ],
-    "container-title": "Proc. CEUR Workshop Proceedings on Computational Humanities Research",
-    "id": "Lahti2020chr",
-    "issued": {
-      "date-parts": [
-        [
-          2020,
-          11
-        ]
-      ]
-    },
-    "keyword": "dh",
-    "page": "80-89",
-    "title": "Quantifying bias and uncertainty in historical data collections with probabilistic programming",
-    "type": "paper-conference"
-  },
-  {
-    "URL": "https://www.hs.fi/mielipide/art-2000006494641.html",
-    "author": [
-      {
-        "family": "Lahti",
-        "given": "Leo"
-      },
-      {
-        "family": "Wallgren",
-        "given": "Thomas"
-      },
-      {
-        "family": "Kulmala",
-        "given": "Markku"
-      }
-    ],
-    "container-title": "HS Mielipide",
-    "id": "Lahti2020hs1",
-    "issued": {
-      "date-parts": [
-        [
-          2020,
-          5
-        ]
-      ]
-    },
-    "keyword": "opinion",
-    "title": "Laskentamallit eivät lähtökohtaisesti ole salassa pidettävää tietoa",
-    "type": "article-journal"
-  },
-  {
-    "URL": "https://www.hs.fi/mielipide/art-2000006545770.html",
-    "author": [
-      {
-        "family": "Lahti",
-        "given": "Leo"
-      }
-    ],
-    "container-title": "HS Mielipide",
-    "id": "Lahti2020hs2",
-    "issued": {
-      "date-parts": [
-        [
-          2020
-        ]
-      ]
-    },
-    "keyword": "opinion",
-    "title": "Lähdekoodin sisältämien yksityiskohtien avoimuus on keskeistä päätöksenteon läpinäkyvyydelle.",
-    "type": "article-journal"
-  },
-  {
-    "URL": "https://www.okf.fi/fi/2020/05/13/tietopyynto-thln-epidemialaskelmien-lahdekoodeista",
-    "author": [
-      {
-        "family": "Lahti",
-        "given": "Leo"
-      },
-      {
-        "family": "Toikkanen",
-        "given": "Tarmo"
-      }
-    ],
-    "container-title": "Open Knowledge Finland Blog",
-    "id": "Lahti2020okf1",
-    "issued": {
-      "date-parts": [
-        [
-          2020,
-          5
-        ]
-      ]
-    },
-    "keyword": "opinion",
-    "title": "Tietopyyntö epidemialaskelmien lähdekoodeista",
-    "type": "article-journal"
-  },
-  {
-    "URL": "https://www.okf.fi/fi/2020/06/15/thln-paatos-epidemialaskelmien-salaamisesta-vastoin-valtioneuvoston-avoimuuslinjausta/",
-    "author": [
-      {
-        "family": "Lahti",
-        "given": "Leo"
-      }
-    ],
-    "container-title": "Open Knowledge Finland Blog",
-    "id": "Lahti2020okf2",
-    "issued": {
-      "date-parts": [
-        [
-          2020
-        ]
-      ]
-    },
-    "keyword": "opinion",
-    "title": "Päätös epidemialaskelmien salaamisesta vastoin valtioneuvoston avoimuuslinjausta",
-    "type": "article-journal"
-  },
-  {
-    "URL": "https://blogs.helsinki.fi/thinkopen/lahdekoodin-avoimuus-paatoksenteossa/",
-    "author": [
-      {
-        "family": "Lahti",
-        "given": "Leo"
-      }
-    ],
-    "container-title": "University of Helsinki, ThinkOpen blog",
-    "id": "Lahti2020thinkopen",
-    "issued": {
-      "date-parts": [
-        [
-          2020
-        ]
-      ]
-    },
-    "keyword": "opinion",
-    "title": "Avoimuus voi vahvistaa päätöksenteon tieteellistä pohjaa",
-    "type": "article-journal"
   },
   {
     "DOI": "10.7490/f1000research.1118712.1",
@@ -3014,266 +569,6 @@
     "volume": "10"
   },
   {
-    "ISBN": "978-1-4503-3948-3",
-    "URL": "https://github.com/openresearchlabs/openresearchlabs.github.io/blob/master/content/publication_resources/papers/2015-Laine-Mindtrek.pdf",
-    "author": [
-      {
-        "family": "Laine",
-        "given": "Heidi"
-      },
-      {
-        "family": "Lahti",
-        "given": "Leo"
-      },
-      {
-        "family": "Lehto",
-        "given": "Anne"
-      },
-      {
-        "family": "Ollila",
-        "given": "Samuli"
-      },
-      {
-        "family": "Miettinen",
-        "given": "Markus"
-      }
-    ],
-    "container-title": "Proceedings of the 19th international academic mindtrek conference in tampere, finland, september 22-24",
-    "id": "Laine15",
-    "issued": {
-      "date-parts": [
-        [
-          2015
-        ]
-      ]
-    },
-    "keyword": "openscience",
-    "publisher": "AcademicMindTrek’15: Proceedings of the 19th International Academic Mindtrek Conference; ACM",
-    "publisher-place": "New York, NY, USA",
-    "title": "Beyond open access - the changing culture of producing and disseminating scientific knowledge",
-    "type": "paper-conference"
-  },
-  {
-    "URL": "https://github.com/openresearchlabs/openresearchlabs.github.io/blob/master/content/publication_resources/papers/2018-Laitinen-IDA.pdf",
-    "author": [
-      {
-        "family": "Laitinen",
-        "given": "Ville"
-      },
-      {
-        "family": "Lahti",
-        "given": "Leo"
-      }
-    ],
-    "container-title": "Advances in intelligent data analysis XVII. Lecture notes in computer science 11191.",
-    "id": "Laitinen2018IDA",
-    "issued": {
-      "date-parts": [
-        [
-          2018
-        ]
-      ]
-    },
-    "keyword": "datascience",
-    "note": "Conference proceedings.",
-    "publisher": "Springer",
-    "publisher-place": "India",
-    "title": "A hierarchical ornstein-uhlenbeck model for stochastic time series analysis",
-    "type": "paper-conference"
-  },
-  {
-    "DOI": "10.4161/sysb.28904",
-    "URL": "https://github.com/openresearchlabs/openresearchlabs.github.io/blob/master/content/publication_resources/papers/2014-Louhimo.pdf",
-    "author": [
-      {
-        "family": "Louhimo",
-        "given": "Riku"
-      },
-      {
-        "family": "Aittomäki",
-        "given": "Viljami"
-      },
-      {
-        "family": "Faisal",
-        "given": "Ali"
-      },
-      {
-        "family": "Laakso",
-        "given": "Marko"
-      },
-      {
-        "family": "Chen",
-        "given": "Ping"
-      },
-      {
-        "family": "Ovaska",
-        "given": "Kristian"
-      },
-      {
-        "family": "Valo",
-        "given": "Erkka"
-      },
-      {
-        "family": "Lahti",
-        "given": "Leo"
-      },
-      {
-        "family": "Rogojin",
-        "given": "Vladimir"
-      },
-      {
-        "family": "Kaski",
-        "given": "Samuel"
-      },
-      {
-        "family": "Hautaniemi.",
-        "given": "Sampsa"
-      }
-    ],
-    "container-title": "Systems Biomedicine (special issue)",
-    "id": "Louhimo14",
-    "issued": {
-      "date-parts": [
-        [
-          2014,
-          4
-        ]
-      ]
-    },
-    "keyword": "bioscience",
-    "note": "Critical Assessment of Massive Data Analysis (CAMDA) workshop",
-    "page": "130-136",
-    "title": "Systematic use of computational methods allows stratifying treatment responders in glioblastoma multiforme",
-    "type": "article-journal",
-    "volume": "1"
-  },
-  {
-    "URL": "https://github.com/openresearchlabs/openresearchlabs.github.io/blob/master/content/publication_resources/papers/2019-Makela-DHN.pdf",
-    "author": [
-      {
-        "family": "Mäkelä",
-        "given": "Eetu"
-      },
-      {
-        "family": "Tolonen",
-        "given": "Mikko"
-      },
-      {
-        "family": "Marjanen",
-        "given": "Jani"
-      },
-      {
-        "family": "Kanner",
-        "given": "Antti"
-      },
-      {
-        "family": "Vaara",
-        "given": "Ville"
-      },
-      {
-        "family": "Lahti",
-        "given": "Leo"
-      }
-    ],
-    "collection-title": "CEUR workshop proceedings",
-    "container-title": "Proc. Twin talks workshop. Digital humanities in the nordic countries",
-    "editor": [
-      {
-        "family": "Krauwer",
-        "given": "Steven"
-      },
-      {
-        "family": "Fišer",
-        "given": "Darja"
-      }
-    ],
-    "id": "Makela2019dhn",
-    "issued": {
-      "date-parts": [
-        [
-          2019
-        ]
-      ]
-    },
-    "keyword": "dh",
-    "page": "55-66",
-    "publisher-place": "Copenhagen",
-    "status": "dh",
-    "title": "Interdisciplinary collaboration in studying newspaper materiality",
-    "type": "paper-conference",
-    "volume": "2365"
-  },
-  {
-    "URL": "https://github.com/openresearchlabs/openresearchlabs.github.io/blob/master/content/publication_resources/papers/2020-Makela-DHN.pdf",
-    "author": [
-      {
-        "family": "Eetu",
-        "given": "M"
-      },
-      {
-        "family": "Lagus",
-        "given": "K"
-      },
-      {
-        "family": "Lahti",
-        "given": "L"
-      },
-      {
-        "family": "Säily",
-        "given": "T"
-      },
-      {
-        "family": "Tolonen",
-        "given": "M"
-      },
-      {
-        "family": "Hämäläinen",
-        "given": "M"
-      },
-      {
-        "family": "Kaislaniemi",
-        "given": "S"
-      },
-      {
-        "family": "Nevalainen",
-        "given": "T"
-      }
-    ],
-    "collection-title": "CEUR workshop proceedings",
-    "container-title": "Proc. Digital humanities in the nordic countries",
-    "editor": [
-      {
-        "family": "Reinsone",
-        "given": "Sanita"
-      },
-      {
-        "family": "Skadiņa",
-        "given": "Inguna"
-      },
-      {
-        "family": "Baklāne",
-        "given": "Anda"
-      },
-      {
-        "family": "Daugavietis",
-        "given": "Jānis"
-      }
-    ],
-    "id": "Makela2020",
-    "issued": {
-      "date-parts": [
-        [
-          2020
-        ]
-      ]
-    },
-    "keyword": "dh",
-    "page": "81-96",
-    "title": "Wrangling with non-standard data",
-    "type": "paper-conference",
-    "volume": "2612"
-  },
-  {
     "URL": "https://www.hs.fi/mielipide/art-2000008325656.html?share=6421b425ce95dfc19d87511d90f6d3c4",
     "author": [
       {
@@ -3297,7 +592,8 @@
     "issued": {
       "date-parts": [
         [
-          2021
+          2021,
+          10
         ]
       ]
     },
@@ -3444,56 +740,6 @@
     "title-short": "Applications of machine learning in human microbiome studies",
     "type": "article-journal",
     "volume": "12"
-  },
-  {
-    "DOI": "10.21825/jeps.v4i1.10483",
-    "URL": "https://github.com/openresearchlabs/openresearchlabs.github.io/blob/master/content/publication_resources/papers/2019-Marjanen-JEPS.pdf",
-    "author": [
-      {
-        "family": "Marjanen",
-        "given": "Jani"
-      },
-      {
-        "family": "Vaara",
-        "given": "Ville"
-      },
-      {
-        "family": "Kanner",
-        "given": "Antti"
-      },
-      {
-        "family": "Roivainen",
-        "given": "Hege"
-      },
-      {
-        "family": "Mäkelä",
-        "given": "Eetu"
-      },
-      {
-        "family": "Lahti",
-        "given": "Leo"
-      },
-      {
-        "family": "Tolonen",
-        "given": "Mikko"
-      }
-    ],
-    "container-title": "Journal of European Periodical Studies",
-    "id": "Marjanen2019",
-    "issue": "1",
-    "issued": {
-      "date-parts": [
-        [
-          2019
-        ]
-      ]
-    },
-    "keyword": "dh",
-    "note": "Special issue: Digital Approaches Towards Serial Publications",
-    "status": "dh",
-    "title": "A national public sphere? Analyzing the language, location, and form of newspapers in finland, 1771–1917",
-    "type": "article-journal",
-    "volume": "4"
   },
   {
     "DOI": "10.3389/fmicb.2021.635781",
@@ -3660,7 +906,8 @@
     "issued": {
       "date-parts": [
         [
-          2021
+          2021,
+          2
         ]
       ]
     },
@@ -3670,691 +917,6 @@
     "title-short": "Statistical and machine learning techniques in human microbiome studies",
     "type": "article-journal",
     "volume": "12"
-  },
-  {
-    "DOI": "10.1038/modpathol.2010.146",
-    "URL": "https://github.com/openresearchlabs/openresearchlabs.github.io/blob/master/content/publication_resources/papers/2010-ModernPathology-Mosakhani-Dupuytre.pdf",
-    "author": [
-      {
-        "family": "Mosakhani",
-        "given": "Neda"
-      },
-      {
-        "family": "Guled",
-        "given": "Mohamed"
-      },
-      {
-        "family": "Lahti",
-        "given": "Leo"
-      },
-      {
-        "family": "Borze",
-        "given": "Ioana"
-      },
-      {
-        "family": "Forsman",
-        "given": "Minna"
-      },
-      {
-        "family": "Ryhänen",
-        "given": "Jorma"
-      },
-      {
-        "family": "Knuutila",
-        "given": "Sakari"
-      }
-    ],
-    "container-title": "Modern Pathology",
-    "id": "Mosakhani10",
-    "issued": {
-      "date-parts": [
-        [
-          2010,
-          11
-        ]
-      ]
-    },
-    "keyword": "bioscience",
-    "note": "International Dupuytren Award for best research paper in 2011",
-    "page": "1544-1522",
-    "title": "Unique microRNA profile in dupuytren’s contracture supports deregulation of beta-catenin pathway",
-    "type": "article-journal",
-    "volume": "23"
-  },
-  {
-    "DOI": "10.1016/j.cancergen.2012.08.003",
-    "URL": "https://github.com/openresearchlabs/openresearchlabs.github.io/blob/master/content/publication_resources/papers/2012-Mosakhani-CG.pdf",
-    "author": [
-      {
-        "family": "Mosakhani",
-        "given": "Neda"
-      },
-      {
-        "family": "Lahti",
-        "given": "Leo"
-      },
-      {
-        "family": "Borze",
-        "given": "Ioana"
-      },
-      {
-        "family": "Karjalainen-Lindsberg",
-        "given": "Marja-Liisa"
-      },
-      {
-        "family": "Sundstrom",
-        "given": "Jari"
-      },
-      {
-        "family": "Ristamaki",
-        "given": "Raija"
-      },
-      {
-        "family": "Osterlund",
-        "given": "Pia"
-      },
-      {
-        "family": "Knuutila",
-        "given": "Sakari"
-      },
-      {
-        "dropping-particle": "and",
-        "family": "Virinder Kaur Sarhadi"
-      }
-    ],
-    "container-title": "Cancer Genetics",
-    "id": "Mosakhani12",
-    "issue": "11",
-    "issued": {
-      "date-parts": [
-        [
-          2012,
-          11
-        ]
-      ]
-    },
-    "keyword": "bioscience",
-    "page": "545-51",
-    "title": "MicroRNA profiling predicts survival in anti-EGFR treated chemorefractory metastatic colorectal cancer patients with wild-type KRAS and BRAF",
-    "type": "article-journal",
-    "volume": "205"
-  },
-  {
-    "DOI": "10.3109/10428194.2012.685731",
-    "URL": "https://github.com/openresearchlabs/openresearchlabs.github.io/blob/master/content/publication_resources/papers/2012-Mosakhani-LL.pdf",
-    "author": [
-      {
-        "family": "Mosakhani",
-        "given": "N"
-      },
-      {
-        "family": "Sarhadi",
-        "given": "VK"
-      },
-      {
-        "family": "Usvasalo",
-        "given": "A"
-      },
-      {
-        "family": "Karjalainen-Lindsberg",
-        "given": "ML"
-      },
-      {
-        "family": "Lahti",
-        "given": "L"
-      },
-      {
-        "family": "Tuononen",
-        "given": "K"
-      },
-      {
-        "family": "Saarinen-Pihkala",
-        "given": "UM"
-      },
-      {
-        "family": "Knuutila",
-        "given": "S"
-      }
-    ],
-    "container-title": "Leukemia & Lymphoma",
-    "id": "Mosakhani12LL",
-    "issue": "12",
-    "issued": {
-      "date-parts": [
-        [
-          2012,
-          12
-        ]
-      ]
-    },
-    "keyword": "bioscience",
-    "page": "2517-2520",
-    "title": "MicroRNA profiling in pediatric acute lymphoblastic leukemia: Novel prognostic tools",
-    "title-short": "MicroRNA profiling in pediatric acute lymphoblastic leukemia",
-    "type": "article-journal",
-    "volume": "53"
-  },
-  {
-    "DOI": "10.1002/gcc.20851",
-    "URL": "https://github.com/openresearchlabs/openresearchlabs.github.io/blob/master/content/publication_resources/papers/2011-Niini-GCC.pdf",
-    "author": [
-      {
-        "family": "Niini",
-        "given": "Tarja"
-      },
-      {
-        "family": "Lahti",
-        "given": "Leo"
-      },
-      {
-        "family": "Michelacci",
-        "given": "Francesca"
-      },
-      {
-        "family": "Ninomiya",
-        "given": "Shinsuke"
-      },
-      {
-        "family": "Hattinger",
-        "given": "Claudia Maria"
-      },
-      {
-        "family": "Guled",
-        "given": "Mohamed"
-      },
-      {
-        "family": "Böhling",
-        "given": "Tom"
-      },
-      {
-        "family": "Picci",
-        "given": "Piero"
-      },
-      {
-        "family": "Serra",
-        "given": "Massimo"
-      },
-      {
-        "family": "Knuutila",
-        "given": "Sakari"
-      }
-    ],
-    "container-title": "Genes, Chromosomes and Cancer",
-    "id": "Niini11mfh",
-    "issue": "5",
-    "issued": {
-      "date-parts": [
-        [
-          2011,
-          5
-        ]
-      ]
-    },
-    "keyword": "bioscience",
-    "page": "291-306",
-    "title": "Array comparative genomic hybridization reveals frequent alterations of G1/s checkpoint genes in undifferentiated pleomorphic sarcoma of bone",
-    "type": "article-journal",
-    "volume": "50"
-  },
-  {
-    "DOI": "10.1016/j.cancergen.2012.09.007",
-    "PMID": "23146407",
-    "author": [
-      {
-        "family": "Niini",
-        "given": "Tarja"
-      },
-      {
-        "family": "Scheinin",
-        "given": "Ilari"
-      },
-      {
-        "family": "Lahti",
-        "given": "Leo"
-      },
-      {
-        "family": "Savola",
-        "given": "Suvi"
-      },
-      {
-        "family": "Mertens",
-        "given": "Fredrik"
-      },
-      {
-        "family": "Hollmén",
-        "given": "Jaakko"
-      },
-      {
-        "family": "Böhling",
-        "given": "Tom"
-      },
-      {
-        "family": "Kivioja",
-        "given": "Aarne"
-      },
-      {
-        "family": "Nord",
-        "given": "Karolin H"
-      },
-      {
-        "family": "Knuutila",
-        "given": "Sakari"
-      }
-    ],
-    "container-title": "Cancer Genetics",
-    "id": "Niini12",
-    "issue": "11",
-    "issued": {
-      "date-parts": [
-        [
-          2012,
-          11
-        ]
-      ]
-    },
-    "keyword": "bioscience",
-    "page": "588-93",
-    "title": "Homozygous deletions of cadherin genes in chondrosarcoma – an array CGH study",
-    "type": "article-journal",
-    "volume": "205"
-  },
-  {
-    "DOI": "10.3390/nu12092570",
-    "author": [
-      {
-        "family": "Nylund",
-        "given": "Lotta"
-      },
-      {
-        "family": "Hakkola",
-        "given": "Salla"
-      },
-      {
-        "family": "Lahti",
-        "given": "Leo"
-      },
-      {
-        "family": "Salminen",
-        "given": "Seppo"
-      },
-      {
-        "family": "Kalliomäki",
-        "given": "Marko"
-      },
-      {
-        "family": "Yang",
-        "given": "Baoru"
-      },
-      {
-        "family": "Linderborg",
-        "given": "Kaisa M."
-      }
-    ],
-    "container-title": "Nutrients",
-    "id": "Nylund2020",
-    "issued": {
-      "date-parts": [
-        [
-          2020
-        ]
-      ]
-    },
-    "keyword": "bioscience",
-    "note": "Special issue.",
-    "page": "2570",
-    "title": "Diet, perceived intestinal well-being, fecal microbiota and short chain fatty acids in oat-using subjects with celiac disease or gluten sensitivity.",
-    "type": "article-journal",
-    "volume": "12"
-  },
-  {
-    "DOI": "10.1186/1471-2164-8-62",
-    "annote": "CCA on two asbestos-exposed cell lines.",
-    "author": [
-      {
-        "family": "Nymark",
-        "given": "Penny"
-      },
-      {
-        "family": "Lindholm",
-        "given": "Pamela M."
-      },
-      {
-        "family": "Korpela",
-        "given": "Mikko V."
-      },
-      {
-        "family": "Lahti",
-        "given": "Leo"
-      },
-      {
-        "family": "Ruosaari",
-        "given": "Salla"
-      },
-      {
-        "family": "Kaski",
-        "given": "Samuel"
-      },
-      {
-        "family": "Hollmen",
-        "given": "Jaakko"
-      },
-      {
-        "family": "Anttila",
-        "given": "Sisko"
-      },
-      {
-        "family": "Kinnula",
-        "given": "Vuokko L."
-      },
-      {
-        "family": "Knuutila",
-        "given": "Sakari"
-      }
-    ],
-    "container-title": "BMC Genomics",
-    "id": "Nymark07",
-    "issue": "62",
-    "issued": {
-      "date-parts": [
-        [
-          2007,
-          3
-        ]
-      ]
-    },
-    "keyword": "bioscience",
-    "title": "Gene expression profiles in asbestos-exposed epithelial and mesothelial lung cell lines",
-    "type": "article-journal",
-    "volume": "8"
-  },
-  {
-    "DOI": "10.1002/gcc.20880",
-    "URL": "https://github.com/openresearchlabs/openresearchlabs.github.io/blob/master/content/publication_resources/papers/2011-Nymark-GCC.pdf",
-    "author": [
-      {
-        "family": "Nymark",
-        "given": "Penny"
-      },
-      {
-        "family": "Guled",
-        "given": "Mohamed"
-      },
-      {
-        "family": "Borze",
-        "given": "Ioana"
-      },
-      {
-        "family": "Faisal",
-        "given": "Ali"
-      },
-      {
-        "family": "Lahti",
-        "given": "Leo"
-      },
-      {
-        "family": "Salmenkivi",
-        "given": "Kaisa"
-      },
-      {
-        "family": "Kettunen",
-        "given": "Eeva"
-      },
-      {
-        "family": "Anttila",
-        "given": "Sisko"
-      },
-      {
-        "family": "Knuutila",
-        "given": "Sakari"
-      }
-    ],
-    "container-title": "Genes, Chromosomes and Cancer",
-    "id": "Nymark11",
-    "issue": "8",
-    "issued": {
-      "date-parts": [
-        [
-          2011,
-          8
-        ]
-      ]
-    },
-    "keyword": "bioscience",
-    "page": "585-597",
-    "title": "Integrative analysis of microRNA, mRNA and aCGH data reveals asbestos- and histology-related changes in lung cancer",
-    "type": "article-journal",
-    "volume": "50"
-  },
-  {
-    "DOI": "10.1038/ncomms7342",
-    "URL": "https://github.com/openresearchlabs/openresearchlabs.github.io/blob/master/content/publication_resources/papers/2015-OKeefe-NComms.pdf",
-    "annote": "Guardian: http://www.theguardian.com/science/2015/apr/28/bowel-cancer-risk-may-be-reduced-by-rural-african-diet-study-finds",
-    "author": [
-      {
-        "family": "O’Keefe",
-        "given": "SJD"
-      },
-      {
-        "family": "Li",
-        "given": "JV"
-      },
-      {
-        "family": "Lahti",
-        "given": "L"
-      },
-      {
-        "family": "Ou",
-        "given": "J"
-      },
-      {
-        "family": "Carbonero",
-        "given": "F"
-      },
-      {
-        "family": "Mohammed",
-        "given": "K"
-      },
-      {
-        "family": "Posma",
-        "given": "JM"
-      },
-      {
-        "family": "Kinross",
-        "given": "J"
-      },
-      {
-        "family": "Wahl",
-        "given": "E"
-      },
-      {
-        "family": "Ruder",
-        "given": "E"
-      },
-      {
-        "family": "Vipperla",
-        "given": "K"
-      },
-      {
-        "family": "Naidoo",
-        "given": "V"
-      },
-      {
-        "family": "Mtshali",
-        "given": "L"
-      },
-      {
-        "family": "Tims",
-        "given": "S"
-      },
-      {
-        "family": "PGB Puylaert",
-        "given": "J DeLany"
-      },
-      {
-        "family": "Krasinskas",
-        "given": "A"
-      },
-      {
-        "family": "Benefiel",
-        "given": "AC"
-      },
-      {
-        "family": "Kaseb",
-        "given": "HO"
-      },
-      {
-        "family": "Newton",
-        "given": "K"
-      },
-      {
-        "family": "Nicholson",
-        "given": "JK"
-      },
-      {
-        "dropping-particle": "de",
-        "family": "Vos",
-        "given": "WM"
-      },
-      {
-        "family": "Gaskins",
-        "given": "HR"
-      },
-      {
-        "family": "Zoetendal",
-        "given": "EG"
-      }
-    ],
-    "container-title": "Nature Communications",
-    "id": "OKeefe15",
-    "issued": {
-      "date-parts": [
-        [
-          2015,
-          4
-        ]
-      ]
-    },
-    "keyword": "bioscience",
-    "note": "Top science article in Guardian on the release day.",
-    "page": "6342",
-    "title": "Fat, fiber and cancer risk in african, americans and rural africans",
-    "type": "article-journal",
-    "volume": "6"
-  },
-  {
-    "DOI": "10.1161/JAHA.120.016641",
-    "author": [
-      {
-        "family": "Palmu",
-        "given": "Joonatan"
-      },
-      {
-        "family": "Salosensaari",
-        "given": "Aaro"
-      },
-      {
-        "family": "Havulinna",
-        "given": "Aki S."
-      },
-      {
-        "family": "Cheng",
-        "given": "Susan"
-      },
-      {
-        "family": "Inouye",
-        "given": "Michael"
-      },
-      {
-        "family": "Jain",
-        "given": "Mohit"
-      },
-      {
-        "family": "Salido",
-        "given": "Rodolfo A."
-      },
-      {
-        "family": "Sanders",
-        "given": "Karenina"
-      },
-      {
-        "family": "Brennan",
-        "given": "Caitriona"
-      },
-      {
-        "family": "Humphrey",
-        "given": "Gregory C."
-      },
-      {
-        "family": "Sanders",
-        "given": "Jon G."
-      },
-      {
-        "family": "Vartiainen",
-        "given": "Erkki"
-      },
-      {
-        "family": "Laatikainen",
-        "given": "Tiina"
-      },
-      {
-        "family": "Jousilahti",
-        "given": "Pekka"
-      },
-      {
-        "family": "Salomaa",
-        "given": "Veikko"
-      },
-      {
-        "family": "Knight",
-        "given": "Rob"
-      },
-      {
-        "family": "Lahti",
-        "given": "Leo"
-      },
-      {
-        "family": "Niiranen",
-        "given": "Teemu J."
-      }
-    ],
-    "container-title": "Journal of the American Heart Association",
-    "id": "Palmu2020",
-    "issued": {
-      "date-parts": [
-        [
-          2020
-        ]
-      ]
-    },
-    "keyword": "bioscience",
-    "title": "Association between the gut microbiota and blood pressure in a population cohort of 6953 individuals",
-    "type": "article-journal"
-  },
-  {
-    "DOI": "10.1161/JAHA.120.017598",
-    "author": [
-      {
-        "family": "Palmu",
-        "given": "Joonatan"
-      },
-      {
-        "literal": "others"
-      }
-    ],
-    "container-title": "Journal of American Heart Association",
-    "id": "Palmu2020JAHA",
-    "issued": {
-      "date-parts": [
-        [
-          2020
-        ]
-      ]
-    },
-    "keyword": "bioscience",
-    "page": "e016641",
-    "title": "Eicosanoid inflammatory mediators are robustly associated with blood pressure in the general population",
-    "type": "article-journal",
-    "volume": "9"
   },
   {
     "DOI": "10.3390/ijerph18031248",
@@ -4378,7 +940,8 @@
     "issued": {
       "date-parts": [
         [
-          2021
+          2021,
+          1
         ]
       ]
     },
@@ -4388,112 +951,6 @@
     "title-short": "Targeting gut microbiota to treat hypertension",
     "type": "article-journal",
     "volume": "18"
-  },
-  {
-    "DOI": "10.3390/nu12113225",
-    "author": [
-      {
-        "family": "Lensu",
-        "given": "Sanna"
-      },
-      {
-        "family": "Pariyani",
-        "given": "Raghunath"
-      },
-      {
-        "family": "Mäkinen",
-        "given": "Elina"
-      },
-      {
-        "family": "Yang",
-        "given": "Baoru"
-      },
-      {
-        "family": "Saleem",
-        "given": "Wisam"
-      },
-      {
-        "family": "Munukka",
-        "given": "Eveliina"
-      },
-      {
-        "family": "Lehti",
-        "given": "Maarit"
-      },
-      {
-        "family": "Yang",
-        "given": "Baoru"
-      },
-      {
-        "family": "Linden",
-        "given": "Jere"
-      },
-      {
-        "family": "Tiirola",
-        "given": "Marja"
-      },
-      {
-        "family": "Lahti",
-        "given": "Leo"
-      },
-      {
-        "family": "Pekkala",
-        "given": "Satu"
-      }
-    ],
-    "container-title": "Nutrients",
-    "id": "Pekkala2020",
-    "issue": "11",
-    "issued": {
-      "date-parts": [
-        [
-          2020
-        ]
-      ]
-    },
-    "keyword": "bioscience",
-    "page": "3225",
-    "title": "Prebiotic xylo-oligosaccharides targeting faecalibacterium prausnitzii prevent high fat diet-induced hepatic steatosis in rats",
-    "type": "article-journal",
-    "volume": "12"
-  },
-  {
-    "DOI": "10.1186/s12864-015-2265-y",
-    "URL": "https://github.com/openresearchlabs/openresearchlabs.github.io/blob/master/content/publication_resources/papers/2015-Ritari-BMCGenomics.pdf",
-    "author": [
-      {
-        "family": "Ritari",
-        "given": "Jarmo"
-      },
-      {
-        "family": "Salojärvi",
-        "given": "Jarkko"
-      },
-      {
-        "family": "Lahti",
-        "given": "Leo"
-      },
-      {
-        "dropping-particle": "de",
-        "family": "Vos",
-        "given": "Willem M."
-      }
-    ],
-    "container-title": "BMC Genomics",
-    "id": "Ritari15",
-    "issued": {
-      "date-parts": [
-        [
-          2015,
-          12
-        ]
-      ]
-    },
-    "keyword": "bioscience",
-    "page": "1056",
-    "title": "Improved taxonomic assignment of human intestinal 16S rRNA sequences by a dedicated reference database",
-    "type": "article-journal",
-    "volume": "16"
   },
   {
     "DOI": "10.1111/1462-2920.15462",
@@ -4613,7 +1070,8 @@
     "issued": {
       "date-parts": [
         [
-          2021
+          2021,
+          3
         ]
       ]
     },
@@ -4731,137 +1189,6 @@
     "volume": "12"
   },
   {
-    "DOI": "10.1016/j.ygeno.2013.01.001",
-    "URL": "https://github.com/openresearchlabs/openresearchlabs.github.io/blob/master/content/publication_resources/papers/2013-Sarhadi-Genomics.pdf",
-    "author": [
-      {
-        "family": "Sarhadi",
-        "given": "Virinder Kaur"
-      },
-      {
-        "family": "Lahti",
-        "given": "Leo"
-      },
-      {
-        "family": "Scheinin",
-        "given": "Ilari"
-      },
-      {
-        "family": "Tyybäkinoja",
-        "given": "Anne"
-      },
-      {
-        "family": "Savola",
-        "given": "Suvi"
-      },
-      {
-        "family": "Usvasalo",
-        "given": "Anu"
-      },
-      {
-        "family": "Räty",
-        "given": "Riikka"
-      },
-      {
-        "family": "Elonen",
-        "given": "Erkki"
-      },
-      {
-        "family": "Ellonen",
-        "given": "Pekka"
-      },
-      {
-        "family": "Saarinen-Pihkala",
-        "given": "Ulla M"
-      },
-      {
-        "family": "Knuutila",
-        "given": "Sakari"
-      }
-    ],
-    "container-title": "Genomics",
-    "id": "Sarhadi13",
-    "issue": "3",
-    "issued": {
-      "date-parts": [
-        [
-          2013,
-          9
-        ]
-      ]
-    },
-    "keyword": "bioscience",
-    "page": "182-188",
-    "title": "Targeted resequencing of 9p in acute lymphoblastic leukemia yields concordant results with array CGH and reveals novel genomic alterations",
-    "type": "article-journal",
-    "volume": "102"
-  },
-  {
-    "DOI": "10.21873/anticanres.14074",
-    "URL": "https://github.com/openresearchlabs/openresearchlabs.github.io/blob/master/content/publication_resources/papers/2020-Sarhadi-Anticanc.pdf",
-    "author": [
-      {
-        "family": "Sarhadi",
-        "given": "V"
-      },
-      {
-        "family": "Lahti",
-        "given": "L"
-      },
-      {
-        "family": "Saberi",
-        "given": "F"
-      },
-      {
-        "family": "Youssef",
-        "given": "O"
-      },
-      {
-        "family": "Kokkola",
-        "given": "A"
-      },
-      {
-        "family": "Karla",
-        "given": "T"
-      },
-      {
-        "family": "Tikkanen",
-        "given": "M"
-      },
-      {
-        "family": "Rautelin",
-        "given": "H"
-      },
-      {
-        "family": "Puolakkainen",
-        "given": "P"
-      },
-      {
-        "family": "Salehi",
-        "given": "R"
-      },
-      {
-        "family": "Knuutila",
-        "given": "S"
-      }
-    ],
-    "container-title": "Anticancer Research",
-    "id": "Sarhadi2020",
-    "issue": "3",
-    "issued": {
-      "date-parts": [
-        [
-          2020
-        ]
-      ]
-    },
-    "keyword": "bioscience",
-    "page": "1325-1334",
-    "title": "Gut microbiota and host gene mutations in colorectal cancer patients and controls of iranian and finnish origin",
-    "type": "article-journal",
-    "volume": "40"
-  },
-  {
     "DOI": "10.1186/s13099-021-00403-x",
     "author": [
       {
@@ -4917,521 +1244,6 @@
     "volume": "13"
   },
   {
-    "DOI": "10.1093/femsre/fuw045",
-    "URL": "https://github.com/openresearchlabs/openresearchlabs.github.io/blob/master/content/publication_resources/papers/2017-Shetty-FEMS.pdf",
-    "author": [
-      {
-        "family": "Shetty",
-        "given": "SA"
-      },
-      {
-        "family": "Hugenholtz",
-        "given": "F"
-      },
-      {
-        "family": "Lahti",
-        "given": "L"
-      },
-      {
-        "family": "Smidt",
-        "given": "H"
-      },
-      {
-        "dropping-particle": "de",
-        "family": "Vos",
-        "given": "WM"
-      },
-      {
-        "family": "Danchin",
-        "given": "A"
-      }
-    ],
-    "container-title": "FEMS Microbiology Reviews",
-    "id": "Shetty2017",
-    "issued": {
-      "date-parts": [
-        [
-          2017
-        ]
-      ]
-    },
-    "keyword": "bioscience",
-    "note": "review",
-    "page": "182-199",
-    "title": "Intestinal microbiome landscaping: Insight in community assemblage and implications for microbial modulation strategies",
-    "title-short": "Intestinal microbiome landscaping",
-    "type": "article-journal",
-    "volume": "41"
-  },
-  {
-    "DOI": "10.1007/s12038-019-9930-2",
-    "URL": "https://github.com/openresearchlabs/openresearchlabs.github.io/blob/master/content/publication_resources/papers/2019-Shetty-MDS.pdf",
-    "author": [
-      {
-        "family": "Shetty",
-        "given": "Sudarshan"
-      },
-      {
-        "family": "Lahti",
-        "given": "Leo"
-      }
-    ],
-    "container-title": "Journal of Biosciences",
-    "id": "Shetty2019",
-    "issued": {
-      "date-parts": [
-        [
-          2019
-        ]
-      ]
-    },
-    "keyword": "bioscience",
-    "page": "115",
-    "title": "Microbiome data science",
-    "type": "article-journal",
-    "volume": "44"
-  },
-  {
-    "DOI": "10.1038/srep17284",
-    "URL": "https://github.com/openresearchlabs/openresearchlabs.github.io/blob/master/content/publication_resources/papers/2015-Atagashi.pdf",
-    "author": [
-      {
-        "family": "Atashgahi",
-        "given": "Siavash"
-      },
-      {
-        "family": "Aydin",
-        "given": "Rozelin"
-      },
-      {
-        "family": "Dimitrov",
-        "given": "Mauricio R."
-      },
-      {
-        "family": "Sipkema",
-        "given": "Detmer"
-      },
-      {
-        "family": "Hamonts",
-        "given": "Kelly"
-      },
-      {
-        "family": "Lahti",
-        "given": "Leo"
-      },
-      {
-        "family": "Maphosa",
-        "given": "Farai"
-      },
-      {
-        "family": "Kruse",
-        "given": "Thomas"
-      },
-      {
-        "family": "Saccenti",
-        "given": "Edoardo"
-      },
-      {
-        "family": "Dirk Springael",
-        "given": "Winnie Dejonghe"
-      },
-      {
-        "family": "Smidt",
-        "given": "Hauke"
-      }
-    ],
-    "container-title": "Scientific Reports",
-    "id": "Siavash15",
-    "issue": "17284",
-    "issued": {
-      "date-parts": [
-        [
-          2015,
-          11
-        ]
-      ]
-    },
-    "keyword": "bioscience",
-    "title": "Impact of a wastewater treatment plant on microbial community composition and function in a hyporheic zone of a eutrophic river",
-    "type": "article-journal",
-    "volume": "5"
-  },
-  {
-    "URL": "https://github.com/openresearchlabs/openresearchlabs.github.io/blob/master/content/publication_resources/papers/2003-TechRep-Sinkkonen-ACBayesFactor.pdf",
-    "author": [
-      {
-        "family": "Sinkkonen",
-        "given": "Janne"
-      },
-      {
-        "family": "Nikkilä",
-        "given": "Janne"
-      },
-      {
-        "family": "Lahti",
-        "given": "Leo"
-      },
-      {
-        "family": "Kaski",
-        "given": "Samuel"
-      }
-    ],
-    "id": "Sinkkonen03tr",
-    "issued": {
-      "date-parts": [
-        [
-          2003,
-          6
-        ]
-      ]
-    },
-    "keyword": "bioscience",
-    "number": "A68",
-    "publisher": "Helsinki University of Technology and Laboratory of Computer and Information Science",
-    "publisher-place": "Espoo, Finland",
-    "title": "Associative clustering by maximizing a Bayes factor",
-    "type": "report"
-  },
-  {
-    "URL": "https://github.com/openresearchlabs/openresearchlabs.github.io/blob/master/content/publication_resources/papers/2004-ECML-Sinkkonen-AC.pdf",
-    "author": [
-      {
-        "family": "Sinkkonen",
-        "given": "Janne"
-      },
-      {
-        "family": "Nikkilä",
-        "given": "Janne"
-      },
-      {
-        "family": "Lahti",
-        "given": "Leo"
-      },
-      {
-        "family": "Kaski",
-        "given": "Samuel"
-      }
-    ],
-    "container-title": "Proceedings of the ECML’04, 15th european conference on machine learning",
-    "editor": [
-      {
-        "family": "Boulicaut"
-      },
-      {
-        "family": "Esposito"
-      },
-      {
-        "family": "Giannotti"
-      },
-      {
-        "family": "Pedreschi"
-      }
-    ],
-    "id": "Sinkkonen04ecml",
-    "issued": {
-      "date-parts": [
-        [
-          2004
-        ]
-      ]
-    },
-    "keyword": "datascience",
-    "page": "396-406",
-    "publisher": "Springer",
-    "publisher-place": "Berlin",
-    "title": "Associative clustering",
-    "type": "chapter"
-  },
-  {
-    "URL": "https://github.com/openresearchlabs/openresearchlabs.github.io/blob/master/content/publication_resources/papers/2005-TechRep-Sinkkonen-ACtechdetails.pdf",
-    "author": [
-      {
-        "family": "Sinkkonen",
-        "given": "Janne"
-      },
-      {
-        "family": "Kaski",
-        "given": "Samuel"
-      },
-      {
-        "family": "Nikkilä",
-        "given": "Janne"
-      },
-      {
-        "family": "Lahti",
-        "given": "Leo"
-      }
-    ],
-    "id": "Sinkkonen05tr",
-    "issued": {
-      "date-parts": [
-        [
-          2005
-        ]
-      ]
-    },
-    "keyword": "datascience",
-    "note": "Publications in Computer and Information Science",
-    "number": "A84",
-    "publisher": "Helsinki University of Technology",
-    "publisher-place": "Espoo, Finland",
-    "title": "Associative clustering (AC): Technical details",
-    "title-short": "Associative clustering (AC)",
-    "type": "report"
-  },
-  {
-    "DOI": "10.1186/s13395-015-0059-1",
-    "URL": "https://github.com/openresearchlabs/openresearchlabs.github.io/blob/master/content/publication_resources/papers/2015-Su-SkeletalMuscle.pdf",
-    "author": [
-      {
-        "family": "Su",
-        "given": "Jing"
-      },
-      {
-        "family": "Ekman",
-        "given": "Carl"
-      },
-      {
-        "family": "Oskolkov",
-        "given": "Nikolay"
-      },
-      {
-        "family": "Lahti",
-        "given": "Leo"
-      },
-      {
-        "family": "Ström",
-        "given": "Kristoffer"
-      },
-      {
-        "family": "Brazma",
-        "given": "Alvis"
-      },
-      {
-        "family": "Groop",
-        "given": "Leif"
-      },
-      {
-        "family": "Rung",
-        "given": "Johan"
-      },
-      {
-        "dropping-particle": "and",
-        "family": "Ola Hansson"
-      }
-    ],
-    "container-title": "Skeletal Muscle",
-    "id": "Su2015",
-    "issue": "35",
-    "issued": {
-      "date-parts": [
-        [
-          2015,
-          10
-        ]
-      ]
-    },
-    "keyword": "bioscience",
-    "title": "A novel atlas of gene expression in human skeletal muscle reveals molecular changes associated with aging",
-    "type": "article-journal",
-    "volume": "5"
-  },
-  {
-    "DOI": "10.1111/1751-7915.13406",
-    "annote": "Comics piece for the popularization of microbiome research.",
-    "author": [
-      {
-        "family": "Timmis",
-        "given": "K"
-      },
-      {
-        "family": "Jebok",
-        "given": "F"
-      },
-      {
-        "family": "Rohde",
-        "given": "M"
-      },
-      {
-        "family": "Lahti",
-        "given": "L"
-      },
-      {
-        "family": "Molinari",
-        "given": "G"
-      }
-    ],
-    "container-title": "Microbial Biotechnology",
-    "id": "Timmis2019",
-    "issued": {
-      "date-parts": [
-        [
-          2019
-        ]
-      ]
-    },
-    "keyword": "misc",
-    "title": "Microbiome yarns: The global phenotype-genotype survey. Episode III: Importance of microbiota diversification for microbiome function and biome health",
-    "title-short": "Microbiome yarns",
-    "type": "article-journal"
-  },
-  {
-    "URL": "https://github.com/openresearchlabs/openresearchlabs.github.io/blob/master/content/publication_resources/papers/2015-EnnenNyt-Tolonen.pdf",
-    "author": [
-      {
-        "family": "Tolonen",
-        "given": "Mikko"
-      },
-      {
-        "family": "Lahti",
-        "given": "Leo"
-      }
-    ],
-    "container-title": "Ennen & Nyt 2",
-    "id": "Tolonen15EnnenNyt",
-    "issued": {
-      "date-parts": [
-        [
-          2015,
-          8
-        ]
-      ]
-    },
-    "keyword": "dh",
-    "title": "Aatehistoria ja digitaalisten aineistojen mahdollisuudet",
-    "type": "article-journal",
-    "volume": "2"
-  },
-  {
-    "URL": "http://dh2016.adho.org/abstracts/9",
-    "author": [
-      {
-        "family": "Tolonen",
-        "given": "Mikko"
-      },
-      {
-        "family": "Ilomäki",
-        "given": "Niko"
-      },
-      {
-        "family": "Roivainen",
-        "given": "Hege"
-      },
-      {
-        "family": "Lahti",
-        "given": "Leo"
-      }
-    ],
-    "container-title": "Digital humanities 2016: Conference abstracts",
-    "id": "Tolonen16dh",
-    "issued": {
-      "date-parts": [
-        [
-          2016,
-          7
-        ]
-      ]
-    },
-    "keyword": "dh",
-    "page": "383-385",
-    "publisher": "Jagiellonian University & Pedagogical University, Kraków",
-    "publisher-place": "Krakow, Poland",
-    "title": "Printing in a periphery: A quantitative study of finnish knowledge production, 1640-1828",
-    "title-short": "Printing in a periphery",
-    "type": "paper-conference"
-  },
-  {
-    "URL": "https://www.gaudeamus.fi/menneisyyden-rakentajat/",
-    "annote": "This is a book chapter but classified as article as could not find a way to include this to CSL automatically generated bibliography yet.",
-    "author": [
-      {
-        "family": "Tolonen",
-        "given": "Mikko"
-      },
-      {
-        "family": "Lahti",
-        "given": "Leo"
-      }
-    ],
-    "container-title": "Menneisyyden rakentajat",
-    "editor": [
-      {
-        "family": "Hannikainen",
-        "given": "MO"
-      },
-      {
-        "family": "Danielsbacka",
-        "given": "M"
-      },
-      {
-        "family": "Tepora",
-        "given": "T"
-      }
-    ],
-    "id": "Tolonen2018gaudeamus",
-    "issued": {
-      "date-parts": [
-        [
-          2018
-        ]
-      ]
-    },
-    "keyword": "dh",
-    "note": "(in Finnish). In: Hannikainen, MO and Danielsbacka, M and Tepora, T (eds.). Menneisyyden rakentajat. Gaudeamus, Helsinki, 2018.",
-    "publisher": "Gaudeamus",
-    "title": "Digitaaliset ihmistieteet ja historiantutkimus",
-    "type": "article-journal"
-  },
-  {
-    "URL": "https://github.com/openresearchlabs/openresearchlabs.github.io/blob/master/content/publication_resources/papers/2019-Tolonen-DHN.pdf",
-    "author": [
-      {
-        "family": "Tolonen",
-        "given": "Mikko"
-      },
-      {
-        "family": "Marjanen",
-        "given": "Jani"
-      },
-      {
-        "family": "Roivainen",
-        "given": "Hege"
-      },
-      {
-        "family": "Lahti",
-        "given": "Leo"
-      }
-    ],
-    "container-title": "Proceedings of the digital humanities in the nordics (DHN2019)",
-    "editor": [
-      {
-        "family": "Navarretta",
-        "given": "Costanza"
-      },
-      {
-        "family": "Agirrezabal",
-        "given": "Manex"
-      },
-      {
-        "family": "Maegaard",
-        "given": "Bente"
-      }
-    ],
-    "id": "Tolonen2019dhn",
-    "issued": {
-      "date-parts": [
-        [
-          2019
-        ]
-      ]
-    },
-    "keyword": "dh",
-    "publisher-place": "Copenhagen",
-    "status": "dh",
-    "title": "Scaling up bibliographic data science",
-    "type": "paper-conference"
-  },
-  {
     "DOI": "10.1007/978-3-030-54913-8_3",
     "author": [
       {
@@ -5467,7 +1279,8 @@
     "issued": {
       "date-parts": [
         [
-          2021
+          2021,
+          3
         ]
       ]
     },
@@ -5500,7 +1313,7 @@
       "date-parts": [
         [
           2021,
-          11
+          10
         ]
       ]
     },
@@ -5545,216 +1358,6 @@
     "title": "Corpus linguistics and eighteenth century collections online (ECCO)",
     "type": "article-journal",
     "volume": "9"
-  },
-  {
-    "author": [
-      {
-        "family": "Vaara",
-        "given": "Ville"
-      },
-      {
-        "family": "Ijaz",
-        "given": "Ali"
-      },
-      {
-        "family": "Tiihonen",
-        "given": "Iiro"
-      },
-      {
-        "family": "Hengchen",
-        "given": "Simon"
-      },
-      {
-        "family": "Kanner",
-        "given": "Antti"
-      },
-      {
-        "family": "Säily",
-        "given": "Tanja"
-      },
-      {
-        "family": "Lahti",
-        "given": "Leo"
-      }
-    ],
-    "container-title": "Proceedings of the digital humanities (DH2019)",
-    "id": "Vaara2019dh",
-    "issued": {
-      "date-parts": [
-        [
-          2019
-        ]
-      ]
-    },
-    "keyword": "dh",
-    "note": "In press.",
-    "title": "The emerging paradigm of bibliographic data science",
-    "type": "paper-conference"
-  },
-  {
-    "DOI": "10.1111/jch.13984",
-    "author": [
-      {
-        "family": "Vaura",
-        "given": "Felix C."
-      },
-      {
-        "family": "Salomaa",
-        "given": "Veikko V."
-      },
-      {
-        "family": "Kantola",
-        "given": "Ilkka M."
-      },
-      {
-        "family": "Kaaja",
-        "given": "Risto"
-      },
-      {
-        "family": "Lahti",
-        "given": "Leo"
-      },
-      {
-        "family": "Niiranen",
-        "given": "Teemu J."
-      }
-    ],
-    "container-title": "Journal of Clinical Hypertension",
-    "id": "Vaura2020jch",
-    "issue": "9",
-    "issued": {
-      "date-parts": [
-        [
-          2020
-        ]
-      ]
-    },
-    "keyword": "bioscience",
-    "page": "1546-1553",
-    "title": "Unsupervised hierarchical clustering identifies a metabolically challenged subgroup of hypertensive individuals",
-    "type": "article-journal",
-    "volume": "22"
-  },
-  {
-    "DOI": "10.1007/s10620-018-5190-5",
-    "URL": "https://github.com/openresearchlabs/openresearchlabs.github.io/blob/master/content/publication_resources/papers/2018-Youssef.pdf",
-    "author": [
-      {
-        "family": "Youssef",
-        "given": "Omar"
-      },
-      {
-        "family": "Lahti",
-        "given": "Leo"
-      },
-      {
-        "family": "Kokkola",
-        "given": "Arto"
-      },
-      {
-        "family": "Karla",
-        "given": "Tiina"
-      },
-      {
-        "family": "Tikkanen",
-        "given": "Milja"
-      },
-      {
-        "family": "Ehsan",
-        "given": "Homa"
-      },
-      {
-        "family": "Carpelan‑Holmström",
-        "given": "Monika"
-      },
-      {
-        "family": "Koskensalo",
-        "given": "Selja"
-      },
-      {
-        "family": "Böhling",
-        "given": "Tom"
-      },
-      {
-        "family": "Rautelin",
-        "given": "Hilpi"
-      },
-      {
-        "family": "Puolakkainen",
-        "given": "Pauli"
-      },
-      {
-        "family": "Knuutila",
-        "given": "Sakari"
-      },
-      {
-        "family": "Sarhadi",
-        "given": "Virinder"
-      }
-    ],
-    "container-title": "Digestive Diseases and Sciences",
-    "id": "Youssef2018",
-    "issue": "11",
-    "issued": {
-      "date-parts": [
-        [
-          2018
-        ]
-      ]
-    },
-    "keyword": "bioscience",
-    "page": "2950-2958",
-    "title": "Stool microbiota composition differs in patients with stomach, colon, and rectal neoplasms",
-    "type": "article-journal",
-    "volume": "63"
-  },
-  {
-    "DOI": "10.4230/DagRep.3.5.78",
-    "ISSN": "2192-5283",
-    "URL": "http://drops.dagstuhl.de/opus/volltexte/2013/4179",
-    "annote": "Keywords: Bioinformatics, Chemoinformatics, Machine learning, Statistics, Interdisciplinary applications. Short abstract for the Dagstuhl seminar.",
-    "author": [
-      {
-        "family": "Lahti",
-        "given": "Leo"
-      }
-    ],
-    "container-title": "Dagstuhl Reports",
-    "editor": [
-      {
-        "family": "Bender",
-        "given": "Andreas"
-      },
-      {
-        "family": "Göhlmann",
-        "given": "Hinrich"
-      },
-      {
-        "family": "Hochreiter",
-        "given": "Sepp"
-      },
-      {
-        "family": "Shkedy",
-        "given": "Ziv"
-      }
-    ],
-    "id": "bender13",
-    "issue": "5",
-    "issued": {
-      "date-parts": [
-        [
-          2013
-        ]
-      ]
-    },
-    "keyword": "bioscience",
-    "page": "78-94",
-    "publisher": "Schloss Dagstuhl–Leibniz-Zentrum fuer Informatik",
-    "publisher-place": "Dagstuhl, Germany",
-    "title": "Intestinal microbiota, individuality and health. In: Computational methods aiding early-stage drug design (dagstuhl seminar 13212)",
-    "title-short": "Intestinal microbiota, individuality and health. In",
-    "type": "article-journal",
-    "volume": "3"
   },
   {
     "DOI": "10.1186/s13102-021-00241-z",
@@ -5853,6 +1456,2904 @@
     "volume": "13"
   },
   {
+    "DOI": "10.1101/2020.06.24.20138933",
+    "URL": "https://www.medrxiv.org/content/early/2020/06/25/2020.06.24.20138933",
+    "author": [
+      {
+        "family": "Liu",
+        "given": "Yang"
+      },
+      {
+        "family": "Meric",
+        "given": "Guillaume"
+      },
+      {
+        "family": "Havulinna",
+        "given": "Aki S."
+      },
+      {
+        "family": "Teo",
+        "given": "Shu Mei"
+      },
+      {
+        "family": "Ruuskanen",
+        "given": "Matti"
+      },
+      {
+        "family": "Sanders",
+        "given": "Jon"
+      },
+      {
+        "family": "Zhu",
+        "given": "Qiyun"
+      },
+      {
+        "family": "Tripathi",
+        "given": "Anupriya"
+      },
+      {
+        "family": "Verspoor",
+        "given": "Karin"
+      },
+      {
+        "family": "Cheng",
+        "given": "Susan"
+      },
+      {
+        "family": "Jain",
+        "given": "Mo"
+      },
+      {
+        "family": "Jousilahti",
+        "given": "Pekka"
+      },
+      {
+        "family": "Vazquez-Baeza",
+        "given": "Yoshiki"
+      },
+      {
+        "family": "Loomba",
+        "given": "Rohit"
+      },
+      {
+        "family": "Lahti",
+        "given": "Leo"
+      },
+      {
+        "family": "Niiranen",
+        "given": "Teemu"
+      },
+      {
+        "family": "Salomaa",
+        "given": "Veikko"
+      },
+      {
+        "family": "Knight",
+        "given": "Rob"
+      },
+      {
+        "family": "Inouye",
+        "given": "Michael"
+      }
+    ],
+    "container-title": "medRxiv",
+    "id": "Liu2021liver",
+    "issued": {
+      "date-parts": [
+        [
+          2020
+        ]
+      ]
+    },
+    "keyword": "preprint",
+    "title": "Early prediction of liver disease using conventional risk factors and gut microbiome-augmented gradient boosting",
+    "type": "article-journal"
+  },
+  {
+    "DOI": "10.1016/j.psyneuen.2020.104754",
+    "author": [
+      {
+        "family": "Aatsinki",
+        "given": "Anna-Katariina"
+      },
+      {
+        "family": "Keskitalo",
+        "given": "Anniina"
+      },
+      {
+        "family": "Laitinen",
+        "given": "Ville"
+      },
+      {
+        "family": "Munukka",
+        "given": "Eveliina"
+      },
+      {
+        "family": "Uusitupa",
+        "given": "Henna-Maria"
+      },
+      {
+        "family": "Lahti",
+        "given": "Leo"
+      },
+      {
+        "family": "Kortesluoma",
+        "given": "Susanna"
+      },
+      {
+        "family": "Mustonen",
+        "given": "Paula"
+      },
+      {
+        "family": "Rodrigues",
+        "given": "Ana João"
+      },
+      {
+        "family": "Coimbra",
+        "given": "Bárbara"
+      },
+      {
+        "family": "Huovinen",
+        "given": "Pentti"
+      },
+      {
+        "family": "Karlsson",
+        "given": "Hasse"
+      },
+      {
+        "family": "Karlsson",
+        "given": "Linnea"
+      }
+    ],
+    "container-title": "Psychoneuroendocrinology",
+    "id": "Aatsinki2020",
+    "issued": {
+      "date-parts": [
+        [
+          2020
+        ]
+      ]
+    },
+    "keyword": "bioscience",
+    "page": "104754",
+    "title": "Maternal prenatal psychological distress and hair cortisol levels associate with infant fecal microbiota composition at 2.5 months of age",
+    "type": "article-journal",
+    "volume": "119"
+  },
+  {
+    "DOI": "10.3390/sym13030368",
+    "author": [
+      {
+        "family": "Khalighi",
+        "given": "Moein"
+      },
+      {
+        "family": "Eftekhari",
+        "given": "Leila"
+      },
+      {
+        "family": "Hosseinpour",
+        "given": "Soleiman"
+      },
+      {
+        "family": "Lahti",
+        "given": "Leo"
+      }
+    ],
+    "container-title": "Symmetry",
+    "id": "Khalighi2021",
+    "issued": {
+      "date-parts": [
+        [
+          2020
+        ]
+      ]
+    },
+    "keyword": "datascience",
+    "page": "368",
+    "title": "Three-species lotka-volterra model with respect to caputo and caputo-fabrizio fractional operators",
+    "type": "article-journal",
+    "volume": "13"
+  },
+  {
+    "DOI": "10.7717/peerj.10442",
+    "author": [
+      {
+        "family": "Koffert",
+        "given": "Jukka"
+      },
+      {
+        "family": "Lahti",
+        "given": "Leo"
+      },
+      {
+        "family": "Nylund",
+        "given": "Lotta"
+      },
+      {
+        "family": "Salminen",
+        "given": "Seppo"
+      },
+      {
+        "family": "Hannukainen",
+        "given": "Jarna C"
+      },
+      {
+        "family": "Salminen",
+        "given": "Paulina"
+      },
+      {
+        "dropping-particle": "de",
+        "family": "Vos",
+        "given": "Willem"
+      },
+      {
+        "family": "Nuutila",
+        "given": "Pirjo"
+      }
+    ],
+    "container-title": "PeerJ – Life & Environment",
+    "id": "Koffert2020",
+    "issued": {
+      "date-parts": [
+        [
+          2020
+        ]
+      ]
+    },
+    "keyword": "bioscience",
+    "note": "Shared first authorship.",
+    "page": "e10442",
+    "title": "Partial restoration of normal intestinal microbiota in morbidly obese women six months after bariatric surgery",
+    "type": "article-journal",
+    "volume": "8"
+  },
+  {
+    "URL": "http://ceur-ws.org/Vol-2723/short46.pdf",
+    "author": [
+      {
+        "family": "Lahti",
+        "given": "Leo"
+      },
+      {
+        "family": "Mäkelä",
+        "given": "Eetu"
+      },
+      {
+        "family": "Tolonen",
+        "given": "Mikko"
+      }
+    ],
+    "container-title": "Proc. CEUR Workshop Proceedings on Computational Humanities Research",
+    "id": "Lahti2020chr",
+    "issued": {
+      "date-parts": [
+        [
+          2020,
+          11
+        ]
+      ]
+    },
+    "keyword": "dh",
+    "page": "80-89",
+    "title": "Quantifying bias and uncertainty in historical data collections with probabilistic programming",
+    "type": "paper-conference"
+  },
+  {
+    "URL": "https://www.hs.fi/mielipide/art-2000006494641.html",
+    "author": [
+      {
+        "family": "Lahti",
+        "given": "Leo"
+      },
+      {
+        "family": "Wallgren",
+        "given": "Thomas"
+      },
+      {
+        "family": "Kulmala",
+        "given": "Markku"
+      }
+    ],
+    "container-title": "HS Mielipide",
+    "id": "Lahti2020hs1",
+    "issued": {
+      "date-parts": [
+        [
+          2020,
+          5
+        ]
+      ]
+    },
+    "keyword": "opinion",
+    "title": "Laskentamallit eivät lähtökohtaisesti ole salassa pidettävää tietoa",
+    "type": "article-journal"
+  },
+  {
+    "URL": "https://www.hs.fi/mielipide/art-2000006545770.html",
+    "author": [
+      {
+        "family": "Lahti",
+        "given": "Leo"
+      }
+    ],
+    "container-title": "HS Mielipide",
+    "id": "Lahti2020hs2",
+    "issued": {
+      "date-parts": [
+        [
+          2020
+        ]
+      ]
+    },
+    "keyword": "opinion",
+    "title": "Lähdekoodin sisältämien yksityiskohtien avoimuus on keskeistä päätöksenteon läpinäkyvyydelle.",
+    "type": "article-journal"
+  },
+  {
+    "URL": "https://www.okf.fi/fi/2020/05/13/tietopyynto-thln-epidemialaskelmien-lahdekoodeista",
+    "author": [
+      {
+        "family": "Lahti",
+        "given": "Leo"
+      },
+      {
+        "family": "Toikkanen",
+        "given": "Tarmo"
+      }
+    ],
+    "container-title": "Open Knowledge Finland Blog",
+    "id": "Lahti2020okf1",
+    "issued": {
+      "date-parts": [
+        [
+          2020,
+          5
+        ]
+      ]
+    },
+    "keyword": "opinion",
+    "title": "Tietopyyntö epidemialaskelmien lähdekoodeista",
+    "type": "article-journal"
+  },
+  {
+    "URL": "https://www.okf.fi/fi/2020/06/15/thln-paatos-epidemialaskelmien-salaamisesta-vastoin-valtioneuvoston-avoimuuslinjausta/",
+    "author": [
+      {
+        "family": "Lahti",
+        "given": "Leo"
+      }
+    ],
+    "container-title": "Open Knowledge Finland Blog",
+    "id": "Lahti2020okf2",
+    "issued": {
+      "date-parts": [
+        [
+          2020
+        ]
+      ]
+    },
+    "keyword": "opinion",
+    "title": "Päätös epidemialaskelmien salaamisesta vastoin valtioneuvoston avoimuuslinjausta",
+    "type": "article-journal"
+  },
+  {
+    "URL": "https://blogs.helsinki.fi/thinkopen/lahdekoodin-avoimuus-paatoksenteossa/",
+    "author": [
+      {
+        "family": "Lahti",
+        "given": "Leo"
+      }
+    ],
+    "container-title": "University of Helsinki, ThinkOpen blog",
+    "id": "Lahti2020thinkopen",
+    "issued": {
+      "date-parts": [
+        [
+          2020
+        ]
+      ]
+    },
+    "keyword": "opinion",
+    "title": "Avoimuus voi vahvistaa päätöksenteon tieteellistä pohjaa",
+    "type": "article-journal"
+  },
+  {
+    "URL": "https://github.com/openresearchlabs/openresearchlabs.github.io/blob/master/content/publication_resources/papers/2020-Makela-DHN.pdf",
+    "author": [
+      {
+        "family": "Eetu",
+        "given": "M"
+      },
+      {
+        "family": "Lagus",
+        "given": "K"
+      },
+      {
+        "family": "Lahti",
+        "given": "L"
+      },
+      {
+        "family": "Säily",
+        "given": "T"
+      },
+      {
+        "family": "Tolonen",
+        "given": "M"
+      },
+      {
+        "family": "Hämäläinen",
+        "given": "M"
+      },
+      {
+        "family": "Kaislaniemi",
+        "given": "S"
+      },
+      {
+        "family": "Nevalainen",
+        "given": "T"
+      }
+    ],
+    "collection-title": "CEUR workshop proceedings",
+    "container-title": "Proc. Digital humanities in the nordic countries",
+    "editor": [
+      {
+        "family": "Reinsone",
+        "given": "Sanita"
+      },
+      {
+        "family": "Skadiņa",
+        "given": "Inguna"
+      },
+      {
+        "family": "Baklāne",
+        "given": "Anda"
+      },
+      {
+        "family": "Daugavietis",
+        "given": "Jānis"
+      }
+    ],
+    "id": "Makela2020",
+    "issued": {
+      "date-parts": [
+        [
+          2020
+        ]
+      ]
+    },
+    "keyword": "dh",
+    "page": "81-96",
+    "title": "Wrangling with non-standard data",
+    "type": "paper-conference",
+    "volume": "2612"
+  },
+  {
+    "DOI": "10.3390/nu12092570",
+    "author": [
+      {
+        "family": "Nylund",
+        "given": "Lotta"
+      },
+      {
+        "family": "Hakkola",
+        "given": "Salla"
+      },
+      {
+        "family": "Lahti",
+        "given": "Leo"
+      },
+      {
+        "family": "Salminen",
+        "given": "Seppo"
+      },
+      {
+        "family": "Kalliomäki",
+        "given": "Marko"
+      },
+      {
+        "family": "Yang",
+        "given": "Baoru"
+      },
+      {
+        "family": "Linderborg",
+        "given": "Kaisa M."
+      }
+    ],
+    "container-title": "Nutrients",
+    "id": "Nylund2020",
+    "issued": {
+      "date-parts": [
+        [
+          2020
+        ]
+      ]
+    },
+    "keyword": "bioscience",
+    "note": "Special issue.",
+    "page": "2570",
+    "title": "Diet, perceived intestinal well-being, fecal microbiota and short chain fatty acids in oat-using subjects with celiac disease or gluten sensitivity.",
+    "type": "article-journal",
+    "volume": "12"
+  },
+  {
+    "DOI": "10.1161/JAHA.120.016641",
+    "author": [
+      {
+        "family": "Palmu",
+        "given": "Joonatan"
+      },
+      {
+        "family": "Salosensaari",
+        "given": "Aaro"
+      },
+      {
+        "family": "Havulinna",
+        "given": "Aki S."
+      },
+      {
+        "family": "Cheng",
+        "given": "Susan"
+      },
+      {
+        "family": "Inouye",
+        "given": "Michael"
+      },
+      {
+        "family": "Jain",
+        "given": "Mohit"
+      },
+      {
+        "family": "Salido",
+        "given": "Rodolfo A."
+      },
+      {
+        "family": "Sanders",
+        "given": "Karenina"
+      },
+      {
+        "family": "Brennan",
+        "given": "Caitriona"
+      },
+      {
+        "family": "Humphrey",
+        "given": "Gregory C."
+      },
+      {
+        "family": "Sanders",
+        "given": "Jon G."
+      },
+      {
+        "family": "Vartiainen",
+        "given": "Erkki"
+      },
+      {
+        "family": "Laatikainen",
+        "given": "Tiina"
+      },
+      {
+        "family": "Jousilahti",
+        "given": "Pekka"
+      },
+      {
+        "family": "Salomaa",
+        "given": "Veikko"
+      },
+      {
+        "family": "Knight",
+        "given": "Rob"
+      },
+      {
+        "family": "Lahti",
+        "given": "Leo"
+      },
+      {
+        "family": "Niiranen",
+        "given": "Teemu J."
+      }
+    ],
+    "container-title": "Journal of the American Heart Association",
+    "id": "Palmu2020",
+    "issued": {
+      "date-parts": [
+        [
+          2020
+        ]
+      ]
+    },
+    "keyword": "bioscience",
+    "title": "Association between the gut microbiota and blood pressure in a population cohort of 6953 individuals",
+    "type": "article-journal"
+  },
+  {
+    "DOI": "10.1161/JAHA.120.017598",
+    "author": [
+      {
+        "family": "Palmu",
+        "given": "Joonatan"
+      },
+      {
+        "literal": "others"
+      }
+    ],
+    "container-title": "Journal of American Heart Association",
+    "id": "Palmu2020JAHA",
+    "issued": {
+      "date-parts": [
+        [
+          2020
+        ]
+      ]
+    },
+    "keyword": "bioscience",
+    "page": "e016641",
+    "title": "Eicosanoid inflammatory mediators are robustly associated with blood pressure in the general population",
+    "type": "article-journal",
+    "volume": "9"
+  },
+  {
+    "DOI": "10.3390/nu12113225",
+    "author": [
+      {
+        "family": "Lensu",
+        "given": "Sanna"
+      },
+      {
+        "family": "Pariyani",
+        "given": "Raghunath"
+      },
+      {
+        "family": "Mäkinen",
+        "given": "Elina"
+      },
+      {
+        "family": "Yang",
+        "given": "Baoru"
+      },
+      {
+        "family": "Saleem",
+        "given": "Wisam"
+      },
+      {
+        "family": "Munukka",
+        "given": "Eveliina"
+      },
+      {
+        "family": "Lehti",
+        "given": "Maarit"
+      },
+      {
+        "family": "Yang",
+        "given": "Baoru"
+      },
+      {
+        "family": "Linden",
+        "given": "Jere"
+      },
+      {
+        "family": "Tiirola",
+        "given": "Marja"
+      },
+      {
+        "family": "Lahti",
+        "given": "Leo"
+      },
+      {
+        "family": "Pekkala",
+        "given": "Satu"
+      }
+    ],
+    "container-title": "Nutrients",
+    "id": "Pekkala2020",
+    "issue": "11",
+    "issued": {
+      "date-parts": [
+        [
+          2020,
+          10
+        ]
+      ]
+    },
+    "keyword": "bioscience",
+    "page": "3225",
+    "title": "Prebiotic xylo-oligosaccharides targeting faecalibacterium prausnitzii prevent high fat diet-induced hepatic steatosis in rats",
+    "type": "article-journal",
+    "volume": "12"
+  },
+  {
+    "DOI": "10.21873/anticanres.14074",
+    "URL": "https://github.com/openresearchlabs/openresearchlabs.github.io/blob/master/content/publication_resources/papers/2020-Sarhadi-Anticanc.pdf",
+    "author": [
+      {
+        "family": "Sarhadi",
+        "given": "V"
+      },
+      {
+        "family": "Lahti",
+        "given": "L"
+      },
+      {
+        "family": "Saberi",
+        "given": "F"
+      },
+      {
+        "family": "Youssef",
+        "given": "O"
+      },
+      {
+        "family": "Kokkola",
+        "given": "A"
+      },
+      {
+        "family": "Karla",
+        "given": "T"
+      },
+      {
+        "family": "Tikkanen",
+        "given": "M"
+      },
+      {
+        "family": "Rautelin",
+        "given": "H"
+      },
+      {
+        "family": "Puolakkainen",
+        "given": "P"
+      },
+      {
+        "family": "Salehi",
+        "given": "R"
+      },
+      {
+        "family": "Knuutila",
+        "given": "S"
+      }
+    ],
+    "container-title": "Anticancer Research",
+    "id": "Sarhadi2020",
+    "issue": "3",
+    "issued": {
+      "date-parts": [
+        [
+          2020,
+          3
+        ]
+      ]
+    },
+    "keyword": "bioscience",
+    "page": "1325-1334",
+    "title": "Gut microbiota and host gene mutations in colorectal cancer patients and controls of iranian and finnish origin",
+    "type": "article-journal",
+    "volume": "40"
+  },
+  {
+    "DOI": "10.1111/jch.13984",
+    "author": [
+      {
+        "family": "Vaura",
+        "given": "Felix C."
+      },
+      {
+        "family": "Salomaa",
+        "given": "Veikko V."
+      },
+      {
+        "family": "Kantola",
+        "given": "Ilkka M."
+      },
+      {
+        "family": "Kaaja",
+        "given": "Risto"
+      },
+      {
+        "family": "Lahti",
+        "given": "Leo"
+      },
+      {
+        "family": "Niiranen",
+        "given": "Teemu J."
+      }
+    ],
+    "container-title": "Journal of Clinical Hypertension",
+    "id": "Vaura2020jch",
+    "issue": "9",
+    "issued": {
+      "date-parts": [
+        [
+          2020,
+          8
+        ]
+      ]
+    },
+    "keyword": "bioscience",
+    "page": "1546-1553",
+    "title": "Unsupervised hierarchical clustering identifies a metabolically challenged subgroup of hypertensive individuals",
+    "type": "article-journal",
+    "volume": "22"
+  },
+  {
+    "author": [
+      {
+        "dropping-particle": "in Open Education (Open Science Coordination in",
+        "family": "Finland)",
+        "given": "Expert Panel"
+      }
+    ],
+    "container-title": "Responsible Research Series",
+    "id": "openedu2020",
+    "issued": {
+      "date-parts": [
+        [
+          2020
+        ]
+      ]
+    },
+    "keyword": "openscience",
+    "publisher": "Committee for Public Information (TJNK) and Federation of Finnish Learned Societies (TSV).",
+    "publisher-place": "Helsinki, Finland",
+    "title": "National policy and executive plan by the higher education and research community for 2021-2025 - policy component 1: Open access to educational resources.",
+    "title-short": "National policy and executive plan by the higher education and research community for 2021-2025 - policy component 1",
+    "type": "report",
+    "volume": "16"
+  },
+  {
+    "DOI": "10.1016/j.bbi.2019.05.035",
+    "URL": "https://github.com/openresearchlabs/openresearchlabs.github.io/blob/master/content/publication_resources/papers/2019-Aatsinki.pdf",
+    "author": [
+      {
+        "family": "Aatsinki",
+        "given": "Anna"
+      },
+      {
+        "family": "Lahti",
+        "given": "Leo"
+      },
+      {
+        "family": "Uusitupa",
+        "given": "Henna"
+      },
+      {
+        "family": "Munukka",
+        "given": "Eveliina"
+      },
+      {
+        "family": "Anniina Keskitalo",
+        "given": "Saara Nolvi"
+      },
+      {
+        "family": "O’Mahony",
+        "given": "Siobhain"
+      },
+      {
+        "family": "Pietilä",
+        "given": "Sami"
+      },
+      {
+        "family": "Elo",
+        "given": "Laura"
+      },
+      {
+        "family": "Eerola",
+        "given": "Erkki"
+      },
+      {
+        "family": "Karlsson",
+        "given": "Hasse"
+      },
+      {
+        "family": "Karlsson",
+        "given": "Linnea"
+      }
+    ],
+    "container-title": "Brain Behavior and Immunity",
+    "id": "Aatsinki2019",
+    "issued": {
+      "date-parts": [
+        [
+          2019,
+          5
+        ]
+      ]
+    },
+    "keyword": "bioscience",
+    "page": "849-858",
+    "title": "Gut microbiota composition is associated with temperament traits in infants",
+    "type": "article-journal",
+    "volume": "80"
+  },
+  {
+    "URL": "https://github.com/openresearchlabs/openresearchlabs.github.io/blob/master/content/publication_resources/papers/2019-Hill-DHN.pdf",
+    "author": [
+      {
+        "family": "Hill",
+        "given": "Mark J"
+      },
+      {
+        "family": "Vaara",
+        "given": "Ville"
+      },
+      {
+        "family": "Säily",
+        "given": "Tanja"
+      },
+      {
+        "family": "Lahti",
+        "given": "Leo"
+      },
+      {
+        "family": "Tolonen",
+        "given": "Mikko"
+      }
+    ],
+    "collection-title": "CEUR workshop proceedings",
+    "container-title": "Proc. Digital humanities in the nordic countries",
+    "editor": [
+      {
+        "family": "Navarretta",
+        "given": "Costanza"
+      },
+      {
+        "family": "Agirrezabal",
+        "given": "Manex"
+      },
+      {
+        "family": "Maegaard",
+        "given": "Bente"
+      }
+    ],
+    "id": "Hill2019dhn",
+    "issued": {
+      "date-parts": [
+        [
+          2019
+        ]
+      ]
+    },
+    "keyword": "dh",
+    "note": "Best paper award.",
+    "page": "201-219",
+    "publisher-place": "Copenhagen",
+    "title": "Reconstructing intellectual networks: From the ESTC’s bibliographic metadata to historical material",
+    "title-short": "Reconstructing intellectual networks",
+    "type": "paper-conference",
+    "volume": "2364"
+  },
+  {
+    "author": [
+      {
+        "family": "Ijaz",
+        "given": "Ali"
+      },
+      {
+        "family": "Roivainen",
+        "given": "Hege"
+      },
+      {
+        "family": "Lahti",
+        "given": "Leo"
+      }
+    ],
+    "container-title": "Proceedings of the digital humanities (DH2019)",
+    "id": "Ijaz2019dh",
+    "issued": {
+      "date-parts": [
+        [
+          2019
+        ]
+      ]
+    },
+    "keyword": "dh",
+    "note": "In press.",
+    "title": "Analytical edition detection in bibliographic metadata",
+    "type": "paper-conference"
+  },
+  {
+    "URL": "https://github.com/openresearchlabs/openresearchlabs.github.io/blob/master/content/publication_resources/papers/2019-Ijaz-RDHum.pdf",
+    "author": [
+      {
+        "family": "Ijaz",
+        "given": "Ali"
+      },
+      {
+        "family": "Tolonen",
+        "given": "Mikko"
+      },
+      {
+        "family": "Lahti",
+        "given": "Leo"
+      }
+    ],
+    "container-title": "Proceedings of the research data in the humanities conference",
+    "id": "Ijaz2019rdhum",
+    "issued": {
+      "date-parts": [
+        [
+          2019
+        ]
+      ]
+    },
+    "keyword": "dh",
+    "publisher-place": "Oulu",
+    "title": "Analytical determination of editions from bibliographic metadata",
+    "type": "paper-conference"
+  },
+  {
+    "DOI": "10.1080/01639374.2018.1543747",
+    "URL": "https://github.com/openresearchlabs/openresearchlabs.github.io/blob/master/content/publication_resources/papers/2019-Lahti-CCQ.pdf",
+    "author": [
+      {
+        "family": "Lahti",
+        "given": "Leo"
+      },
+      {
+        "family": "Marjanen",
+        "given": "Jani"
+      },
+      {
+        "family": "Roivainen",
+        "given": "Hege"
+      },
+      {
+        "family": "Tolonen",
+        "given": "Mikko"
+      }
+    ],
+    "container-title": "Cataloging & Classification Quarterly",
+    "id": "Lahti2019bds",
+    "issue": "1",
+    "issued": {
+      "date-parts": [
+        [
+          2019
+        ]
+      ]
+    },
+    "keyword": "dh",
+    "note": "Special issue.",
+    "page": "5-23",
+    "publisher": "Routledge",
+    "title": "Bibliographic data science and the history of the book (c. 1500–1800)",
+    "type": "article-journal",
+    "volume": "57"
+  },
+  {
+    "URL": "https://github.com/openresearchlabs/openresearchlabs.github.io/blob/master/content/publication_resources/papers/2019-Lahti-RDHUM.pdf",
+    "author": [
+      {
+        "family": "Lahti",
+        "given": "Leo"
+      },
+      {
+        "family": "Vaara",
+        "given": "Ville"
+      },
+      {
+        "family": "Marjanen",
+        "given": "Jani"
+      },
+      {
+        "family": "Tolonen",
+        "given": "Mikko"
+      }
+    ],
+    "container-title": "Proceedings of the research data in the humanities conference",
+    "id": "Lahti2019rdhum",
+    "issued": {
+      "date-parts": [
+        [
+          2019
+        ]
+      ]
+    },
+    "keyword": "dh",
+    "publisher-place": "Oulu",
+    "title": "Best practices in bibliographic data science",
+    "type": "paper-conference"
+  },
+  {
+    "URL": "https://github.com/openresearchlabs/openresearchlabs.github.io/blob/master/content/publication_resources/papers/2019-Makela-DHN.pdf",
+    "author": [
+      {
+        "family": "Mäkelä",
+        "given": "Eetu"
+      },
+      {
+        "family": "Tolonen",
+        "given": "Mikko"
+      },
+      {
+        "family": "Marjanen",
+        "given": "Jani"
+      },
+      {
+        "family": "Kanner",
+        "given": "Antti"
+      },
+      {
+        "family": "Vaara",
+        "given": "Ville"
+      },
+      {
+        "family": "Lahti",
+        "given": "Leo"
+      }
+    ],
+    "collection-title": "CEUR workshop proceedings",
+    "container-title": "Proc. Twin talks workshop. Digital humanities in the nordic countries",
+    "editor": [
+      {
+        "family": "Krauwer",
+        "given": "Steven"
+      },
+      {
+        "family": "Fišer",
+        "given": "Darja"
+      }
+    ],
+    "id": "Makela2019dhn",
+    "issued": {
+      "date-parts": [
+        [
+          2019
+        ]
+      ]
+    },
+    "keyword": "dh",
+    "page": "55-66",
+    "publisher-place": "Copenhagen",
+    "status": "dh",
+    "title": "Interdisciplinary collaboration in studying newspaper materiality",
+    "type": "paper-conference",
+    "volume": "2365"
+  },
+  {
+    "DOI": "10.21825/jeps.v4i1.10483",
+    "URL": "https://github.com/openresearchlabs/openresearchlabs.github.io/blob/master/content/publication_resources/papers/2019-Marjanen-JEPS.pdf",
+    "author": [
+      {
+        "family": "Marjanen",
+        "given": "Jani"
+      },
+      {
+        "family": "Vaara",
+        "given": "Ville"
+      },
+      {
+        "family": "Kanner",
+        "given": "Antti"
+      },
+      {
+        "family": "Roivainen",
+        "given": "Hege"
+      },
+      {
+        "family": "Mäkelä",
+        "given": "Eetu"
+      },
+      {
+        "family": "Lahti",
+        "given": "Leo"
+      },
+      {
+        "family": "Tolonen",
+        "given": "Mikko"
+      }
+    ],
+    "container-title": "Journal of European Periodical Studies",
+    "id": "Marjanen2019",
+    "issue": "1",
+    "issued": {
+      "date-parts": [
+        [
+          2019
+        ]
+      ]
+    },
+    "keyword": "dh",
+    "note": "Special issue: Digital Approaches Towards Serial Publications",
+    "status": "dh",
+    "title": "A national public sphere? Analyzing the language, location, and form of newspapers in finland, 1771–1917",
+    "type": "article-journal",
+    "volume": "4"
+  },
+  {
+    "DOI": "10.1007/s12038-019-9930-2",
+    "URL": "https://github.com/openresearchlabs/openresearchlabs.github.io/blob/master/content/publication_resources/papers/2019-Shetty-MDS.pdf",
+    "author": [
+      {
+        "family": "Shetty",
+        "given": "Sudarshan"
+      },
+      {
+        "family": "Lahti",
+        "given": "Leo"
+      }
+    ],
+    "container-title": "Journal of Biosciences",
+    "id": "Shetty2019",
+    "issued": {
+      "date-parts": [
+        [
+          2019
+        ]
+      ]
+    },
+    "keyword": "bioscience",
+    "page": "115",
+    "title": "Microbiome data science",
+    "type": "article-journal",
+    "volume": "44"
+  },
+  {
+    "DOI": "10.1111/1751-7915.13406",
+    "annote": "Comics piece for the popularization of microbiome research.",
+    "author": [
+      {
+        "family": "Timmis",
+        "given": "K"
+      },
+      {
+        "family": "Jebok",
+        "given": "F"
+      },
+      {
+        "family": "Rohde",
+        "given": "M"
+      },
+      {
+        "family": "Lahti",
+        "given": "L"
+      },
+      {
+        "family": "Molinari",
+        "given": "G"
+      }
+    ],
+    "container-title": "Microbial Biotechnology",
+    "id": "Timmis2019",
+    "issued": {
+      "date-parts": [
+        [
+          2019
+        ]
+      ]
+    },
+    "keyword": "misc",
+    "title": "Microbiome yarns: The global phenotype-genotype survey. Episode III: Importance of microbiota diversification for microbiome function and biome health",
+    "title-short": "Microbiome yarns",
+    "type": "article-journal"
+  },
+  {
+    "URL": "https://github.com/openresearchlabs/openresearchlabs.github.io/blob/master/content/publication_resources/papers/2019-Tolonen-DHN.pdf",
+    "author": [
+      {
+        "family": "Tolonen",
+        "given": "Mikko"
+      },
+      {
+        "family": "Marjanen",
+        "given": "Jani"
+      },
+      {
+        "family": "Roivainen",
+        "given": "Hege"
+      },
+      {
+        "family": "Lahti",
+        "given": "Leo"
+      }
+    ],
+    "container-title": "Proceedings of the digital humanities in the nordics (DHN2019)",
+    "editor": [
+      {
+        "family": "Navarretta",
+        "given": "Costanza"
+      },
+      {
+        "family": "Agirrezabal",
+        "given": "Manex"
+      },
+      {
+        "family": "Maegaard",
+        "given": "Bente"
+      }
+    ],
+    "id": "Tolonen2019dhn",
+    "issued": {
+      "date-parts": [
+        [
+          2019
+        ]
+      ]
+    },
+    "keyword": "dh",
+    "publisher-place": "Copenhagen",
+    "status": "dh",
+    "title": "Scaling up bibliographic data science",
+    "type": "paper-conference"
+  },
+  {
+    "author": [
+      {
+        "family": "Vaara",
+        "given": "Ville"
+      },
+      {
+        "family": "Ijaz",
+        "given": "Ali"
+      },
+      {
+        "family": "Tiihonen",
+        "given": "Iiro"
+      },
+      {
+        "family": "Hengchen",
+        "given": "Simon"
+      },
+      {
+        "family": "Kanner",
+        "given": "Antti"
+      },
+      {
+        "family": "Säily",
+        "given": "Tanja"
+      },
+      {
+        "family": "Lahti",
+        "given": "Leo"
+      }
+    ],
+    "container-title": "Proceedings of the digital humanities (DH2019)",
+    "id": "Vaara2019dh",
+    "issued": {
+      "date-parts": [
+        [
+          2019
+        ]
+      ]
+    },
+    "keyword": "dh",
+    "note": "In press.",
+    "title": "The emerging paradigm of bibliographic data science",
+    "type": "paper-conference"
+  },
+  {
+    "DOI": "10.1093/femsec/fiz096",
+    "URL": "https://github.com/openresearchlabs/openresearchlabs.github.io/blob/master/content/publication_resources/papers/2019-Stolaki-FEMS.pdf",
+    "author": [
+      {
+        "family": "Stolaki",
+        "given": "Maria"
+      },
+      {
+        "family": "Minekus",
+        "given": "Mans"
+      },
+      {
+        "family": "Venema",
+        "given": "Koen"
+      },
+      {
+        "family": "Lahti",
+        "given": "Leo"
+      },
+      {
+        "family": "Smid",
+        "given": "Eddy J."
+      },
+      {
+        "family": "Kleerebezem",
+        "given": "Michiel"
+      },
+      {
+        "family": "Zoetendal",
+        "given": "Erwin G"
+      }
+    ],
+    "container-title": "FEMS Microbiology Ecology",
+    "id": "stolaki2019",
+    "issue": "8",
+    "issued": {
+      "date-parts": [
+        [
+          2019
+        ]
+      ]
+    },
+    "keyword": "bioscience",
+    "page": "fiz096",
+    "title": "Microbial communities in a dynamic it in vitro model for the human ileum resemble the human ileal microbiota",
+    "type": "article-journal"
+  },
+  {
+    "DOI": "10.1080/01615440.2018.1526657",
+    "URL": "https://github.com/openresearchlabs/openresearchlabs.github.io/blob/master/content/publication_resources/papers/2019-Tolonen.pdf",
+    "author": [
+      {
+        "family": "Tolonen",
+        "given": "Mikko"
+      },
+      {
+        "family": "Lahti",
+        "given": "Leo"
+      },
+      {
+        "family": "Roivainen",
+        "given": "Hege"
+      },
+      {
+        "family": "Marjanen",
+        "given": "Jani"
+      }
+    ],
+    "container-title": "Historical Methods: A Journal of Quantitative and Interdisciplinary History",
+    "id": "tolonen2019",
+    "issued": {
+      "date-parts": [
+        [
+          2019
+        ]
+      ]
+    },
+    "keyword": "dh",
+    "page": "57-78",
+    "publisher": "Routledge",
+    "title": "A quantitative approach to book-printing in sweden and finland, 1640–1828",
+    "type": "article-journal",
+    "volume": "52"
+  },
+  {
+    "DOI": "10.1089/jwh.2017.6488",
+    "URL": "https://github.com/openresearchlabs/openresearchlabs.github.io/blob/master/content/publication_resources/papers/2018-Aatsinki.pdf",
+    "author": [
+      {
+        "family": "Aatsinki",
+        "given": "Anna-Katariina"
+      },
+      {
+        "family": "Uusitupa",
+        "given": "Henna-Maria"
+      },
+      {
+        "family": "Munukka",
+        "given": "Eveliina"
+      },
+      {
+        "family": "Pesonen",
+        "given": "Henri"
+      },
+      {
+        "family": "Rintala",
+        "given": "Anniina"
+      },
+      {
+        "family": "Pietilä",
+        "given": "Sami"
+      },
+      {
+        "family": "Lahti",
+        "given": "Leo"
+      },
+      {
+        "family": "Eerola",
+        "given": "Erkki"
+      },
+      {
+        "family": "Karlsson",
+        "given": "Linnea"
+      },
+      {
+        "family": "Karlsson",
+        "given": "Hasse"
+      }
+    ],
+    "container-title": "Journal of Womens Health",
+    "id": "Aatsinki2018",
+    "issued": {
+      "date-parts": [
+        [
+          2018,
+          5
+        ]
+      ]
+    },
+    "keyword": "bioscience",
+    "note": "Epub ahead of print.",
+    "title": "Gut microbiota composition in mid-pregnancy is associated with gestational weight gain but not prepregnancy body mass index",
+    "type": "article-journal"
+  },
+  {
+    "DOI": "10.1103/PhysRevE.97.062407",
+    "ISSN": "2470-0045",
+    "URL": "https://github.com/openresearchlabs/openresearchlabs.github.io/blob/master/content/publication_resources/papers/2018-Arani-PhysRevE.pdf",
+    "author": [
+      {
+        "family": "Arani",
+        "given": "Babak M. S."
+      },
+      {
+        "family": "Mahmoudi",
+        "given": "Mahdi"
+      },
+      {
+        "family": "Lahti",
+        "given": "Leo"
+      },
+      {
+        "family": "González",
+        "given": "Javier"
+      },
+      {
+        "family": "Wit",
+        "given": "Ernst C."
+      }
+    ],
+    "container-title": "Physical Review E",
+    "id": "Arani2018",
+    "issue": "6",
+    "issued": {
+      "date-parts": [
+        [
+          2018,
+          6
+        ]
+      ]
+    },
+    "keyword": "datascience",
+    "page": "062407",
+    "publisher": "American Physical Society",
+    "title": "Stability estimation of autoregulated genes under michaelis-menten type kinetics",
+    "type": "article-journal",
+    "volume": "97"
+  },
+  {
+    "URL": "https://github.com/openresearchlabs/openresearchlabs.github.io/blob/master/content/publication_resources/papers/2018-Bjork-ATT.pdf",
+    "author": [
+      {
+        "family": "Björk",
+        "given": "Anna"
+      },
+      {
+        "family": "Paavolainen",
+        "given": "Juho-Matti"
+      },
+      {
+        "family": "Ropponen",
+        "given": "Teemu"
+      },
+      {
+        "family": "Laakso",
+        "given": "Mikael"
+      },
+      {
+        "family": "Lahti",
+        "given": "Leo"
+      }
+    ],
+    "id": "Bjork2018",
+    "issued": {
+      "date-parts": [
+        [
+          2018
+        ]
+      ]
+    },
+    "keyword": "openscience",
+    "note": "Report on the openness of major scientific publishers commissioned by Finnish Ministry of Education and Culture",
+    "publisher": "unknown; Open Science and Research Initiative (ATT)",
+    "status": "openscience",
+    "title": "Opening academic publishing: Development and application of systematic evaluation criteria",
+    "title-short": "Opening academic publishing",
+    "type": "report"
+  },
+  {
+    "DOI": "10.1186/s40168-018-0496-2",
+    "URL": "https://github.com/openresearchlabs/openresearchlabs.github.io/blob/master/content/publication_resources/papers/2018-Faust-Microbiome.pdf",
+    "author": [
+      {
+        "family": "Faust",
+        "given": "Karoline"
+      },
+      {
+        "family": "Bauchinger",
+        "given": "Franziska"
+      },
+      {
+        "family": "Laroche",
+        "given": "Beatrice"
+      },
+      {
+        "dropping-particle": "de",
+        "family": "Buyl",
+        "given": "Sophie"
+      },
+      {
+        "family": "Lahti",
+        "given": "Leo"
+      },
+      {
+        "family": "Washburne",
+        "given": "Alex D"
+      },
+      {
+        "family": "Gonze",
+        "given": "Didier"
+      },
+      {
+        "family": "Widder",
+        "given": "Stefanie"
+      }
+    ],
+    "container-title": "Microbiome",
+    "id": "Faust2018",
+    "issue": "120",
+    "issued": {
+      "date-parts": [
+        [
+          2018
+        ]
+      ]
+    },
+    "keyword": "bioscience",
+    "title": "Signatures of ecological processes in microbial community time series",
+    "type": "article-journal",
+    "volume": "6"
+  },
+  {
+    "DOI": "10.1016/j.mib.2018.07.004",
+    "URL": "https://github.com/openresearchlabs/openresearchlabs.github.io/blob/master/content/publication_resources/papers/2018-Gonze.pdf",
+    "author": [
+      {
+        "family": "Gonze",
+        "given": "Didier"
+      },
+      {
+        "family": "Coyte",
+        "given": "Katharine Z"
+      },
+      {
+        "family": "Lahti",
+        "given": "Leo"
+      },
+      {
+        "family": "Faust",
+        "given": "Karoline"
+      }
+    ],
+    "container-title": "Current Opinion in Microbiology",
+    "id": "Gonze2018",
+    "issued": {
+      "date-parts": [
+        [
+          2018
+        ]
+      ]
+    },
+    "keyword": "bioscience",
+    "page": "41-49",
+    "title": "Microbial communities as dynamical systems",
+    "type": "article-journal",
+    "volume": "44"
+  },
+  {
+    "author": [
+      {
+        "family": "Hill",
+        "given": "Mark J"
+      },
+      {
+        "family": "Kanner",
+        "given": "Antti"
+      },
+      {
+        "family": "Marjanen",
+        "given": "Jani"
+      },
+      {
+        "family": "Vaara",
+        "given": "Ville"
+      },
+      {
+        "family": "Mäkelä",
+        "given": "Eetu"
+      },
+      {
+        "family": "Lahti",
+        "given": "Leo"
+      },
+      {
+        "family": "Tolonen",
+        "given": "Mikko"
+      }
+    ],
+    "container-title": "Proceedings of the digital humanities in the nordics conference",
+    "id": "Hill2018",
+    "issued": {
+      "date-parts": [
+        [
+          2018,
+          3
+        ]
+      ]
+    },
+    "keyword": "dh",
+    "publisher-place": "Helsinki, Finland",
+    "title": "Spheres of “public” in eighteenth-century britain",
+    "type": "paper-conference"
+  },
+  {
+    "URL": "https://github.com/openresearchlabs/openresearchlabs.github.io/blob/master/content/publication_resources/papers/2018-Lahti-IDA.pdf",
+    "author": [
+      {
+        "family": "Lahti",
+        "given": "Leo"
+      }
+    ],
+    "container-title": "Advances in intelligent data analysis XVII. Lecture notes in computer science 11191.",
+    "id": "Lahti2018IDA",
+    "issued": {
+      "date-parts": [
+        [
+          2018
+        ]
+      ]
+    },
+    "keyword": "openscience",
+    "note": "Conference proceedings.",
+    "publisher": "Springer Nature",
+    "publisher-place": "India",
+    "title": "Open data science",
+    "type": "paper-conference",
+    "volume": "11191"
+  },
+  {
+    "URL": "https://github.com/openresearchlabs/openresearchlabs.github.io/blob/master/content/publication_resources/papers/2018-Laitinen-IDA.pdf",
+    "author": [
+      {
+        "family": "Laitinen",
+        "given": "Ville"
+      },
+      {
+        "family": "Lahti",
+        "given": "Leo"
+      }
+    ],
+    "container-title": "Advances in intelligent data analysis XVII. Lecture notes in computer science 11191.",
+    "id": "Laitinen2018IDA",
+    "issued": {
+      "date-parts": [
+        [
+          2018
+        ]
+      ]
+    },
+    "keyword": "datascience",
+    "note": "Conference proceedings.",
+    "publisher": "Springer",
+    "publisher-place": "India",
+    "title": "A hierarchical ornstein-uhlenbeck model for stochastic time series analysis",
+    "type": "paper-conference"
+  },
+  {
+    "URL": "https://www.gaudeamus.fi/menneisyyden-rakentajat/",
+    "annote": "This is a book chapter but classified as article as could not find a way to include this to CSL automatically generated bibliography yet.",
+    "author": [
+      {
+        "family": "Tolonen",
+        "given": "Mikko"
+      },
+      {
+        "family": "Lahti",
+        "given": "Leo"
+      }
+    ],
+    "container-title": "Menneisyyden rakentajat",
+    "editor": [
+      {
+        "family": "Hannikainen",
+        "given": "MO"
+      },
+      {
+        "family": "Danielsbacka",
+        "given": "M"
+      },
+      {
+        "family": "Tepora",
+        "given": "T"
+      }
+    ],
+    "id": "Tolonen2018gaudeamus",
+    "issued": {
+      "date-parts": [
+        [
+          2018
+        ]
+      ]
+    },
+    "keyword": "dh",
+    "note": "(in Finnish). In: Hannikainen, MO and Danielsbacka, M and Tepora, T (eds.). Menneisyyden rakentajat. Gaudeamus, Helsinki, 2018.",
+    "publisher": "Gaudeamus",
+    "title": "Digitaaliset ihmistieteet ja historiantutkimus",
+    "type": "article-journal"
+  },
+  {
+    "DOI": "10.1007/s10620-018-5190-5",
+    "URL": "https://github.com/openresearchlabs/openresearchlabs.github.io/blob/master/content/publication_resources/papers/2018-Youssef.pdf",
+    "author": [
+      {
+        "family": "Youssef",
+        "given": "Omar"
+      },
+      {
+        "family": "Lahti",
+        "given": "Leo"
+      },
+      {
+        "family": "Kokkola",
+        "given": "Arto"
+      },
+      {
+        "family": "Karla",
+        "given": "Tiina"
+      },
+      {
+        "family": "Tikkanen",
+        "given": "Milja"
+      },
+      {
+        "family": "Ehsan",
+        "given": "Homa"
+      },
+      {
+        "family": "Carpelan‑Holmström",
+        "given": "Monika"
+      },
+      {
+        "family": "Koskensalo",
+        "given": "Selja"
+      },
+      {
+        "family": "Böhling",
+        "given": "Tom"
+      },
+      {
+        "family": "Rautelin",
+        "given": "Hilpi"
+      },
+      {
+        "family": "Puolakkainen",
+        "given": "Pauli"
+      },
+      {
+        "family": "Knuutila",
+        "given": "Sakari"
+      },
+      {
+        "family": "Sarhadi",
+        "given": "Virinder"
+      }
+    ],
+    "container-title": "Digestive Diseases and Sciences",
+    "id": "Youssef2018",
+    "issue": "11",
+    "issued": {
+      "date-parts": [
+        [
+          2018
+        ]
+      ]
+    },
+    "keyword": "bioscience",
+    "page": "2950-2958",
+    "title": "Stool microbiota composition differs in patients with stomach, colon, and rectal neoplasms",
+    "type": "article-journal",
+    "volume": "63"
+  },
+  {
+    "URL": "https://github.com/openresearchlabs/openresearchlabs.github.io/blob/master/content/publication_resources/papers/2018-avoimen-tutkimuksen-politiikka-fi.pdf",
+    "annote": "Member in the work group that developed the report.",
+    "author": [
+      {
+        "literal": "OpenUTU work group"
+      }
+    ],
+    "container-title": "unknown",
+    "id": "openutu2018",
+    "issued": {
+      "date-parts": [
+        [
+          2018,
+          5
+        ]
+      ]
+    },
+    "keyword": "openscience",
+    "note": "(in Finnish)",
+    "publisher": "University of Turku; Report",
+    "title": "Turun yliopiston avoimen tutkimuksen politiikka / open research policy",
+    "type": "report"
+  },
+  {
+    "DOI": "10.1186/s40168-017-0309-z",
+    "URL": "https://github.com/openresearchlabs/openresearchlabs.github.io/blob/master/content/publication_resources/papers/2017-Buelow-Microbiome.pdf",
+    "author": [
+      {
+        "family": "Buelow",
+        "given": "Elena"
+      },
+      {
+        "family": "González",
+        "given": "Teresita d.J. Bello"
+      },
+      {
+        "family": "Fuentes",
+        "given": "Susana"
+      },
+      {
+        "family": "Steenhuijsen Piters",
+        "given": "Wouter A. A.",
+        "non-dropping-particle": "de"
+      },
+      {
+        "family": "Lahti",
+        "given": "Leo"
+      },
+      {
+        "family": "Bayjanov",
+        "given": "Jumamurat R."
+      },
+      {
+        "family": "Majoor",
+        "given": "Eline A. M."
+      },
+      {
+        "family": "Braat",
+        "given": "Johanna C."
+      },
+      {
+        "dropping-particle": "van",
+        "family": "Mourik",
+        "given": "Maaike S."
+      },
+      {
+        "family": "Oostdijk",
+        "given": "Evelien A. N."
+      },
+      {
+        "family": "Willems",
+        "given": "Rob J. L."
+      },
+      {
+        "family": "Bonten",
+        "given": "Marc J. M."
+      },
+      {
+        "dropping-particle": "van",
+        "family": "Passel",
+        "given": "Mark W. J."
+      },
+      {
+        "family": "Smidt",
+        "given": "Hauke"
+      },
+      {
+        "dropping-particle": "van",
+        "family": "Schaik",
+        "given": "Willem"
+      }
+    ],
+    "container-title": "Microbiome",
+    "id": "Buelow2017",
+    "issue": "1",
+    "issued": {
+      "date-parts": [
+        [
+          2017,
+          8
+        ]
+      ]
+    },
+    "keyword": "bioscience",
+    "page": "88",
+    "title": "Comparative gut microbiota and resistome profiling of intensive care patients receiving selective digestive tract decontamination and healthy subjects",
+    "type": "article-journal",
+    "volume": "5"
+  },
+  {
+    "DOI": "10.1038/ismej.2017.60",
+    "URL": "https://github.com/openresearchlabs/openresearchlabs.github.io/blob/master/content/publication_resources/papers/2017-Faust-ISME.pdf",
+    "author": [
+      {
+        "family": "Gonze",
+        "given": "Didier"
+      },
+      {
+        "family": "Lahti",
+        "given": "Leo"
+      },
+      {
+        "family": "Raes",
+        "given": "Jeroen"
+      },
+      {
+        "family": "Faust",
+        "given": "Karoline"
+      }
+    ],
+    "container-title": "ISME Journal",
+    "id": "Faust2017",
+    "issued": {
+      "date-parts": [
+        [
+          2017,
+          5
+        ]
+      ]
+    },
+    "keyword": "bioscience",
+    "page": "2159-2166",
+    "title": "Multi-stability and the origin of microbial community types",
+    "type": "article-journal",
+    "volume": "11"
+  },
+  {
+    "DOI": "10.1109/JPROC.2015.2428213",
+    "URL": "https://github.com/openresearchlabs/openresearchlabs.github.io/blob/master/content/publication_resources/papers/2017-Harris-IEEE.pdf",
+    "author": [
+      {
+        "family": "Harris",
+        "given": "Keith"
+      },
+      {
+        "family": "Parsons",
+        "given": "Todd L"
+      },
+      {
+        "family": "Ijaz",
+        "given": "Umer Z"
+      },
+      {
+        "family": "Lahti",
+        "given": "Leo"
+      },
+      {
+        "family": "Holmes",
+        "given": "Ian"
+      },
+      {
+        "family": "Quince",
+        "given": "Christopher"
+      }
+    ],
+    "container-title": "Proceedings of the IEEE",
+    "id": "Harris17",
+    "issue": "3",
+    "issued": {
+      "date-parts": [
+        [
+          2017
+        ]
+      ]
+    },
+    "keyword": "bioscience",
+    "page": "516-529",
+    "title": "Linking statistical and ecological theory: Hubbell’s unified neutral theory of biodiversity as a hierarchical dirichlet process",
+    "title-short": "Linking statistical and ecological theory",
+    "type": "article-journal",
+    "volume": "105"
+  },
+  {
+    "URL": "https://github.com/openresearchlabs/openresearchlabs.github.io/blob/master/content/publication_resources/papers/2017-Lahti-RJournal.pdf",
+    "annote": "R package homepage URL: http://ropengov.github.io/eurostat/",
+    "author": [
+      {
+        "family": "Lahti",
+        "given": "Leo"
+      },
+      {
+        "family": "Huovari",
+        "given": "Janne"
+      },
+      {
+        "family": "Kainu",
+        "given": "Markus"
+      },
+      {
+        "family": "Biecek",
+        "given": "Przemysław"
+      }
+    ],
+    "container-title": "The R Journal",
+    "id": "Lahti17eurostat",
+    "issue": "1",
+    "issued": {
+      "date-parts": [
+        [
+          2017
+        ]
+      ]
+    },
+    "keyword": "dh",
+    "page": "385-392",
+    "title": "Retrieval and analysis of eurostat open data with the eurostat package",
+    "type": "article-journal",
+    "volume": "9"
+  },
+  {
+    "DOI": "10.3897/rio.3.e13593",
+    "URL": "https://github.com/openresearchlabs/openresearchlabs.github.io/blob/master/content/publication_resources/papers/2017-Lahti-PHOS.pdf",
+    "author": [
+      {
+        "family": "Lahti",
+        "given": "Leo"
+      },
+      {
+        "dropping-particle": "da",
+        "family": "Silva",
+        "given": "Filipe"
+      },
+      {
+        "family": "Laine",
+        "given": "Markus Petteri"
+      },
+      {
+        "family": "Lähteenoja",
+        "given": "Viivi"
+      },
+      {
+        "family": "Tolonen",
+        "given": "Mikko"
+      }
+    ],
+    "container-title": "RIO Journal",
+    "id": "Lahti17phos",
+    "issued": {
+      "date-parts": [
+        [
+          2017,
+          5
+        ]
+      ]
+    },
+    "keyword": "dh",
+    "note": "Review of the international conference, including electronic material (video interviews, lectures and podcasts.",
+    "page": "e13593",
+    "status": "openscience",
+    "title": "Alchemy & algorithms: Perspectives on the philosophy and history of open science",
+    "title-short": "Alchemy & algorithms",
+    "type": "article-journal",
+    "volume": "3"
+  },
+  {
+    "DOI": "10.1093/femsre/fuw045",
+    "URL": "https://github.com/openresearchlabs/openresearchlabs.github.io/blob/master/content/publication_resources/papers/2017-Shetty-FEMS.pdf",
+    "author": [
+      {
+        "family": "Shetty",
+        "given": "SA"
+      },
+      {
+        "family": "Hugenholtz",
+        "given": "F"
+      },
+      {
+        "family": "Lahti",
+        "given": "L"
+      },
+      {
+        "family": "Smidt",
+        "given": "H"
+      },
+      {
+        "dropping-particle": "de",
+        "family": "Vos",
+        "given": "WM"
+      },
+      {
+        "family": "Danchin",
+        "given": "A"
+      }
+    ],
+    "container-title": "FEMS Microbiology Reviews",
+    "id": "Shetty2017",
+    "issued": {
+      "date-parts": [
+        [
+          2017
+        ]
+      ]
+    },
+    "keyword": "bioscience",
+    "note": "review",
+    "page": "182-199",
+    "title": "Intestinal microbiome landscaping: Insight in community assemblage and implications for microbial modulation strategies",
+    "title-short": "Intestinal microbiome landscaping",
+    "type": "article-journal",
+    "volume": "41"
+  },
+  {
+    "URL": "http://dh2016.adho.org/abstracts/9",
+    "author": [
+      {
+        "family": "Tolonen",
+        "given": "Mikko"
+      },
+      {
+        "family": "Ilomäki",
+        "given": "Niko"
+      },
+      {
+        "family": "Roivainen",
+        "given": "Hege"
+      },
+      {
+        "family": "Lahti",
+        "given": "Leo"
+      }
+    ],
+    "container-title": "Digital humanities 2016: Conference abstracts",
+    "id": "Tolonen16dh",
+    "issued": {
+      "date-parts": [
+        [
+          2016,
+          7
+        ]
+      ]
+    },
+    "keyword": "dh",
+    "page": "383-385",
+    "publisher": "Jagiellonian University & Pedagogical University, Kraków",
+    "publisher-place": "Krakow, Poland",
+    "title": "Printing in a periphery: A quantitative study of finnish knowledge production, 1640-1828",
+    "title-short": "Printing in a periphery",
+    "type": "paper-conference"
+  },
+  {
+    "DOI": "10.12688/f1000research.5686.2",
+    "URL": "https://github.com/openresearchlabs/openresearchlabs.github.io/blob/master/content/publication_resources/papers/2014-Aleksic.pdf",
+    "author": [
+      {
+        "family": "Aleksic",
+        "given": "Jelena"
+      },
+      {
+        "family": "Alexa",
+        "given": "Adrian"
+      },
+      {
+        "family": "Attwood",
+        "given": "Teresa K"
+      },
+      {
+        "family": "Hong",
+        "given": "Neil Chue"
+      },
+      {
+        "family": "Dahlö",
+        "given": "Martin"
+      },
+      {
+        "family": "Davey",
+        "given": "Robert"
+      },
+      {
+        "family": "Dinkel",
+        "given": "Holger"
+      },
+      {
+        "family": "Förstner",
+        "given": "Konrad U"
+      },
+      {
+        "family": "Grigorov",
+        "given": "Ivo"
+      },
+      {
+        "family": "Hériché",
+        "given": "Jean-Karim"
+      },
+      {
+        "family": "Lahti",
+        "given": "Leo"
+      },
+      {
+        "family": "MacLean",
+        "given": "Dan"
+      },
+      {
+        "family": "Markie",
+        "given": "Michael L"
+      },
+      {
+        "family": "Molloy",
+        "given": "Jenny"
+      },
+      {
+        "family": "Schneider",
+        "given": "Maria Victoria"
+      },
+      {
+        "family": "Scott",
+        "given": "Camille"
+      },
+      {
+        "family": "Smith-Unna",
+        "given": "Richard"
+      },
+      {
+        "family": "Vieira",
+        "given": "Bruno Miguel"
+      }
+    ],
+    "container-title": "F1000Research",
+    "id": "Aleksic14",
+    "issued": {
+      "date-parts": [
+        [
+          2015,
+          1
+        ]
+      ]
+    },
+    "keyword": "openscience",
+    "note": "AllBio: Open Science & Reproducibility Best Practice Workshop",
+    "page": "271",
+    "title": "The open science peer review oath",
+    "type": "article-journal",
+    "volume": "3"
+  },
+  {
+    "DOI": "10.1016/j.mib.2015.04.004",
+    "URL": "https://github.com/openresearchlabs/openresearchlabs.github.io/blob/master/content/publication_resources/papers/2015-Faust-CurrOpMicrob.pdf",
+    "author": [
+      {
+        "family": "Faust",
+        "given": "Karoline"
+      },
+      {
+        "family": "Lahti",
+        "given": "Leo"
+      },
+      {
+        "family": "Gonze",
+        "given": "Didier"
+      },
+      {
+        "dropping-particle": "de",
+        "family": "Vos",
+        "given": "Willem M"
+      },
+      {
+        "family": "Raes",
+        "given": "Jeroen"
+      }
+    ],
+    "container-title": "Current Opinion in Microbiology",
+    "id": "Faust15",
+    "issued": {
+      "date-parts": [
+        [
+          2015,
+          6
+        ]
+      ]
+    },
+    "keyword": "bioscience",
+    "page": "56-66",
+    "title": "Metagenomics meets time series analysis: Unraveling microbial community dynamics",
+    "title-short": "Metagenomics meets time series analysis",
+    "type": "article-journal",
+    "volume": "25"
+  },
+  {
+    "DOI": "10.18352/lq.10112",
+    "ISSN": "2213-056X",
+    "URL": "https://github.com/openresearchlabs/openresearchlabs.github.io/blob/master/content/publication_resources/papers/2015-Lahti-LIBERQuarterly.pdf",
+    "author": [
+      {
+        "family": "Lahti",
+        "given": "Leo"
+      },
+      {
+        "family": "Ilomäki",
+        "given": "Niko"
+      },
+      {
+        "family": "Tolonen",
+        "given": "Mikko"
+      }
+    ],
+    "container-title": "LIBER Quarterly",
+    "id": "Lahti15LIBER",
+    "issue": "2",
+    "issued": {
+      "date-parts": [
+        [
+          2015,
+          12
+        ]
+      ]
+    },
+    "keyword": "dh",
+    "page": "87-116",
+    "status": "dh",
+    "title": "A quantitative study of history in the english short-title catalogue (ESTC) 1470-1800",
+    "type": "article-journal",
+    "volume": "25"
+  },
+  {
+    "ISBN": "978-1-4503-3948-3",
+    "URL": "https://github.com/openresearchlabs/openresearchlabs.github.io/blob/master/content/publication_resources/papers/2015-Laine-Mindtrek.pdf",
+    "author": [
+      {
+        "family": "Laine",
+        "given": "Heidi"
+      },
+      {
+        "family": "Lahti",
+        "given": "Leo"
+      },
+      {
+        "family": "Lehto",
+        "given": "Anne"
+      },
+      {
+        "family": "Ollila",
+        "given": "Samuli"
+      },
+      {
+        "family": "Miettinen",
+        "given": "Markus"
+      }
+    ],
+    "container-title": "Proceedings of the 19th international academic mindtrek conference in tampere, finland, september 22-24",
+    "id": "Laine15",
+    "issued": {
+      "date-parts": [
+        [
+          2015
+        ]
+      ]
+    },
+    "keyword": "openscience",
+    "publisher": "AcademicMindTrek’15: Proceedings of the 19th International Academic Mindtrek Conference; ACM",
+    "publisher-place": "New York, NY, USA",
+    "title": "Beyond open access - the changing culture of producing and disseminating scientific knowledge",
+    "type": "paper-conference"
+  },
+  {
+    "DOI": "10.1038/ncomms7342",
+    "URL": "https://github.com/openresearchlabs/openresearchlabs.github.io/blob/master/content/publication_resources/papers/2015-OKeefe-NComms.pdf",
+    "annote": "Guardian: http://www.theguardian.com/science/2015/apr/28/bowel-cancer-risk-may-be-reduced-by-rural-african-diet-study-finds",
+    "author": [
+      {
+        "family": "O’Keefe",
+        "given": "SJD"
+      },
+      {
+        "family": "Li",
+        "given": "JV"
+      },
+      {
+        "family": "Lahti",
+        "given": "L"
+      },
+      {
+        "family": "Ou",
+        "given": "J"
+      },
+      {
+        "family": "Carbonero",
+        "given": "F"
+      },
+      {
+        "family": "Mohammed",
+        "given": "K"
+      },
+      {
+        "family": "Posma",
+        "given": "JM"
+      },
+      {
+        "family": "Kinross",
+        "given": "J"
+      },
+      {
+        "family": "Wahl",
+        "given": "E"
+      },
+      {
+        "family": "Ruder",
+        "given": "E"
+      },
+      {
+        "family": "Vipperla",
+        "given": "K"
+      },
+      {
+        "family": "Naidoo",
+        "given": "V"
+      },
+      {
+        "family": "Mtshali",
+        "given": "L"
+      },
+      {
+        "family": "Tims",
+        "given": "S"
+      },
+      {
+        "family": "PGB Puylaert",
+        "given": "J DeLany"
+      },
+      {
+        "family": "Krasinskas",
+        "given": "A"
+      },
+      {
+        "family": "Benefiel",
+        "given": "AC"
+      },
+      {
+        "family": "Kaseb",
+        "given": "HO"
+      },
+      {
+        "family": "Newton",
+        "given": "K"
+      },
+      {
+        "family": "Nicholson",
+        "given": "JK"
+      },
+      {
+        "dropping-particle": "de",
+        "family": "Vos",
+        "given": "WM"
+      },
+      {
+        "family": "Gaskins",
+        "given": "HR"
+      },
+      {
+        "family": "Zoetendal",
+        "given": "EG"
+      }
+    ],
+    "container-title": "Nature Communications",
+    "id": "OKeefe15",
+    "issued": {
+      "date-parts": [
+        [
+          2015,
+          4
+        ]
+      ]
+    },
+    "keyword": "bioscience",
+    "note": "Top science article in Guardian on the release day.",
+    "page": "6342",
+    "title": "Fat, fiber and cancer risk in african, americans and rural africans",
+    "type": "article-journal",
+    "volume": "6"
+  },
+  {
+    "DOI": "10.1186/s12864-015-2265-y",
+    "URL": "https://github.com/openresearchlabs/openresearchlabs.github.io/blob/master/content/publication_resources/papers/2015-Ritari-BMCGenomics.pdf",
+    "author": [
+      {
+        "family": "Ritari",
+        "given": "Jarmo"
+      },
+      {
+        "family": "Salojärvi",
+        "given": "Jarkko"
+      },
+      {
+        "family": "Lahti",
+        "given": "Leo"
+      },
+      {
+        "dropping-particle": "de",
+        "family": "Vos",
+        "given": "Willem M."
+      }
+    ],
+    "container-title": "BMC Genomics",
+    "id": "Ritari15",
+    "issued": {
+      "date-parts": [
+        [
+          2015,
+          12
+        ]
+      ]
+    },
+    "keyword": "bioscience",
+    "page": "1056",
+    "title": "Improved taxonomic assignment of human intestinal 16S rRNA sequences by a dedicated reference database",
+    "type": "article-journal",
+    "volume": "16"
+  },
+  {
+    "DOI": "10.1038/srep17284",
+    "URL": "https://github.com/openresearchlabs/openresearchlabs.github.io/blob/master/content/publication_resources/papers/2015-Atagashi.pdf",
+    "author": [
+      {
+        "family": "Atashgahi",
+        "given": "Siavash"
+      },
+      {
+        "family": "Aydin",
+        "given": "Rozelin"
+      },
+      {
+        "family": "Dimitrov",
+        "given": "Mauricio R."
+      },
+      {
+        "family": "Sipkema",
+        "given": "Detmer"
+      },
+      {
+        "family": "Hamonts",
+        "given": "Kelly"
+      },
+      {
+        "family": "Lahti",
+        "given": "Leo"
+      },
+      {
+        "family": "Maphosa",
+        "given": "Farai"
+      },
+      {
+        "family": "Kruse",
+        "given": "Thomas"
+      },
+      {
+        "family": "Saccenti",
+        "given": "Edoardo"
+      },
+      {
+        "family": "Dirk Springael",
+        "given": "Winnie Dejonghe"
+      },
+      {
+        "family": "Smidt",
+        "given": "Hauke"
+      }
+    ],
+    "container-title": "Scientific Reports",
+    "id": "Siavash15",
+    "issue": "17284",
+    "issued": {
+      "date-parts": [
+        [
+          2015,
+          11
+        ]
+      ]
+    },
+    "keyword": "bioscience",
+    "title": "Impact of a wastewater treatment plant on microbial community composition and function in a hyporheic zone of a eutrophic river",
+    "type": "article-journal",
+    "volume": "5"
+  },
+  {
+    "DOI": "10.1186/s13395-015-0059-1",
+    "URL": "https://github.com/openresearchlabs/openresearchlabs.github.io/blob/master/content/publication_resources/papers/2015-Su-SkeletalMuscle.pdf",
+    "author": [
+      {
+        "family": "Su",
+        "given": "Jing"
+      },
+      {
+        "family": "Ekman",
+        "given": "Carl"
+      },
+      {
+        "family": "Oskolkov",
+        "given": "Nikolay"
+      },
+      {
+        "family": "Lahti",
+        "given": "Leo"
+      },
+      {
+        "family": "Ström",
+        "given": "Kristoffer"
+      },
+      {
+        "family": "Brazma",
+        "given": "Alvis"
+      },
+      {
+        "family": "Groop",
+        "given": "Leif"
+      },
+      {
+        "family": "Rung",
+        "given": "Johan"
+      },
+      {
+        "dropping-particle": "and",
+        "family": "Ola Hansson"
+      }
+    ],
+    "container-title": "Skeletal Muscle",
+    "id": "Su2015",
+    "issue": "35",
+    "issued": {
+      "date-parts": [
+        [
+          2015,
+          10
+        ]
+      ]
+    },
+    "keyword": "bioscience",
+    "title": "A novel atlas of gene expression in human skeletal muscle reveals molecular changes associated with aging",
+    "type": "article-journal",
+    "volume": "5"
+  },
+  {
+    "URL": "https://github.com/openresearchlabs/openresearchlabs.github.io/blob/master/content/publication_resources/papers/2015-EnnenNyt-Tolonen.pdf",
+    "author": [
+      {
+        "family": "Tolonen",
+        "given": "Mikko"
+      },
+      {
+        "family": "Lahti",
+        "given": "Leo"
+      }
+    ],
+    "container-title": "Ennen & Nyt 2",
+    "id": "Tolonen15EnnenNyt",
+    "issued": {
+      "date-parts": [
+        [
+          2015,
+          8
+        ]
+      ]
+    },
+    "keyword": "dh",
+    "title": "Aatehistoria ja digitaalisten aineistojen mahdollisuudet",
+    "type": "article-journal",
+    "volume": "2"
+  },
+  {
+    "DOI": "10.1038/nmeth.3103",
+    "URL": "https://github.com/openresearchlabs/openresearchlabs.github.io/blob/master/content/publication_resources/papers/2014-Alneberg-NatMeth.pdf",
+    "author": [
+      {
+        "family": "Alneberg",
+        "given": "Johannes"
+      },
+      {
+        "family": "Bjarnason",
+        "given": "Brynjar Smári"
+      },
+      {
+        "dropping-particle": "de",
+        "family": "Bruijn",
+        "given": "Ino"
+      },
+      {
+        "family": "Schirmer",
+        "given": "Melanie"
+      },
+      {
+        "family": "Quick",
+        "given": "Joshua"
+      },
+      {
+        "family": "Ijaz",
+        "given": "Umer Z"
+      },
+      {
+        "family": "Lahti",
+        "given": "Leo"
+      },
+      {
+        "family": "Loman",
+        "given": "Nicholas J"
+      },
+      {
+        "family": "Andersson",
+        "given": "Anders F"
+      },
+      {
+        "family": "Quince",
+        "given": "Christopher"
+      }
+    ],
+    "container-title": "Nature Methods",
+    "id": "Alneberg14",
+    "issue": "1144–1146",
+    "issued": {
+      "date-parts": [
+        [
+          2014
+        ]
+      ]
+    },
+    "keyword": "bioscience",
+    "note": "CONCOCT algorithm",
+    "title": "Binning metagenomic contigs by coverage and composition",
+    "type": "article-journal",
+    "volume": "11"
+  },
+  {
+    "DOI": "10.4161/sysb.28904",
+    "URL": "https://github.com/openresearchlabs/openresearchlabs.github.io/blob/master/content/publication_resources/papers/2014-Louhimo.pdf",
+    "author": [
+      {
+        "family": "Louhimo",
+        "given": "Riku"
+      },
+      {
+        "family": "Aittomäki",
+        "given": "Viljami"
+      },
+      {
+        "family": "Faisal",
+        "given": "Ali"
+      },
+      {
+        "family": "Laakso",
+        "given": "Marko"
+      },
+      {
+        "family": "Chen",
+        "given": "Ping"
+      },
+      {
+        "family": "Ovaska",
+        "given": "Kristian"
+      },
+      {
+        "family": "Valo",
+        "given": "Erkka"
+      },
+      {
+        "family": "Lahti",
+        "given": "Leo"
+      },
+      {
+        "family": "Rogojin",
+        "given": "Vladimir"
+      },
+      {
+        "family": "Kaski",
+        "given": "Samuel"
+      },
+      {
+        "family": "Hautaniemi.",
+        "given": "Sampsa"
+      }
+    ],
+    "container-title": "Systems Biomedicine (special issue)",
+    "id": "Louhimo14",
+    "issued": {
+      "date-parts": [
+        [
+          2014,
+          4
+        ]
+      ]
+    },
+    "keyword": "bioscience",
+    "note": "Critical Assessment of Massive Data Analysis (CAMDA) workshop",
+    "page": "130-136",
+    "title": "Systematic use of computational methods allows stratifying treatment responders in glioblastoma multiforme",
+    "type": "article-journal",
+    "volume": "1"
+  },
+  {
     "DOI": "10.1038/ncomms5344",
     "URL": "https://github.com/openresearchlabs/openresearchlabs.github.io/blob/master/content/publication_resources/papers/2014-Lahti-NatComm.pdf",
     "author": [
@@ -5893,55 +4394,6 @@
     "title": "Tipping elements in the human intestinal ecosystem",
     "type": "article-journal",
     "volume": "5"
-  },
-  {
-    "author": [
-      {
-        "dropping-particle": "in Open Education (Open Science Coordination in",
-        "family": "Finland)",
-        "given": "Expert Panel"
-      }
-    ],
-    "container-title": "Responsible Research Series",
-    "id": "openedu2020",
-    "issued": {
-      "date-parts": [
-        [
-          2020
-        ]
-      ]
-    },
-    "keyword": "openscience",
-    "publisher": "Committee for Public Information (TJNK) and Federation of Finnish Learned Societies (TSV).",
-    "publisher-place": "Helsinki, Finland",
-    "title": "National policy and executive plan by the higher education and research community for 2021-2025 - policy component 1: Open access to educational resources.",
-    "title-short": "National policy and executive plan by the higher education and research community for 2021-2025 - policy component 1",
-    "type": "report",
-    "volume": "16"
-  },
-  {
-    "URL": "https://github.com/openresearchlabs/openresearchlabs.github.io/blob/master/content/publication_resources/papers/2018-avoimen-tutkimuksen-politiikka-fi.pdf",
-    "annote": "Member in the work group that developed the report.",
-    "author": [
-      {
-        "literal": "OpenUTU work group"
-      }
-    ],
-    "container-title": "unknown",
-    "id": "openutu2018",
-    "issued": {
-      "date-parts": [
-        [
-          2018,
-          5
-        ]
-      ]
-    },
-    "keyword": "openscience",
-    "note": "(in Finnish)",
-    "publisher": "University of Turku; Report",
-    "title": "Turun yliopiston avoimen tutkimuksen politiikka / open research policy",
-    "type": "report"
   },
   {
     "DOI": "10.1038/ismej.2014.63",
@@ -6070,88 +4522,1649 @@
     "volume": "53"
   },
   {
-    "DOI": "10.1093/femsec/fiz096",
-    "URL": "https://github.com/openresearchlabs/openresearchlabs.github.io/blob/master/content/publication_resources/papers/2019-Stolaki-FEMS.pdf",
+    "URL": "http://ropengov.github.io",
     "author": [
       {
-        "family": "Stolaki",
-        "given": "Maria"
+        "family": "Leo Lahti",
+        "given": "Joona Lehtomäki",
+        "suffix": "Juuso Parkkinen"
       },
       {
-        "family": "Minekus",
-        "given": "Mans"
-      },
-      {
-        "family": "Venema",
-        "given": "Koen"
-      },
+        "family": "Kainu",
+        "given": "Markus"
+      }
+    ],
+    "id": "Lahti13icml",
+    "issued": {
+      "date-parts": [
+        [
+          2013,
+          12
+        ]
+      ]
+    },
+    "keyword": "datascience",
+    "note": "ICML/MLOSS workshop (Int’l Conf. on Machine Learning - Open Source Software workshop).",
+    "publisher": "software",
+    "title": "rOpenGov: Open source ecosystem for computational social sciences and digital humanities",
+    "title-short": "rOpenGov",
+    "type": ""
+  },
+  {
+    "DOI": "10.1093/nar/gkt229",
+    "URL": "https://github.com/openresearchlabs/openresearchlabs.github.io/blob/master/content/publication_resources/papers/2013-Lahti-NAR.pdf",
+    "author": [
       {
         "family": "Lahti",
         "given": "Leo"
       },
       {
-        "family": "Smid",
-        "given": "Eddy J."
+        "family": "Torrente",
+        "given": "Aurora"
       },
       {
-        "family": "Kleerebezem",
-        "given": "Michiel"
+        "family": "Elo",
+        "given": "Laura L"
       },
       {
-        "family": "Zoetendal",
-        "given": "Erwin G"
+        "family": "Brazma",
+        "given": "Alvis"
+      },
+      {
+        "family": "Rung",
+        "given": "Johan"
       }
     ],
-    "container-title": "FEMS Microbiology Ecology",
-    "id": "stolaki2019",
-    "issue": "8",
+    "container-title": "Nucleic Acids Research",
+    "id": "Lahti13nar",
+    "issue": "10",
     "issued": {
       "date-parts": [
         [
-          2019
+          2013
         ]
       ]
     },
     "keyword": "bioscience",
-    "page": "fiz096",
-    "title": "Microbial communities in a dynamic it in vitro model for the human ileum resemble the human ileal microbiota",
-    "type": "article-journal"
+    "note": "Implementation available through Bioconductor RPA package.",
+    "page": "e110",
+    "title": "A fully scalable online pre-processing algorithm for short oligonucleotide microarray atlases",
+    "type": "article-journal",
+    "volume": "41"
   },
   {
-    "DOI": "10.1080/01615440.2018.1526657",
-    "URL": "https://github.com/openresearchlabs/openresearchlabs.github.io/blob/master/content/publication_resources/papers/2019-Tolonen.pdf",
+    "DOI": "10.7717/peerj.32",
+    "PMID": "23638368",
+    "URL": "https://github.com/openresearchlabs/openresearchlabs.github.io/blob/master/content/publication_resources/papers/2013-Lahti-PeerJ.pdf",
     "author": [
       {
-        "family": "Tolonen",
-        "given": "Mikko"
+        "family": "Lahti",
+        "given": "Leo"
+      },
+      {
+        "family": "Salonen",
+        "given": "Anne"
+      },
+      {
+        "family": "Kekkonen",
+        "given": "Riina A."
+      },
+      {
+        "family": "Salojärvi",
+        "given": "Jarkko"
+      },
+      {
+        "family": "Jalanka-Tuovinen",
+        "given": "Jonna"
+      },
+      {
+        "family": "Palva",
+        "given": "Airi"
+      },
+      {
+        "family": "Orešič",
+        "given": "Matej"
+      },
+      {
+        "dropping-particle": "de",
+        "family": "Vos",
+        "given": "Willem M."
+      }
+    ],
+    "container-title": "PeerJ",
+    "id": "Lahti13provasI",
+    "issued": {
+      "date-parts": [
+        [
+          2013
+        ]
+      ]
+    },
+    "keyword": "bioscience",
+    "note": "Highly accessed, featured in PeerJ journal blog and Top-10 Microbiology collection.",
+    "page": "e32",
+    "title": "Associations between the human intestinal microbiota, lactobacillus rhamnosus GG and serum lipids indicated by integrated analysis of high-throughput profiling data",
+    "type": "article-journal",
+    "volume": "1"
+  },
+  {
+    "DOI": "10.1093/bib/bbs005",
+    "URL": "https://github.com/openresearchlabs/openresearchlabs.github.io/blob/master/content/publication_resources/papers/2013-Lahti-BriefBioinf.pdf",
+    "author": [
+      {
+        "family": "Lahti",
+        "given": "Leo"
+      },
+      {
+        "family": "Schäfer",
+        "given": "Martin"
+      },
+      {
+        "family": "Klein",
+        "given": "Hans-Ulrich"
+      },
+      {
+        "family": "Bicciato",
+        "given": "Silvio"
+      },
+      {
+        "family": "Dugas",
+        "given": "Martin"
+      }
+    ],
+    "container-title": "Briefings in Bioinformatics",
+    "id": "Lahti2012intcomp",
+    "issue": "1",
+    "issued": {
+      "date-parts": [
+        [
+          2013,
+          6
+        ]
+      ]
+    },
+    "keyword": "bioscience",
+    "page": "27-35",
+    "title": "Cancer gene prioritization by integrative analysis of mRNA expression and DNA copy number data: A comparative review",
+    "title-short": "Cancer gene prioritization by integrative analysis of mRNA expression and DNA copy number data",
+    "type": "article-journal",
+    "volume": "14"
+  },
+  {
+    "DOI": "10.1016/j.ygeno.2013.01.001",
+    "URL": "https://github.com/openresearchlabs/openresearchlabs.github.io/blob/master/content/publication_resources/papers/2013-Sarhadi-Genomics.pdf",
+    "author": [
+      {
+        "family": "Sarhadi",
+        "given": "Virinder Kaur"
       },
       {
         "family": "Lahti",
         "given": "Leo"
       },
       {
-        "family": "Roivainen",
-        "given": "Hege"
+        "family": "Scheinin",
+        "given": "Ilari"
       },
       {
-        "family": "Marjanen",
-        "given": "Jani"
+        "family": "Tyybäkinoja",
+        "given": "Anne"
+      },
+      {
+        "family": "Savola",
+        "given": "Suvi"
+      },
+      {
+        "family": "Usvasalo",
+        "given": "Anu"
+      },
+      {
+        "family": "Räty",
+        "given": "Riikka"
+      },
+      {
+        "family": "Elonen",
+        "given": "Erkki"
+      },
+      {
+        "family": "Ellonen",
+        "given": "Pekka"
+      },
+      {
+        "family": "Saarinen-Pihkala",
+        "given": "Ulla M"
+      },
+      {
+        "family": "Knuutila",
+        "given": "Sakari"
       }
     ],
-    "container-title": "Historical Methods: A Journal of Quantitative and Interdisciplinary History",
-    "id": "tolonen2019",
+    "container-title": "Genomics",
+    "id": "Sarhadi13",
+    "issue": "3",
     "issued": {
       "date-parts": [
         [
-          2019
+          2013,
+          9
         ]
       ]
     },
-    "keyword": "dh",
-    "page": "57-78",
-    "publisher": "Routledge",
-    "title": "A quantitative approach to book-printing in sweden and finland, 1640–1828",
+    "keyword": "bioscience",
+    "page": "182-188",
+    "title": "Targeted resequencing of 9p in acute lymphoblastic leukemia yields concordant results with array CGH and reveals novel genomic alterations",
     "type": "article-journal",
-    "volume": "52"
+    "volume": "102"
+  },
+  {
+    "DOI": "10.4230/DagRep.3.5.78",
+    "ISSN": "2192-5283",
+    "URL": "http://drops.dagstuhl.de/opus/volltexte/2013/4179",
+    "annote": "Keywords: Bioinformatics, Chemoinformatics, Machine learning, Statistics, Interdisciplinary applications. Short abstract for the Dagstuhl seminar.",
+    "author": [
+      {
+        "family": "Lahti",
+        "given": "Leo"
+      }
+    ],
+    "container-title": "Dagstuhl Reports",
+    "editor": [
+      {
+        "family": "Bender",
+        "given": "Andreas"
+      },
+      {
+        "family": "Göhlmann",
+        "given": "Hinrich"
+      },
+      {
+        "family": "Hochreiter",
+        "given": "Sepp"
+      },
+      {
+        "family": "Shkedy",
+        "given": "Ziv"
+      }
+    ],
+    "id": "bender13",
+    "issue": "5",
+    "issued": {
+      "date-parts": [
+        [
+          2013
+        ]
+      ]
+    },
+    "keyword": "bioscience",
+    "page": "78-94",
+    "publisher": "Schloss Dagstuhl–Leibniz-Zentrum fuer Informatik",
+    "publisher-place": "Dagstuhl, Germany",
+    "title": "Intestinal microbiota, individuality and health. In: Computational methods aiding early-stage drug design (dagstuhl seminar 13212)",
+    "title-short": "Intestinal microbiota, individuality and health. In",
+    "type": "article-journal",
+    "volume": "3"
+  },
+  {
+    "DOI": "10.1111/j.1469-0691.2012.03855.x",
+    "URL": "https://github.com/openresearchlabs/openresearchlabs.github.io/blob/master/content/publication_resources/papers/2012-Salonen-CMI.pdf",
+    "author": [
+      {
+        "family": "Salonen",
+        "given": "Anne"
+      },
+      {
+        "family": "Salojärvi",
+        "given": "Jarkko"
+      },
+      {
+        "family": "Lahti",
+        "given": "Leo"
+      },
+      {
+        "dropping-particle": "and Willem M. de",
+        "family": "Vos"
+      }
+    ],
+    "container-title": "Clinical Microbiology and Infection",
+    "id": "Lahti12cmi",
+    "issue": "Suppl. 4",
+    "issued": {
+      "date-parts": [
+        [
+          2012
+        ]
+      ]
+    },
+    "keyword": "bioscience",
+    "page": "16-20",
+    "title": "The adult intestinal core microbiota is determined by analysis depth and health status",
+    "type": "article-journal",
+    "volume": "18"
+  },
+  {
+    "DOI": "10.1016/j.cancergen.2012.08.003",
+    "URL": "https://github.com/openresearchlabs/openresearchlabs.github.io/blob/master/content/publication_resources/papers/2012-Mosakhani-CG.pdf",
+    "author": [
+      {
+        "family": "Mosakhani",
+        "given": "Neda"
+      },
+      {
+        "family": "Lahti",
+        "given": "Leo"
+      },
+      {
+        "family": "Borze",
+        "given": "Ioana"
+      },
+      {
+        "family": "Karjalainen-Lindsberg",
+        "given": "Marja-Liisa"
+      },
+      {
+        "family": "Sundstrom",
+        "given": "Jari"
+      },
+      {
+        "family": "Ristamaki",
+        "given": "Raija"
+      },
+      {
+        "family": "Osterlund",
+        "given": "Pia"
+      },
+      {
+        "family": "Knuutila",
+        "given": "Sakari"
+      },
+      {
+        "dropping-particle": "and",
+        "family": "Virinder Kaur Sarhadi"
+      }
+    ],
+    "container-title": "Cancer Genetics",
+    "id": "Mosakhani12",
+    "issue": "11",
+    "issued": {
+      "date-parts": [
+        [
+          2012,
+          11
+        ]
+      ]
+    },
+    "keyword": "bioscience",
+    "page": "545-51",
+    "title": "MicroRNA profiling predicts survival in anti-EGFR treated chemorefractory metastatic colorectal cancer patients with wild-type KRAS and BRAF",
+    "type": "article-journal",
+    "volume": "205"
+  },
+  {
+    "DOI": "10.3109/10428194.2012.685731",
+    "URL": "https://github.com/openresearchlabs/openresearchlabs.github.io/blob/master/content/publication_resources/papers/2012-Mosakhani-LL.pdf",
+    "author": [
+      {
+        "family": "Mosakhani",
+        "given": "N"
+      },
+      {
+        "family": "Sarhadi",
+        "given": "VK"
+      },
+      {
+        "family": "Usvasalo",
+        "given": "A"
+      },
+      {
+        "family": "Karjalainen-Lindsberg",
+        "given": "ML"
+      },
+      {
+        "family": "Lahti",
+        "given": "L"
+      },
+      {
+        "family": "Tuononen",
+        "given": "K"
+      },
+      {
+        "family": "Saarinen-Pihkala",
+        "given": "UM"
+      },
+      {
+        "family": "Knuutila",
+        "given": "S"
+      }
+    ],
+    "container-title": "Leukemia & Lymphoma",
+    "id": "Mosakhani12LL",
+    "issue": "12",
+    "issued": {
+      "date-parts": [
+        [
+          2012,
+          12
+        ]
+      ]
+    },
+    "keyword": "bioscience",
+    "page": "2517-2520",
+    "title": "MicroRNA profiling in pediatric acute lymphoblastic leukemia: Novel prognostic tools",
+    "title-short": "MicroRNA profiling in pediatric acute lymphoblastic leukemia",
+    "type": "article-journal",
+    "volume": "53"
+  },
+  {
+    "DOI": "10.1016/j.cancergen.2012.09.007",
+    "PMID": "23146407",
+    "author": [
+      {
+        "family": "Niini",
+        "given": "Tarja"
+      },
+      {
+        "family": "Scheinin",
+        "given": "Ilari"
+      },
+      {
+        "family": "Lahti",
+        "given": "Leo"
+      },
+      {
+        "family": "Savola",
+        "given": "Suvi"
+      },
+      {
+        "family": "Mertens",
+        "given": "Fredrik"
+      },
+      {
+        "family": "Hollmén",
+        "given": "Jaakko"
+      },
+      {
+        "family": "Böhling",
+        "given": "Tom"
+      },
+      {
+        "family": "Kivioja",
+        "given": "Aarne"
+      },
+      {
+        "family": "Nord",
+        "given": "Karolin H"
+      },
+      {
+        "family": "Knuutila",
+        "given": "Sakari"
+      }
+    ],
+    "container-title": "Cancer Genetics",
+    "id": "Niini12",
+    "issue": "11",
+    "issued": {
+      "date-parts": [
+        [
+          2012,
+          11
+        ]
+      ]
+    },
+    "keyword": "bioscience",
+    "page": "588-93",
+    "title": "Homozygous deletions of cadherin genes in chondrosarcoma – an array CGH study",
+    "type": "article-journal",
+    "volume": "205"
+  },
+  {
+    "DOI": "10.1016/j.leukres.2010.08.005",
+    "author": [
+      {
+        "family": "Borze",
+        "given": "Ioana"
+      },
+      {
+        "family": "Guled",
+        "given": "Mohamed"
+      },
+      {
+        "family": "Musse",
+        "given": "Suad"
+      },
+      {
+        "family": "Raunio",
+        "given": "Anna"
+      },
+      {
+        "family": "Elonen",
+        "given": "Erkki"
+      },
+      {
+        "family": "Saarinen-Pihkala",
+        "given": "Ulla"
+      },
+      {
+        "family": "Karjalainen-Lindsberg",
+        "given": "Marja-Liisa"
+      },
+      {
+        "family": "Lahti",
+        "given": "Leo"
+      },
+      {
+        "family": "Knuutila.",
+        "given": "Sakari"
+      }
+    ],
+    "container-title": "Leukemia Research",
+    "id": "Borze11",
+    "issued": {
+      "date-parts": [
+        [
+          2011,
+          2
+        ]
+      ]
+    },
+    "keyword": "bioscience",
+    "page": "188-195",
+    "title": "MicroRNA microarrays on archive bone marrow core biopsies of leukemias - method validation",
+    "type": "article-journal",
+    "volume": "35"
+  },
+  {
+    "URL": "https://github.com/openresearchlabs/openresearchlabs.github.io/blob/master/content/publication_resources/papers/2011-Faisal-NIPS.pdf",
+    "author": [
+      {
+        "family": "Faisal",
+        "given": "Ali"
+      },
+      {
+        "family": "Louhimo",
+        "given": "Riku"
+      },
+      {
+        "family": "Lahti",
+        "given": "Leo"
+      },
+      {
+        "family": "Hautaniemi",
+        "given": "Sampsa"
+      },
+      {
+        "family": "Kaski",
+        "given": "Samuel"
+      }
+    ],
+    "container-title": "NIPS 2011 workshop from statistical genetics to predictive models in personalized medicine",
+    "id": "Faisal2011",
+    "issued": {
+      "date-parts": [
+        [
+          2011
+        ]
+      ]
+    },
+    "keyword": "bioscience",
+    "title": "Biomarker discovery via dependency analysis of multi-view functional genomics data",
+    "type": "paper-conference"
+  },
+  {
+    "URL": "https://github.com/openresearchlabs/openresearchlabs.github.io/blob/master/content/publication_resources/papers/2011-JalankaTuovinen-PLoS.pdf",
+    "author": [
+      {
+        "family": "Jalanka-Tuovinen",
+        "given": "Jonna"
+      },
+      {
+        "family": "Salonen",
+        "given": "Anne"
+      },
+      {
+        "family": "Nikkilä",
+        "given": "Janne"
+      },
+      {
+        "family": "Immonen",
+        "given": "Outi"
+      },
+      {
+        "family": "Kekkonen",
+        "given": "Riina"
+      },
+      {
+        "family": "Lahti",
+        "given": "Leo"
+      },
+      {
+        "family": "Palva",
+        "given": "Airi"
+      },
+      {
+        "dropping-particle": "de",
+        "family": "Vos",
+        "given": "Willem M."
+      }
+    ],
+    "container-title": "PLoS One",
+    "id": "Jalanka-Tuovinen11",
+    "issue": "7",
+    "issued": {
+      "date-parts": [
+        [
+          2011,
+          7
+        ]
+      ]
+    },
+    "keyword": "bioscience",
+    "page": "e23035",
+    "title": "Intestinal microbiota in healthy adults: Temporal analysis reveals individual and common core and relation to intestinal symptoms",
+    "title-short": "Intestinal microbiota in healthy adults",
+    "type": "article-journal",
+    "volume": "6"
+  },
+  {
+    "URL": "http://intcomp.r-forge.r-project.org/",
+    "author": [
+      {
+        "family": "Lahti",
+        "given": "Leo"
+      },
+      {
+        "family": "Schäfer",
+        "given": "Martin"
+      },
+      {
+        "family": "Klein",
+        "given": "Hans-Ulrich"
+      },
+      {
+        "family": "Bicciato",
+        "given": "Silvio"
+      },
+      {
+        "family": "Dugas",
+        "given": "Martin"
+      }
+    ],
+    "id": "Lahti11intcomp",
+    "issued": {
+      "date-parts": [
+        [
+          2011,
+          2
+        ]
+      ]
+    },
+    "keyword": "bioscience",
+    "note": "R-forge",
+    "publisher": "software",
+    "title": "Intcomp: A benchmarking pipeline for integrative cancer gene detection algorithms",
+    "title-short": "Intcomp",
+    "type": ""
+  },
+  {
+    "URL": "https://github.com/openresearchlabs/openresearchlabs.github.io/blob/master/content/publication_resources/papers/2011-MLSB-Lahti.pdf",
+    "author": [
+      {
+        "family": "Lahti",
+        "given": "Leo"
+      },
+      {
+        "family": "Kaski",
+        "given": "Samuel"
+      }
+    ],
+    "id": "Lahti11ismb",
+    "issued": {
+      "date-parts": [
+        [
+          2011
+        ]
+      ]
+    },
+    "keyword": "bioscience",
+    "note": "Machine Learning for Systems Biology workshop, ISMB, Vienna, Austria",
+    "title": "Probabilistic dependency models for data integration in functional genomics",
+    "type": ""
+  },
+  {
+    "DOI": "10.1109/TCBB.2009.38",
+    "URL": "https://github.com/openresearchlabs/openresearchlabs.github.io/blob/master/content/publication_resources/papers/2011-Lahti-TCBB.pdf",
+    "annote": "R/Bioconductor: RPA",
+    "author": [
+      {
+        "family": "Lahti",
+        "given": "Leo"
+      },
+      {
+        "family": "Elo",
+        "given": "Laura L."
+      },
+      {
+        "family": "Aittokallio",
+        "given": "Tero"
+      },
+      {
+        "family": "Kaski",
+        "given": "Samuel"
+      }
+    ],
+    "container-title": "IEEE/ACM Transactions on Computational Biology and Bioinformatics",
+    "id": "Lahti11rpa",
+    "issue": "1",
+    "issued": {
+      "date-parts": [
+        [
+          2011
+        ]
+      ]
+    },
+    "keyword": "bioscience",
+    "page": "217-225",
+    "publisher": "IEEE Computer Society",
+    "publisher-place": "Los Alamitos, CA, USA",
+    "title": "Probabilistic analysis of probe reliability in differential gene expression studies with short oligonucleotide arrays",
+    "type": "article-journal",
+    "volume": "8"
+  },
+  {
+    "DOI": "10.1002/gcc.20851",
+    "URL": "https://github.com/openresearchlabs/openresearchlabs.github.io/blob/master/content/publication_resources/papers/2011-Niini-GCC.pdf",
+    "author": [
+      {
+        "family": "Niini",
+        "given": "Tarja"
+      },
+      {
+        "family": "Lahti",
+        "given": "Leo"
+      },
+      {
+        "family": "Michelacci",
+        "given": "Francesca"
+      },
+      {
+        "family": "Ninomiya",
+        "given": "Shinsuke"
+      },
+      {
+        "family": "Hattinger",
+        "given": "Claudia Maria"
+      },
+      {
+        "family": "Guled",
+        "given": "Mohamed"
+      },
+      {
+        "family": "Böhling",
+        "given": "Tom"
+      },
+      {
+        "family": "Picci",
+        "given": "Piero"
+      },
+      {
+        "family": "Serra",
+        "given": "Massimo"
+      },
+      {
+        "family": "Knuutila",
+        "given": "Sakari"
+      }
+    ],
+    "container-title": "Genes, Chromosomes and Cancer",
+    "id": "Niini11mfh",
+    "issue": "5",
+    "issued": {
+      "date-parts": [
+        [
+          2011,
+          5
+        ]
+      ]
+    },
+    "keyword": "bioscience",
+    "page": "291-306",
+    "title": "Array comparative genomic hybridization reveals frequent alterations of G1/s checkpoint genes in undifferentiated pleomorphic sarcoma of bone",
+    "type": "article-journal",
+    "volume": "50"
+  },
+  {
+    "DOI": "10.1002/gcc.20880",
+    "URL": "https://github.com/openresearchlabs/openresearchlabs.github.io/blob/master/content/publication_resources/papers/2011-Nymark-GCC.pdf",
+    "author": [
+      {
+        "family": "Nymark",
+        "given": "Penny"
+      },
+      {
+        "family": "Guled",
+        "given": "Mohamed"
+      },
+      {
+        "family": "Borze",
+        "given": "Ioana"
+      },
+      {
+        "family": "Faisal",
+        "given": "Ali"
+      },
+      {
+        "family": "Lahti",
+        "given": "Leo"
+      },
+      {
+        "family": "Salmenkivi",
+        "given": "Kaisa"
+      },
+      {
+        "family": "Kettunen",
+        "given": "Eeva"
+      },
+      {
+        "family": "Anttila",
+        "given": "Sisko"
+      },
+      {
+        "family": "Knuutila",
+        "given": "Sakari"
+      }
+    ],
+    "container-title": "Genes, Chromosomes and Cancer",
+    "id": "Nymark11",
+    "issue": "8",
+    "issued": {
+      "date-parts": [
+        [
+          2011,
+          8
+        ]
+      ]
+    },
+    "keyword": "bioscience",
+    "page": "585-597",
+    "title": "Integrative analysis of microRNA, mRNA and aCGH data reveals asbestos- and histology-related changes in lung cancer",
+    "type": "article-journal",
+    "volume": "50"
+  },
+  {
+    "DOI": "10.1093/bioinformatics/btq500",
+    "URL": "https://github.com/openresearchlabs/openresearchlabs.github.io/blob/master/content/publication_resources/papers/2010-Bioinformatics-Lahti-NetResponse.pdf",
+    "annote": "ArXiv: http://arxiv.org/abs/1202.0501; R/Matlab source code http://netpro.r-forge.r-project.org",
+    "author": [
+      {
+        "family": "Lahti",
+        "given": "Leo"
+      },
+      {
+        "family": "Knuuttila",
+        "given": "Juha E. A."
+      },
+      {
+        "family": "Kaski",
+        "given": "Samuel"
+      }
+    ],
+    "container-title": "Bioinformatics",
+    "id": "Lahti10bioinf",
+    "issued": {
+      "date-parts": [
+        [
+          2010,
+          11
+        ]
+      ]
+    },
+    "keyword": "bioscience",
+    "note": "R/Matlab implementations available at http://netpro.r-forge.r-project.org/",
+    "page": "2713-2720",
+    "title": "Global modeling of transcriptional responses in interaction networks",
+    "type": "article-journal",
+    "volume": "26"
+  },
+  {
+    "URL": "http://dmt.r-forge.r-project.org/",
+    "author": [
+      {
+        "family": "Lahti",
+        "given": "Leo"
+      },
+      {
+        "family": "Tripathi",
+        "given": "Abhishek"
+      },
+      {
+        "family": "Huovilainen",
+        "given": "Olli-Pekka"
+      }
+    ],
+    "id": "Lahti10dmt",
+    "issued": {
+      "date-parts": [
+        [
+          2010,
+          6
+        ]
+      ]
+    },
+    "keyword": "datascience",
+    "note": "CRAN: dmt",
+    "publisher": "software; ICML workshop",
+    "title": "Dependency modeling toolkit",
+    "type": ""
+  },
+  {
+    "DOI": "10.18129/B9.BIOC.NETRESPONSE",
+    "URL": "http://www.bioconductor.org/help/bioc-views/devel/bioc/html/netresponse.html",
+    "author": [
+      {
+        "family": "Lahti",
+        "given": "Leo"
+      },
+      {
+        "family": "Gusmao",
+        "given": "Antonio"
+      },
+      {
+        "family": "Huovilainen",
+        "given": "Olli-Pekka"
+      }
+    ],
+    "id": "Lahti10netresponse",
+    "issued": {
+      "date-parts": [
+        [
+          2010
+        ]
+      ]
+    },
+    "keyword": "datascience",
+    "note": "R/Bioconductor: netresponse",
+    "publisher": "software",
+    "title": "NetResponse (functional network analysis)",
+    "type": ""
+  },
+  {
+    "URL": "http://bioconductor.org/packages/devel/bioc/html/pint.html",
+    "author": [
+      {
+        "family": "Huovilainen",
+        "given": "Olli-Pekka"
+      },
+      {
+        "family": "Lahti",
+        "given": "Leo"
+      }
+    ],
+    "id": "Lahti10pint",
+    "issued": {
+      "date-parts": [
+        [
+          2010
+        ]
+      ]
+    },
+    "keyword": "datascience",
+    "note": "R/BioConductor: pint",
+    "publisher": "software",
+    "title": "Pairwise integration of functional genomics data",
+    "type": ""
+  },
+  {
+    "ISSN": "1797-5069",
+    "URL": "https://github.com/openresearchlabs/openresearchlabs.github.io/blob/master/content/publication_resources/papers/2010-Lahti-thesis.pdf",
+    "abstract": "Recent advances in high-throughput measurement technologies and efficient sharing of biomedical data through community databases have made it possible to investigate the complete collection of genetic material, the genome, which encodes the heritable genetic program of an organism. This has opened up new views to the study of living organisms with a profound impact on biological research. Functional genomics is a subdiscipline of molecular biology that investigates the functional organization of genetic information. This thesis develops computational strategies to investigate a key functional layer of the genome, the transcriptome. The time- and context-specific transcriptional activity of the genes regulates the function of living cells through protein synthesis. Efficient computational techniques are needed in order to extract useful information from high-dimensional genomic observations that are associated with high levels of complex variation. Statistical learning and probabilistic models provide the theoretical framework for combining statistical evidence across multiple observations and the wealth of background information in genomic data repositories. This thesis addresses three key challenges in transcriptome analysis. First, new preprocessing techniques that utilize side information in genomic sequence databases and microarray collections are developed to improve the accuracy of high-throughput microarray measurements. Second, a novel exploratory approach is proposed in order to construct a global view of cell-biological network activation patterns and functional relatedness between tissues across normal human body. Information in genomic interaction databases is used to derive constraints that help to focus the modeling in those parts of the data that are supported by known or potential interactions between the genes, and to scale up the analysis. The third contribution is to develop novel approaches to model dependency between co-occurring measurement sources. The methods are used to study cancer mechanisms and transcriptome evolution; integrative analysis of the human transcriptome and other layers of genomic information allows the identification of functional mechanisms and interactions that could not be detected based on the individual measurement sources. Open source implementations of the key methodological contributions have been released to facilitat e their further adoption by the research community.",
+    "author": [
+      {
+        "family": "Lahti",
+        "given": "Leo"
+      }
+    ],
+    "collection-title": "TKK dissertations in information and computer science",
+    "genre": "PhD thesis",
+    "id": "Lahti10thesis",
+    "issued": {
+      "date-parts": [
+        [
+          2010,
+          12
+        ]
+      ]
+    },
+    "keyword": "thesis, probabilistic models, Bayesian analysis, data integration, gene expression, microarrays, computational science, data analysis, machine learning, computational biology, open source, open access, creative commons",
+    "note": "LaTeX sources and the pdf version are openly available: https://github.com/antagomir/thesis/tree/master/phd10; Press release: https://github.com/antagomir/thesis/blob/master/phd10/Vaitostiedote-LeoLahti-20101207.pdf",
+    "number": "TKK-ICS-D19",
+    "publisher": "Aalto University School of Science and Technology, Faculty of Information and Natural Sciences, Department of Information and Computer Science",
+    "publisher-place": "Espoo",
+    "title": "Probabilistic analysis of the human transcriptome with side information",
+    "type": "thesis"
+  },
+  {
+    "DOI": "10.1038/modpathol.2010.146",
+    "URL": "https://github.com/openresearchlabs/openresearchlabs.github.io/blob/master/content/publication_resources/papers/2010-ModernPathology-Mosakhani-Dupuytre.pdf",
+    "author": [
+      {
+        "family": "Mosakhani",
+        "given": "Neda"
+      },
+      {
+        "family": "Guled",
+        "given": "Mohamed"
+      },
+      {
+        "family": "Lahti",
+        "given": "Leo"
+      },
+      {
+        "family": "Borze",
+        "given": "Ioana"
+      },
+      {
+        "family": "Forsman",
+        "given": "Minna"
+      },
+      {
+        "family": "Ryhänen",
+        "given": "Jorma"
+      },
+      {
+        "family": "Knuutila",
+        "given": "Sakari"
+      }
+    ],
+    "container-title": "Modern Pathology",
+    "id": "Mosakhani10",
+    "issued": {
+      "date-parts": [
+        [
+          2010,
+          11
+        ]
+      ]
+    },
+    "keyword": "bioscience",
+    "note": "International Dupuytren Award for best research paper in 2011",
+    "page": "1544-1522",
+    "title": "Unique microRNA profile in dupuytren’s contracture supports deregulation of beta-catenin pathway",
+    "type": "article-journal",
+    "volume": "23"
+  },
+  {
+    "DOI": "10.1002/gcc.20669",
+    "URL": "https://github.com/openresearchlabs/openresearchlabs.github.io/blob/master/content/publication_resources/papers/2009-GCC-Guled-miRNA.pdf",
+    "author": [
+      {
+        "family": "Guled",
+        "given": "Mohamed"
+      },
+      {
+        "family": "Lahti",
+        "given": "Leo"
+      },
+      {
+        "family": "Lindholm",
+        "given": "Pamela M."
+      },
+      {
+        "family": "Salmenkivi",
+        "given": "Kaisa"
+      },
+      {
+        "family": "Bagwan",
+        "given": "Izhar"
+      },
+      {
+        "family": "Nicholson",
+        "given": "Andrew G."
+      },
+      {
+        "family": "Knuutila",
+        "given": "Sakari"
+      }
+    ],
+    "container-title": "Genes, Chromosomes and Cancer",
+    "id": "Guled09",
+    "issue": "7",
+    "issued": {
+      "date-parts": [
+        [
+          2009,
+          7
+        ]
+      ]
+    },
+    "keyword": "bioscience",
+    "page": "615-623",
+    "title": "CDKN2A, NF2 and JUN are dysregulated among other genes by miRNAs in malignant mesothelioma - a miRNA microarray analysis",
+    "type": "article-journal",
+    "volume": "48"
+  },
+  {
+    "URL": "https://github.com/openresearchlabs/openresearchlabs.github.io/blob/master/content/publication_resources/theses/LeoLahti-BSc-2008.pdf",
+    "author": [
+      {
+        "family": "Lahti",
+        "given": "Leo"
+      }
+    ],
+    "id": "Lahti09bsc",
+    "issued": {
+      "date-parts": [
+        [
+          2009,
+          7
+        ]
+      ]
+    },
+    "keyword": "thesis",
+    "note": "(In Finnish)",
+    "publisher": "B.Sc. thesis. University of Helsinki, Faculty of Political Sciences",
+    "title": "Concerning blackburn’s quasi-realism in securing moral discussion",
+    "type": ""
+  },
+  {
+    "URL": "https://github.com/openresearchlabs/openresearchlabs.github.io/blob/master/content/publication_resources/papers/2009-MLSP-Lahti-SimCCA.pdf",
+    "author": [
+      {
+        "family": "Lahti",
+        "given": "Leo"
+      },
+      {
+        "family": "Myllykangas",
+        "given": "Samuel"
+      },
+      {
+        "family": "Knuutila",
+        "given": "Sakari"
+      },
+      {
+        "family": "Kaski",
+        "given": "Samuel"
+      }
+    ],
+    "container-title": "Proc. MLSP’09 IEEE international workshop on machine learning for signal processing XIX",
+    "editor": [
+      {
+        "family": "Adali T",
+        "given": "Jutten C",
+        "suffix": "Chanussot J"
+      },
+      {
+        "family": "J",
+        "given": "Larsen"
+      }
+    ],
+    "id": "Lahti09mlsp",
+    "issued": {
+      "date-parts": [
+        [
+          2009
+        ]
+      ]
+    },
+    "keyword": "datascience",
+    "note": "R/Bioconductor: pint",
+    "page": "198-203",
+    "publisher": "software",
+    "publisher-place": "Piscataway, NJ",
+    "title": "Dependency detection with similarity constraints",
+    "type": "paper-conference"
+  },
+  {
+    "DOI": "10.18129/B9.BIOC.RPA",
+    "URL": "http://bioconductor.org/packages/release/bioc/html/RPA.html",
+    "author": [
+      {
+        "family": "Lahti",
+        "given": "Leo"
+      }
+    ],
+    "id": "Lahti09rpa",
+    "issued": {
+      "date-parts": [
+        [
+          2009
+        ]
+      ]
+    },
+    "keyword": "bioscience",
+    "note": "R/Bioconductor: RPA",
+    "publisher": "software",
+    "title": "RPA: Probe reliability and differential gene expression analysis",
+    "title-short": "RPA",
+    "type": ""
+  },
+  {
+    "URL": "https://arxiv.org/abs/1109.4919",
+    "author": [
+      {
+        "family": "Lahti",
+        "given": "Leo"
+      }
+    ],
+    "id": "Lahti2006biopax",
+    "issued": {
+      "date-parts": [
+        [
+          2007
+        ]
+      ]
+    },
+    "keyword": "bioscience",
+    "note": "(in Finnish)",
+    "publisher": "arXiv",
+    "title": "A brief overview on the BioPAX and SBML standards",
+    "type": ""
+  },
+  {
+    "DOI": "10.1186/1471-2164-8-62",
+    "annote": "CCA on two asbestos-exposed cell lines.",
+    "author": [
+      {
+        "family": "Nymark",
+        "given": "Penny"
+      },
+      {
+        "family": "Lindholm",
+        "given": "Pamela M."
+      },
+      {
+        "family": "Korpela",
+        "given": "Mikko V."
+      },
+      {
+        "family": "Lahti",
+        "given": "Leo"
+      },
+      {
+        "family": "Ruosaari",
+        "given": "Salla"
+      },
+      {
+        "family": "Kaski",
+        "given": "Samuel"
+      },
+      {
+        "family": "Hollmen",
+        "given": "Jaakko"
+      },
+      {
+        "family": "Anttila",
+        "given": "Sisko"
+      },
+      {
+        "family": "Kinnula",
+        "given": "Vuokko L."
+      },
+      {
+        "family": "Knuutila",
+        "given": "Sakari"
+      }
+    ],
+    "container-title": "BMC Genomics",
+    "id": "Nymark07",
+    "issue": "62",
+    "issued": {
+      "date-parts": [
+        [
+          2007,
+          3
+        ]
+      ]
+    },
+    "keyword": "bioscience",
+    "title": "Gene expression profiles in asbestos-exposed epithelial and mesothelial lung cell lines",
+    "type": "article-journal",
+    "volume": "8"
+  },
+  {
+    "DOI": "10.1093/nar/gni193",
+    "URL": "https://github.com/openresearchlabs/openresearchlabs.github.io/blob/master/content/publication_resources/papers/2005-Elo-NAR.pdf",
+    "author": [
+      {
+        "family": "Elo",
+        "given": "Laura L."
+      },
+      {
+        "family": "Lahti",
+        "given": "Leo"
+      },
+      {
+        "family": "Skottman",
+        "given": "Heli"
+      },
+      {
+        "family": "Kyläniemi",
+        "given": "Minna"
+      },
+      {
+        "family": "Lahesmaa",
+        "given": "Riitta"
+      },
+      {
+        "family": "Aittokallio",
+        "given": "Tero"
+      }
+    ],
+    "container-title": "Nucleic Acids Research",
+    "id": "Elo05",
+    "issue": "22",
+    "issued": {
+      "date-parts": [
+        [
+          2005,
+          12
+        ]
+      ]
+    },
+    "keyword": "bioscience",
+    "page": "e193",
+    "title": "Integrating probe-level expression changes across generations of affymetrix arrays",
+    "type": "article-journal",
+    "volume": "33"
+  },
+  {
+    "DOI": "10.1109/TCBB.2005.32",
+    "URL": "https://github.com/openresearchlabs/openresearchlabs.github.io/blob/master/content/publication_resources/papers/2005-TCBB–Kaski-AC.pdf",
+    "author": [
+      {
+        "family": "Kaski",
+        "given": "Samuel"
+      },
+      {
+        "family": "Nikkilä",
+        "given": "Janne"
+      },
+      {
+        "family": "Sinkkonen",
+        "given": "Janne"
+      },
+      {
+        "family": "Lahti",
+        "given": "Leo"
+      },
+      {
+        "family": "Knuuttila",
+        "given": "Juha"
+      },
+      {
+        "family": "Roos",
+        "given": "Christophe"
+      }
+    ],
+    "container-title": "IEEE/ACM Transactions on Computational Biology and Bioinformatics",
+    "id": "Kaski05",
+    "issue": "3",
+    "issued": {
+      "date-parts": [
+        [
+          2005
+        ]
+      ]
+    },
+    "keyword": "datascience",
+    "note": "Special Issue on Machine Learning for Bioinformatics – Part 2",
+    "page": "203-216",
+    "title": "Associative clustering for exploring dependencies between functional genomics data sets",
+    "type": "article-journal",
+    "volume": "2"
+  },
+  {
+    "URL": "https://github.com/openresearchlabs/openresearchlabs.github.io/blob/master/content/publication_resources/papers/2005-TechRep-Sinkkonen-ACtechdetails.pdf",
+    "author": [
+      {
+        "family": "Sinkkonen",
+        "given": "Janne"
+      },
+      {
+        "family": "Kaski",
+        "given": "Samuel"
+      },
+      {
+        "family": "Nikkilä",
+        "given": "Janne"
+      },
+      {
+        "family": "Lahti",
+        "given": "Leo"
+      }
+    ],
+    "id": "Sinkkonen05tr",
+    "issued": {
+      "date-parts": [
+        [
+          2005
+        ]
+      ]
+    },
+    "keyword": "datascience",
+    "note": "Publications in Computer and Information Science",
+    "number": "A84",
+    "publisher": "Helsinki University of Technology",
+    "publisher-place": "Espoo, Finland",
+    "title": "Associative clustering (AC): Technical details",
+    "title-short": "Associative clustering (AC)",
+    "type": "report"
+  },
+  {
+    "URL": "https://github.com/openresearchlabs/openresearchlabs.github.io/blob/master/content/publication_resources/papers/2004-ECML-Sinkkonen-AC.pdf",
+    "author": [
+      {
+        "family": "Sinkkonen",
+        "given": "Janne"
+      },
+      {
+        "family": "Nikkilä",
+        "given": "Janne"
+      },
+      {
+        "family": "Lahti",
+        "given": "Leo"
+      },
+      {
+        "family": "Kaski",
+        "given": "Samuel"
+      }
+    ],
+    "container-title": "Proceedings of the ECML’04, 15th european conference on machine learning",
+    "editor": [
+      {
+        "family": "Boulicaut"
+      },
+      {
+        "family": "Esposito"
+      },
+      {
+        "family": "Giannotti"
+      },
+      {
+        "family": "Pedreschi"
+      }
+    ],
+    "id": "Sinkkonen04ecml",
+    "issued": {
+      "date-parts": [
+        [
+          2004
+        ]
+      ]
+    },
+    "keyword": "datascience",
+    "page": "396-406",
+    "publisher": "Springer",
+    "publisher-place": "Berlin",
+    "title": "Associative clustering",
+    "type": "chapter"
+  },
+  {
+    "URL": "https://github.com/antagomir/thesis/blob/master/msc03/dtyo.pdf",
+    "author": [
+      {
+        "family": "Lahti",
+        "given": "Leo"
+      }
+    ],
+    "genre": "Master’s thesis",
+    "id": "Lahti03",
+    "issued": {
+      "date-parts": [
+        [
+          2003,
+          12
+        ]
+      ]
+    },
+    "keyword": "thesis",
+    "note": "(in Finnish)",
+    "publisher": "Helsinki University of Technology",
+    "title": "Comparative functional genome analysis using associative clustering",
+    "type": "thesis"
+  },
+  {
+    "URL": "https://github.com/openresearchlabs/openresearchlabs.github.io/blob/master/content/publication_resources/papers/2003-TechRep-Sinkkonen-ACBayesFactor.pdf",
+    "author": [
+      {
+        "family": "Sinkkonen",
+        "given": "Janne"
+      },
+      {
+        "family": "Nikkilä",
+        "given": "Janne"
+      },
+      {
+        "family": "Lahti",
+        "given": "Leo"
+      },
+      {
+        "family": "Kaski",
+        "given": "Samuel"
+      }
+    ],
+    "id": "Sinkkonen03tr",
+    "issued": {
+      "date-parts": [
+        [
+          2003,
+          6
+        ]
+      ]
+    },
+    "keyword": "bioscience",
+    "number": "A68",
+    "publisher": "Helsinki University of Technology and Laboratory of Computer and Information Science",
+    "publisher-place": "Espoo, Finland",
+    "title": "Associative clustering by maximizing a Bayes factor",
+    "type": "report"
+  },
+  {
+    "URL": "https://github.com/antagomir/thesis/tree/master/hausdorff02",
+    "author": [
+      {
+        "family": "Lahti",
+        "given": "Leo"
+      }
+    ],
+    "id": "Lahti2002",
+    "issued": {
+      "date-parts": [
+        [
+          2002
+        ]
+      ]
+    },
+    "keyword": "thesis",
+    "note": "Special assignment in Mathematics (in Finnish)",
+    "title": "Itsesimilaaristen joukkojen hausdorffin dimension määrittäminen",
+    "type": ""
+  },
+  {
+    "URL": "https://github.com/antagomir/thesis/tree/master/julia01",
+    "author": [
+      {
+        "family": "Lahti",
+        "given": "Leo"
+      }
+    ],
+    "id": "Lahti2001",
+    "issued": {
+      "date-parts": [
+        [
+          2001
+        ]
+      ]
+    },
+    "keyword": "thesis",
+    "note": "Special assignment in Mathematics (in Finnish)",
+    "title": "Julian joukko iteraatioden valuma-altaan reunana",
+    "type": ""
+  },
+  {
+    "URL": "http://antagomir.wordpress.com/",
+    "author": [
+      {
+        "family": "Lahti",
+        "given": "Leo"
+      }
+    ],
+    "id": "Lahti10blog",
+    "keyword": "blog",
+    "title": "Opencomp blog",
+    "type": ""
+  },
+  {
+    "URL": "http://louhos.github.io/",
+    "author": [
+      {
+        "family": "Lahti",
+        "given": "Leo"
+      },
+      {
+        "family": "Lehtomäki",
+        "given": "Joona"
+      },
+      {
+        "family": "Parkkinen",
+        "given": "Juuso"
+      },
+      {
+        "literal": "others"
+      }
+    ],
+    "id": "Lahti11-louhos",
+    "keyword": "blog",
+    "note": "Open government data analytics blog (in Finnish)",
+    "title": "Louhos blog",
+    "type": ""
+  },
+  {
+    "URL": "http://ropengov.github.io/",
+    "author": [
+      {
+        "family": "Lahti",
+        "given": "Leo"
+      },
+      {
+        "family": "Lehtomäki",
+        "given": "Joona"
+      },
+      {
+        "family": "Kainu",
+        "given": "Markus"
+      },
+      {
+        "family": "Parkkinen",
+        "given": "Juuso"
+      },
+      {
+        "literal": "others"
+      }
+    ],
+    "id": "Lahti13-ropengov",
+    "keyword": "blog",
+    "note": "Open government data analytics blog",
+    "title": "rOpenGov blog",
+    "type": ""
   }
 ]

--- a/data/publications/lahti.json
+++ b/data/publications/lahti.json
@@ -63,6 +63,7 @@
         ]
       ]
     },
+    "keyword": "bioscience",
     "note": "",
     "page": "2021.11.10.21266163",
     "status": "preprint",

--- a/data/publications/lahti.json
+++ b/data/publications/lahti.json
@@ -65,6 +65,7 @@
     },
     "note": "",
     "page": "2021.11.10.21266163",
+    "status": "preprint",
     "title": "Gut microbiome composition is predictive of incident type 2 diabetes",
     "type": "article-journal",
     "volume": ""
@@ -934,6 +935,7 @@
     "keyword": "openscience",
     "note": "Report on the openness of major scientific publishers commissioned by Finnish Ministry of Education and Culture",
     "publisher": "unknown; Open Science and Research Initiative (ATT)",
+    "status": "openscience",
     "title": "Opening academic publishing: Development and application of systematic evaluation criteria",
     "title-short": "Opening academic publishing",
     "type": "report"
@@ -2534,6 +2536,7 @@
     },
     "keyword": "dh",
     "page": "87-116",
+    "status": "dh",
     "title": "A quantitative study of history in the english short-title catalogue (ESTC) 1470-1800",
     "type": "article-journal",
     "volume": "25"
@@ -2614,6 +2617,7 @@
     "keyword": "dh",
     "note": "Review of the international conference, including electronic material (video interviews, lectures and podcasts.",
     "page": "e13593",
+    "status": "openscience",
     "title": "Alchemy & algorithms: Perspectives on the philosophy and history of open science",
     "title-short": "Alchemy & algorithms",
     "type": "article-journal",
@@ -3194,6 +3198,7 @@
     "keyword": "dh",
     "page": "55-66",
     "publisher-place": "Copenhagen",
+    "status": "dh",
     "title": "Interdisciplinary collaboration in studying newspaper materiality",
     "type": "paper-conference",
     "volume": "2365"
@@ -3485,6 +3490,7 @@
     },
     "keyword": "dh",
     "note": "Special issue: Digital Approaches Towards Serial Publications",
+    "status": "dh",
     "title": "A national public sphere? Analyzing the language, location, and form of newspapers in finland, 1771–1917",
     "type": "article-journal",
     "volume": "4"
@@ -5421,6 +5427,7 @@
     },
     "keyword": "dh",
     "publisher-place": "Copenhagen",
+    "status": "dh",
     "title": "Scaling up bibliographic data science",
     "type": "paper-conference"
   },

--- a/themes/hugo-universal-theme/layouts/partials/research.html
+++ b/themes/hugo-universal-theme/layouts/partials/research.html
@@ -9,7 +9,5 @@
         learning/AI, probabilistic programming, statistical ecology, and data
         science, and drive open developer communities that help to translate
         latest theoretical advances into accessible methods to inform
-        modeling, experimentation, and decision-making.
-
-    </p>
+        modeling, experimentation, and decision-making. For a full list of publications check <a href="http://datascience.utu.fi/research-topics/">this page</a>.
 </div>

--- a/themes/hugo-universal-theme/layouts/shortcodes/articles.html
+++ b/themes/hugo-universal-theme/layouts/shortcodes/articles.html
@@ -1,17 +1,20 @@
-{{ if .IsNamedParams }}
+{{ $path := index $.Site.Data.publications.lahti }}
+
+{{- if .IsNamedParams -}}
   {{- if (isset .Params "id") -}}
-    {{ $path := index $.Site.Data.publications.lahti }}
-      {{ range where $path "id" $.Params.id }}
-        {{ partial "publications_partial" . }}
-      {{ end }}
+    {{ range where $path "id" $.Params.id }}
+      {{ partial "publications_partial" . }}
+    {{ end }}
   {{ else if (isset .Params "keyword") }}
-    {{ $path := index $.Site.Data.publications.lahti }}
-      {{ range where $path "keyword" $.Params.keyword }}
+    {{ range where $path "keyword" $.Params.keyword }}
+      {{ partial "publications_partial" . }}
+    {{ end }}
+  {{ else if (isset .Params "status") }}
+      {{ range where $path "status" $.Params.status }}
         {{ partial "publications_partial" . }}
       {{ end }}
-  {{- end -}}
+  {{ end }}
 {{ else }}
-  {{ $path := index $.Site.Data.publications.lahti }}
   {{ range $path }}
     {{ partial "publications_partial" . }}
   {{ end }}

--- a/themes/hugo-universal-theme/layouts/shortcodes/articles.html
+++ b/themes/hugo-universal-theme/layouts/shortcodes/articles.html
@@ -6,8 +6,20 @@
       {{ partial "publications_partial" . }}
     {{ end }}
   {{ else if (isset .Params "keyword") }}
+    <!-- Get items where keyword is exact match -->
     {{ range where $path "keyword" $.Params.keyword }}
       {{ partial "publications_partial" . }}
+    {{ end }}
+    <!-- Get items that contain more than 1 keyword -->
+    {{ range $path }}
+      {{ $keywords := split .keyword "," }}
+      {{ $longlists := len $keywords }}
+      {{ if gt $longlists 1 }}
+      {{ $keywords_delimit := delimit $keywords "," }}
+        {{ if in $keywords_delimit $.Params.keyword }}
+          {{ partial "publications_partial" . }}
+        {{ end }}
+      {{ end }}
     {{ end }}
   {{ else if (isset .Params "status") }}
       {{ range where $path "status" $.Params.status }}
@@ -15,6 +27,7 @@
       {{ end }}
   {{ end }}
 {{ else }}
+  <!-- print all items -->
   {{ range $path }}
     {{ partial "publications_partial" . }}
   {{ end }}

--- a/themes/hugo-universal-theme/layouts/shortcodes/articles.html
+++ b/themes/hugo-universal-theme/layouts/shortcodes/articles.html
@@ -13,8 +13,8 @@
     <!-- Get items that contain more than 1 keyword -->
     {{ range $path }}
       {{ $keywords := split .keyword "," }}
-      {{ $longlists := len $keywords }}
-      {{ if gt $longlists 1 }}
+      {{ $keyword_array_length := len $keywords }}
+      {{ if gt $keyword_array_length 1 }}
       {{ $keywords_delimit := delimit $keywords "," }}
         {{ if in $keywords_delimit $.Params.keyword }}
           {{ partial "publications_partial" . }}
@@ -26,8 +26,8 @@
         {{ partial "publications_partial" . }}
       {{ end }}
   {{ end }}
+<!-- if no named parameters, print all items -->
 {{ else }}
-  <!-- print all items -->
   {{ range $path }}
     {{ partial "publications_partial" . }}
   {{ end }}


### PR DESCRIPTION
- Able to print articles based on a partial match of keywords.
- Able to print articles based on status field (pubstate in original .bib file)
- Added keywords to lahti.bib items that didn't have them
- Sorted lahti.bib by year as a quick fix for having newest articles on top (WITH THE EXCEPTION of items that have more than 1 keyword: Those are currently printed last!)

Resolves #78